### PR TITLE
docs(docs): clarify PR title validation and simplify local deploy testing

### DIFF
--- a/.github/workflows/TESTING-LOCALLY.md
+++ b/.github/workflows/TESTING-LOCALLY.md
@@ -251,33 +251,9 @@ Server: nginx/1.18.0
 
 **Precondition:** Complete the [One-time Setup](#one-time-setup) above, and ensure the container is running.
 
-**Important:** The atomic-deploy workflow clones from GitHub, so **the container must be able to fetch your branch from the real repository**. This means:
+**Important:** The atomic-deploy workflow clones from GitHub, so the commit under test must already exist on the remote repository. Unpushed local changes will not work.
 
-- ✅ Testing against `main` — always works (already on GitHub)
-- ✅ Testing against a pushed feature branch — works (just push to GitHub first)
-- ❌ Testing against unpushed local changes — **will not work** (remote git fetch fails)
-
-**Quick workflow for testing your branch:**
-
-1. Push your branch (or commit and squash to main locally):
-
-   ```bash
-   git push origin my-feature-branch
-   ```
-
-2. Then test against that ref:
-
-   ```bash
-   gh act push -W .github/workflows/atomic-deploy.yml --secret-file .secrets.local -s DEPLOY_SSH_KEY="$(cat .keys-local/deploy_test_rsa)" --pull=false
-   ```
-
-   Or test against a specific branch:
-
-   ```bash
-   gh act workflow_dispatch -i ref=my-feature-branch -i confirm=deploy -W .github/workflows/atomic-deploy.yml --secret-file .secrets.local -s DEPLOY_SSH_KEY="$(cat .keys-local/deploy_test_rsa)" --pull=false
-   ```
-
-**Default test (against current branch or main):**
+**Default test:**
 
 ```bash
 gh act push -W .github/workflows/atomic-deploy.yml --secret-file .secrets.local -s DEPLOY_SSH_KEY="$(cat .keys-local/deploy_test_rsa)" --pull=false
@@ -288,10 +264,10 @@ gh act push -W .github/workflows/atomic-deploy.yml --secret-file .secrets.local 
 1. Loads secrets from `.secrets.local` file
 2. Injects the private SSH key as `DEPLOY_SSH_KEY`
 3. Runs the `atomic-deploy.yml` workflow locally:
-   - Checks out current branch
+   - Checks out the current commit for the local run
    - Builds docs and demo apps
    - SSHes to `localhost:2046` (the container)
-   - Fetches current branch on container's repo
+   - Fetches the commit under test on the container repo
    - Runs `npm ci` on container
    - Executes `deploy/scripts/workflow/atomic-deploy.sh` on container
    - Rsyncs build artifacts to `/home/llatt/sites/esheet/releases/<sha>/`
@@ -405,7 +381,7 @@ gh act push -W .github/workflows/atomic-deploy.yml --secret-file .secrets.local 
 
 4. **Refresh SSH keys if container is recreated:** The container's host key changes, and you may need to remove old entries from `~/.ssh/known_hosts` (see [refresh-local-ssh-key.sh](./scripts/manual/refresh-local-ssh-key.sh))
 
-5. **Commit before testing deploy** — the container clones from GitHub; test against a pushed branch or local commits that are squash-committed to main
+5. **Commit and push before testing deploy** — the container clones from GitHub, so unpushed local changes cannot be tested
 
 6. **Inspect failed steps** — act shows full step output; scroll up in Terminal to find error details before re-running
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -37,8 +37,17 @@ jobs:
             perf(scope): description
             refactor(scope): description
             docs(scope): description
+            test(scope): description
             chore(scope): description
+            ci(scope): description
+            build(scope): description
             repo(scope): description
+
+          Allowed tags:
+            feat, enhance, fix, perf, refactor, docs, test, chore, ci, build, repo
+
+          Allowed scopes:
+            repo, docs, demo, core, fields, builder, renderer, renderer-standalone, renderer-blaze
 
           Examples:
             repo(repo): update CI workflow


### PR DESCRIPTION
## Changes

### 1. Simplify local atomic deploy testing guidance
**File:** `.github/workflows/TESTING-LOCALLY.md`

Remove the branch-specific testing flow and keep only the default current-branch behavior.

- Removed instructions for testing against a specific branch via `ref` input
- Removed `Quick workflow for testing your branch` subsection and the `gh act workflow_dispatch -i ref=...` example
- Replaced with a single prerequisite note: commits must exist on the remote repository
- Updated "What it does" language to refer to "current commit" instead of explicit branch wording
- Clarified in Best Practices that commits must be pushed before deploy testing (local changes don't work)

**Why:** The branch-override path added unnecessary complexity. The default behavior (testing current branch) is the common case and is simpler to document.

### 2. Expose PR title validation rules in workflow
**File:** `.github/workflows/pr-title-check.yml`

Add explicit lists of allowed tags and scopes to the PR title validation failure message, so developers have a clear reference.

- Added `Allowed tags:` line listing all 11 valid tag types
- Added `Allowed scopes:` line listing all 9 valid scope values
- Added example format lines for previously undocumented valid tags (`test`, `ci`, `build`)
- No validation logic changed; documentation-only update

**Why:** Developers would see validation failures without knowing what values are allowed. This makes the error actionable.

## Testing

- Verify PR titles matching the documented format are accepted
- Verify the documented tags and scopes match the regex in the workflow

## Related

None