### PR TITLE
feat(core): add MCP elicitation support and remove schemaType

### DIFF
--- a/apps/demo/public/comprehensive.json
+++ b/apps/demo/public/comprehensive.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "id": "comprehensive",
   "title": "Comprehensive Field Showcase",
   "fields": [

--- a/apps/demo/public/employee-onboarding.json
+++ b/apps/demo/public/employee-onboarding.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "id": "employee-onboarding",
   "title": "Employee Onboarding Form",
   "fields": [

--- a/apps/demo/public/nps.json
+++ b/apps/demo/public/nps.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "id": "nps",
   "title": "Net Promoter Score Survey",
   "fields": [

--- a/apps/demo/public/patient-intake-broken.json
+++ b/apps/demo/public/patient-intake-broken.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "title": "Patient Intake Form broken",
   "randomInjeciton": "Code does things",
   "fields": [

--- a/apps/demo/public/patient-intake.json
+++ b/apps/demo/public/patient-intake.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "id": "patient-intake",
   "title": "Patient Intake Form",
   "fields": [

--- a/apps/demo/public/phq9.json
+++ b/apps/demo/public/phq9.json
@@ -1,5 +1,4 @@
 {
-  "schemaType": "mieforms-v1.0",
   "id": "phq9",
   "title": "PHQ-9 Patient Health Questionnaire",
   "fields": [

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -4,7 +4,6 @@ import type { FormDefinition } from '@esheet/core';
 import { Navbar } from '../components/Navbar';
 
 const INITIAL_DEF: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
   id: 'demo-builder',
   fields: [
     { id: 'q1', fieldType: 'text', question: 'What is your name?' },

--- a/packages/builder/src/lib/EsheetBuilder.spec.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.spec.tsx
@@ -33,7 +33,6 @@ describe('EsheetBuilder', () => {
     render(
       <EsheetBuilder
         definition={{
-          schemaType: 'mieforms-v1.0',
           id: 'initial-form',
           fields: [{ id: 'q1', fieldType: 'text', question: 'Name?' }],
         }}
@@ -63,7 +62,6 @@ describe('EsheetBuilder', () => {
 
     act(() => {
       form!.getState().loadDefinition({
-        schemaType: 'mieforms-v1.0',
         id: 'change-form',
         fields: [{ id: 'f1', fieldType: 'text' }],
       });
@@ -146,7 +144,6 @@ describe('BuilderHeader import feedback', () => {
     const form = createFormStore();
     const ui = createUIStore();
     mockFileContent = JSON.stringify({
-      schemaType: 'mieforms-v2',
       id: 'invalid-schema',
       fields: [{ fieldType: 'text' }],
     });
@@ -180,7 +177,6 @@ describe('BuilderHeader import feedback', () => {
     const form = createFormStore();
     const ui = createUIStore();
     mockFileContent = JSON.stringify({
-      schemaType: 'mieforms-v1.0',
       id: 'with-warnings',
       fields: [
         { id: 'a', fieldType: 'text', question: 'A' },
@@ -227,7 +223,6 @@ describe('BuilderHeader import feedback', () => {
     const form = createFormStore();
     const ui = createUIStore();
     mockFileContent = JSON.stringify({
-      schemaType: 'mieforms-v1.0',
       id: 'good-form',
       fields: [{ id: 'ok', fieldType: 'text', question: 'OK' }],
     });
@@ -255,7 +250,6 @@ describe('BuilderHeader import feedback', () => {
 describe('BuilderHeader dry run submit', () => {
   function createRequiredTextDefinition() {
     return {
-      schemaType: 'mieforms-v1.0' as const,
       id: 'dry-run-form',
       fields: [
         {
@@ -343,7 +337,6 @@ describe('BuilderHeader dry run submit', () => {
 
   it('dry run excludes disabled answers from the serialized response payload', async () => {
     const form = createFormStore({
-      schemaType: 'mieforms-v1.0',
       id: 'conditional-form',
       fields: [
         {

--- a/packages/builder/src/lib/components/BuilderHeader.tsx
+++ b/packages/builder/src/lib/components/BuilderHeader.tsx
@@ -378,6 +378,18 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
         if (!isYaml) {
           const p = parsed as Record<string, unknown>;
           const params = p?.params as Record<string, unknown> | undefined;
+
+          // URL mode — no requestedSchema, nothing to import as a form.
+          const mode = params?.mode ?? p?.mode;
+          if (mode === 'url') {
+            showFeedback(
+              'error',
+              'URL Mode Not Supported',
+              'This MCP elicitation uses URL mode (out-of-band). Only form mode schemas can be imported into the builder.'
+            );
+            return;
+          }
+
           let mcpSchema: McpElicitationSchema | undefined;
           if (params?.requestedSchema) {
             mcpSchema = params.requestedSchema as McpElicitationSchema;
@@ -389,9 +401,18 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
 
           if (mcpSchema) {
             const message = params?.message ?? p?.message;
+            const mcpId = p?.id ?? params?.id;
+            const mcpMeta = p?.meta;
             const formDef = importFromMcp(mcpSchema, {
               formId: form.getState().hydrateDefinition().id || 'mcp-form',
-              ...(typeof message === 'string' ? { title: message } : {}),
+              ...(typeof message === 'string' && message.length > 0
+                ? { description: message }
+                : {}),
+              ...(mcpId !== undefined
+                ? { mcpId: mcpId as string | number }
+                : {}),
+              ...(typeof message === 'string' ? { mcpMessage: message } : {}),
+              ...(mcpMeta !== undefined ? { mcpMeta } : {}),
             });
             form.getState().loadDefinition(formDef);
             showFeedback(

--- a/packages/builder/src/lib/components/BuilderHeader.tsx
+++ b/packages/builder/src/lib/components/BuilderHeader.tsx
@@ -3,6 +3,9 @@ import YAML from 'js-yaml';
 import {
   formatZodValidationError,
   formDefinitionSchema,
+  importFromMcp,
+  exportToMcp,
+  type McpElicitationSchema,
   type Condition,
   isExpressionValid,
   type FieldDefinition,
@@ -223,6 +226,9 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
   const [exportIdModalOpen, setExportIdModalOpen] = React.useState(false);
   const [exportIdInput, setExportIdInput] = React.useState('');
   const [exportIdError, setExportIdError] = React.useState('');
+  const [exportFormat, setExportFormat] = React.useState<'esheet' | 'mcp'>(
+    'esheet'
+  );
   const [feedback, setFeedback] = React.useState<FeedbackState>({
     open: false,
     title: '',
@@ -311,6 +317,23 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
   }, []);
 
   const handleConfirmExportId = React.useCallback(() => {
+    if (exportFormat === 'mcp') {
+      const definition = form.getState().hydrateDefinition();
+      const schema = exportToMcp(definition);
+      const filename = (definition.id || 'form') + '-mcp-schema.json';
+      const blob = new Blob([JSON.stringify(schema, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      setExportIdModalOpen(false);
+      return;
+    }
+
     const nextId = sanitizeFormId(exportIdInput);
     if (!nextId) {
       setExportIdError(
@@ -324,7 +347,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
     finalizeExport(definition);
     setExportIdModalOpen(false);
     setExportIdError('');
-  }, [exportIdInput, finalizeExport, form]);
+  }, [exportFormat, exportIdInput, finalizeExport, form]);
 
   const handleExport = () => {
     const definition = form.getState().hydrateDefinition();
@@ -340,16 +363,45 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
     const file = e.currentTarget.files?.[0];
     if (!file) return;
 
-    // Detect file format from extension
     const fileName = file.name.toLowerCase();
     const isYaml = fileName.endsWith('.yaml') || fileName.endsWith('.yml');
-    const format = isYaml ? 'YAML' : 'JSON';
+    const fileFormat = isYaml ? 'YAML' : 'JSON';
 
     const reader = new FileReader();
     reader.onload = (ev) => {
       try {
         const content = ev.target?.result as string;
         const parsed = isYaml ? YAML.load(content) : JSON.parse(content);
+
+        // Auto-detect MCP elicitation schema (JSON only).
+        // Accepts: full elicitation/create request, params object, or raw requestedSchema.
+        if (!isYaml) {
+          const p = parsed as Record<string, unknown>;
+          const params = p?.params as Record<string, unknown> | undefined;
+          let mcpSchema: McpElicitationSchema | undefined;
+          if (params?.requestedSchema) {
+            mcpSchema = params.requestedSchema as McpElicitationSchema;
+          } else if (p?.requestedSchema) {
+            mcpSchema = p.requestedSchema as McpElicitationSchema;
+          } else if (p?.type === 'object' && p?.properties) {
+            mcpSchema = p as unknown as McpElicitationSchema;
+          }
+
+          if (mcpSchema) {
+            const message = params?.message ?? p?.message;
+            const formDef = importFromMcp(mcpSchema, {
+              formId: form.getState().hydrateDefinition().id || 'mcp-form',
+              ...(typeof message === 'string' ? { title: message } : {}),
+            });
+            form.getState().loadDefinition(formDef);
+            showFeedback(
+              'success',
+              'Import Successful',
+              `Loaded ${formDef.fields.length} field(s) from MCP elicitation schema.`
+            );
+            return;
+          }
+        }
 
         const validated = formDefinitionSchema.safeParse(parsed);
         if (!validated.success) {
@@ -359,7 +411,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
           showFeedback(
             'error',
             'Import Failed',
-            `The file is valid ${format} but does not match the form schema.`,
+            `The file is valid ${fileFormat} but does not match the form schema.`,
             issues.length > shownIssues.length
               ? `Showing ${shownIssues.length} of ${issues.length} issue(s).`
               : undefined,
@@ -388,7 +440,6 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
         }
 
         form.getState().loadDefinition(validated.data);
-
         showFeedback(
           'success',
           'Import Successful',
@@ -398,7 +449,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
         showFeedback(
           'error',
           'Import Failed',
-          `Invalid ${format} file format.`
+          `Invalid ${fileFormat} file format.`
         );
       }
     };
@@ -448,37 +499,80 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
     <header className="builder-header ms:w-full ms:bg-mssurface ms:border ms:border-msborder ms:rounded-lg ms:shadow-sm ms:shrink-0">
       <FeedbackModal
         open={exportIdModalOpen}
-        title="Use This Form ID?"
-        message={`Do you want to use '${
-          sanitizeFormId(exportIdInput) || exportIdInput
-        }' as the form id? You can edit it below before exporting.`}
+        title="Export Form"
+        message={
+          exportFormat === 'mcp'
+            ? 'Choose a format to export your form.'
+            : `Do you want to use '${
+                sanitizeFormId(exportIdInput) || exportIdInput
+              }' as the form id? You can edit it below before exporting.`
+        }
         content={
-          <div className="ms:space-y-2 ms:mb-2">
-            <label
-              htmlFor={`${form.getState().instanceId}-export-form-id`}
-              className="ms:block ms:text-sm ms:font-medium ms:text-mstext"
-            >
-              Form ID
-            </label>
-            <input
-              id={`${form.getState().instanceId}-export-form-id`}
-              aria-label="Form ID"
-              type="text"
-              value={exportIdInput}
-              onChange={(e) => {
-                setExportIdInput(e.target.value);
-                if (exportIdError) setExportIdError('');
-              }}
-              placeholder="my-form-id"
-              className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary/30 ms:outline-none ms:transition-colors"
-            />
-            {exportIdError && (
-              <p className="ms:text-xs ms:text-msdanger">{exportIdError}</p>
+          <div className="ms:space-y-4 ms:mb-2">
+            <div className="ms:flex ms:gap-4">
+              <label className="ms:flex ms:items-center ms:gap-2 ms:text-sm ms:text-mstext ms:cursor-pointer">
+                <input
+                  type="radio"
+                  name="export-format"
+                  value="esheet"
+                  checked={exportFormat === 'esheet'}
+                  onChange={() => setExportFormat('esheet')}
+                />
+                eSheet JSON
+              </label>
+              <label className="ms:flex ms:items-center ms:gap-2 ms:text-sm ms:text-mstext ms:cursor-pointer">
+                <input
+                  type="radio"
+                  name="export-format"
+                  value="mcp"
+                  checked={exportFormat === 'mcp'}
+                  onChange={() => setExportFormat('mcp')}
+                />
+                MCP Elicitation Schema
+              </label>
+            </div>
+            {exportFormat === 'esheet' && (
+              <div className="ms:space-y-2">
+                <label
+                  htmlFor={`${form.getState().instanceId}-export-form-id`}
+                  className="ms:block ms:text-sm ms:font-medium ms:text-mstext"
+                >
+                  Form ID
+                </label>
+                <input
+                  id={`${form.getState().instanceId}-export-form-id`}
+                  aria-label="Form ID"
+                  type="text"
+                  value={exportIdInput}
+                  onChange={(e) => {
+                    setExportIdInput(e.target.value);
+                    if (exportIdError) setExportIdError('');
+                  }}
+                  placeholder="my-form-id"
+                  className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary/30 ms:outline-none ms:transition-colors"
+                />
+                {exportIdError && (
+                  <p className="ms:text-xs ms:text-msdanger">{exportIdError}</p>
+                )}
+              </div>
+            )}
+            {exportFormat === 'mcp' && (
+              <p className="ms:text-sm ms:text-mstextmuted">
+                Exports as a flat{' '}
+                <code className="ms:font-mono ms:text-xs ms:bg-msbackground ms:px-1 ms:py-0.5 ms:rounded">
+                  requestedSchema
+                </code>{' '}
+                object. Field IDs, required fields, and supported types are
+                preserved. Unsupported types (matrix, signature, etc.) are
+                omitted.
+              </p>
             )}
           </div>
         }
         variant="info"
-        confirmLabel="Use This ID & Export"
+        confirmLabel={
+          exportFormat === 'mcp' ? 'Export MCP Schema' : 'Use This ID & Export'
+        }
         cancelLabel="Cancel"
         showCancel
         onConfirm={handleConfirmExportId}

--- a/packages/builder/src/lib/components/CodeView.tsx
+++ b/packages/builder/src/lib/components/CodeView.tsx
@@ -187,7 +187,6 @@ export function CodeView({ form, ui }: CodeViewProps) {
       if (!text) {
         const currentId = fs.getState().hydrateDefinition().id;
         fs.getState().loadDefinition({
-          schemaType: 'mieforms-v1.0',
           id: currentId,
           fields: [],
         });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,6 @@ export {
   type FieldTypeMeta,
   type FieldTypeRegistry,
   type RankedAnswer,
-  type MatrixRowAnswer,
   type AttachmentAnswer,
   type AnswerValue,
   type ResponseItem,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,5 @@
 export {
   // Constants
-  SCHEMA_TYPE,
   FIELD_TYPES,
   TEXT_INPUT_TYPES,
   CONDITION_OPERATORS,
@@ -21,7 +20,6 @@ export {
   formDefinitionJSONSchema,
 
   // Types
-  type SchemaType,
   type FieldType,
   type FieldCategory,
   type AnswerType,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   type FieldTypeMeta,
   type FieldTypeRegistry,
   type RankedAnswer,
+  type MatrixRowAnswer,
   type AttachmentAnswer,
   type AnswerValue,
   type ResponseItem,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,3 +103,16 @@ export {
 } from './lib/stores/ui-store.js';
 
 export { type FieldComponentProps } from './lib/field-component-props.js';
+
+export {
+  importFromMcp,
+  exportToMcp,
+  type McpElicitationSchema,
+  type McpElicitationRequest,
+  type McpProperty,
+  type McpStringProp,
+  type McpNumberProp,
+  type McpBooleanProp,
+  type McpArrayProp,
+  type McpConstOption,
+} from './lib/functions/mcp.js';

--- a/packages/core/src/lib/functions/hydrate-response.ts
+++ b/packages/core/src/lib/functions/hydrate-response.ts
@@ -3,8 +3,10 @@
 // ---------------------------------------------------------------------------
 
 import type {
+  FieldDefinition,
   FieldResponse,
   FieldResponseMap,
+  MatrixRowAnswer,
   SelectedOption,
   RankedAnswer,
   AttachmentAnswer,
@@ -86,7 +88,10 @@ export function hydrateResponse(
         continue;
       }
 
-      const answer = extractAnswer(responses[id], meta.answerType);
+      const answer =
+        meta.answerType === 'matrix'
+          ? extractMatrixAnswer(responses[id], definition)
+          : extractAnswer(responses[id], meta.answerType);
       const item: ResponseItem = {
         id,
         text: definition.question ?? definition.title ?? '',
@@ -120,6 +125,31 @@ function isEmptyAnswer(value: unknown): boolean {
   return false;
 }
 
+/** Build a structured MatrixRowAnswer[] from a matrix field response. */
+function extractMatrixAnswer(
+  response: FieldResponse | undefined,
+  definition: Omit<FieldDefinition, 'fields'>
+): MatrixRowAnswer[] | undefined {
+  if (!response?.selected) return undefined;
+  const raw = response.selected as Record<
+    string,
+    SelectedOption | SelectedOption[]
+  >;
+  const rows = definition.rows ?? [];
+  const result: MatrixRowAnswer[] = [];
+  for (const row of rows) {
+    const sel = raw[row.id];
+    if (!sel) continue;
+    const cols = Array.isArray(sel) ? sel : [sel];
+    result.push({
+      id: row.id,
+      value: row.value,
+      items: cols.map((c) => ({ id: c.id, value: c.value })),
+    });
+  }
+  return result.length > 0 ? result : undefined;
+}
+
 /** Pull the actual answer value out of a FieldResponse based on answer type. */
 function extractAnswer(
   response: FieldResponse | undefined,
@@ -132,7 +162,6 @@ function extractAnswer(
       return response.answer;
     case 'selection':
     case 'multiselection':
-    case 'matrix':
       return response.selected;
     case 'multitext':
       return response.multitextAnswers;

--- a/packages/core/src/lib/functions/hydrate-response.ts
+++ b/packages/core/src/lib/functions/hydrate-response.ts
@@ -6,11 +6,10 @@ import type {
   FieldDefinition,
   FieldResponse,
   FieldResponseMap,
-  MatrixRowAnswer,
+  ResponseItem,
   SelectedOption,
   RankedAnswer,
   AttachmentAnswer,
-  ResponseItem,
   FormResponse,
 } from '../types.js';
 import type { NormalizedDefinition } from './normalize.js';
@@ -125,27 +124,25 @@ function isEmptyAnswer(value: unknown): boolean {
   return false;
 }
 
-/** Build a structured MatrixRowAnswer[] from a matrix field response. */
+/** Build nested ResponseItem[] from a matrix field — each row is a sub-item with its own answer. */
 function extractMatrixAnswer(
   response: FieldResponse | undefined,
   definition: Omit<FieldDefinition, 'fields'>
-): MatrixRowAnswer[] | undefined {
+): ResponseItem[] | undefined {
   if (!response?.selected) return undefined;
   const raw = response.selected as Record<
     string,
     SelectedOption | SelectedOption[]
   >;
   const rows = definition.rows ?? [];
-  const result: MatrixRowAnswer[] = [];
+  const result: ResponseItem[] = [];
   for (const row of rows) {
     const sel = raw[row.id];
     if (!sel) continue;
-    const cols = Array.isArray(sel) ? sel : [sel];
-    result.push({
-      id: row.id,
-      value: row.value,
-      items: cols.map((c) => ({ id: c.id, value: c.value })),
-    });
+    const answer = Array.isArray(sel)
+      ? sel.map((c) => ({ id: c.id, value: c.value }))
+      : { id: sel.id, value: sel.value };
+    result.push({ id: row.id, text: row.value, answer });
   }
   return result.length > 0 ? result : undefined;
 }

--- a/packages/core/src/lib/functions/hydrate-response.ts
+++ b/packages/core/src/lib/functions/hydrate-response.ts
@@ -3,7 +3,6 @@
 // ---------------------------------------------------------------------------
 
 import type {
-  FieldDefinition,
   FieldResponse,
   FieldResponseMap,
   ResponseItem,
@@ -87,10 +86,7 @@ export function hydrateResponse(
         continue;
       }
 
-      const answer =
-        meta.answerType === 'matrix'
-          ? extractMatrixAnswer(responses[id], definition)
-          : extractAnswer(responses[id], meta.answerType);
+      const answer = extractAnswer(responses[id], meta.answerType);
       const item: ResponseItem = {
         id,
         text: definition.question ?? definition.title ?? '',
@@ -124,29 +120,6 @@ function isEmptyAnswer(value: unknown): boolean {
   return false;
 }
 
-/** Build nested ResponseItem[] from a matrix field — each row is a sub-item with its own answer. */
-function extractMatrixAnswer(
-  response: FieldResponse | undefined,
-  definition: Omit<FieldDefinition, 'fields'>
-): ResponseItem[] | undefined {
-  if (!response?.selected) return undefined;
-  const raw = response.selected as Record<
-    string,
-    SelectedOption | SelectedOption[]
-  >;
-  const rows = definition.rows ?? [];
-  const result: ResponseItem[] = [];
-  for (const row of rows) {
-    const sel = raw[row.id];
-    if (!sel) continue;
-    const answer = Array.isArray(sel)
-      ? sel.map((c) => ({ id: c.id, value: c.value }))
-      : { id: sel.id, value: sel.value };
-    result.push({ id: row.id, text: row.value, answer });
-  }
-  return result.length > 0 ? result : undefined;
-}
-
 /** Pull the actual answer value out of a FieldResponse based on answer type. */
 function extractAnswer(
   response: FieldResponse | undefined,
@@ -159,6 +132,7 @@ function extractAnswer(
       return response.answer;
     case 'selection':
     case 'multiselection':
+    case 'matrix':
       return response.selected;
     case 'multitext':
       return response.multitextAnswers;

--- a/packages/core/src/lib/functions/mcp.spec.ts
+++ b/packages/core/src/lib/functions/mcp.spec.ts
@@ -1,0 +1,406 @@
+// ---------------------------------------------------------------------------
+// Tests — importFromMcp / exportToMcp (spec 2025-11-25)
+// ---------------------------------------------------------------------------
+
+import { importFromMcp, exportToMcp } from './mcp.js';
+import type { McpElicitationSchema, McpElicitationRequest } from './mcp.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getFormSchema(req: McpElicitationRequest): McpElicitationSchema {
+  if (req.params.mode === 'url') throw new Error('unexpected url mode');
+  return req.params.requestedSchema;
+}
+
+// The schema from mcp.json (original reference fixture)
+const referenceSchema: McpElicitationSchema = {
+  type: 'object',
+  required: ['appName', 'appType'],
+  properties: {
+    appName: {
+      type: 'string',
+      title: 'App Name',
+      minLength: 3,
+      maxLength: 50,
+    },
+    description: {
+      type: 'string',
+      title: 'Description',
+      maxLength: 200,
+    },
+    appType: {
+      type: 'string',
+      title: 'App Type',
+      enum: ['SaaS', 'Portfolio', 'E-commerce', 'Dashboard'],
+    },
+    features: {
+      type: 'array',
+      title: 'Select Features',
+      items: {
+        type: 'string',
+        enum: ['Authentication', 'Payments', 'Analytics', 'Notifications'],
+      },
+      uniqueItems: true,
+    },
+    isPublic: {
+      type: 'boolean',
+      title: 'Publicly Accessible',
+    },
+    userLimit: {
+      type: 'integer',
+      title: 'Max Users',
+      minimum: 1,
+      maximum: 100000,
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// importFromMcp
+// ---------------------------------------------------------------------------
+
+describe('importFromMcp', () => {
+  it('maps string property to text field', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: { name: { type: 'string', title: 'Full Name' } },
+    });
+    const field = form.fields[0];
+    expect(field.id).toBe('name');
+    expect(field.fieldType).toBe('text');
+    expect(field.question).toBe('Full Name');
+  });
+
+  it('marks required fields', () => {
+    const form = importFromMcp({
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        bio: { type: 'string' },
+      },
+    });
+    expect(form.fields.find((f) => f.id === 'name')?.required).toBe(true);
+    expect(form.fields.find((f) => f.id === 'bio')?.required).toBeUndefined();
+  });
+
+  it('maps string enum to radio field', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        appType: {
+          type: 'string',
+          title: 'App Type',
+          enum: ['SaaS', 'Portfolio'],
+        },
+      },
+    });
+    const field = form.fields[0];
+    expect(field.fieldType).toBe('radio');
+    expect(field.options?.map((o) => o.value)).toEqual(['SaaS', 'Portfolio']);
+  });
+
+  it('maps string oneOf enum to radio field with titles', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        color: {
+          type: 'string',
+          title: 'Color',
+          oneOf: [
+            { const: '#FF0000', title: 'Red' },
+            { const: '#00FF00', title: 'Green' },
+          ],
+        },
+      },
+    });
+    const field = form.fields[0];
+    expect(field.fieldType).toBe('radio');
+    expect(field.options?.map((o) => o.value)).toEqual(['#FF0000', '#00FF00']);
+    expect(field.options?.map((o) => o.text)).toEqual(['Red', 'Green']);
+  });
+
+  it('maps array enum to check field', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        features: {
+          type: 'array',
+          title: 'Features',
+          items: { type: 'string', enum: ['A', 'B', 'C'] },
+          uniqueItems: true,
+        },
+      },
+    });
+    const field = form.fields[0];
+    expect(field.fieldType).toBe('check');
+    expect(field.options?.map((o) => o.value)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('preserves uniqueItems in _sourceData', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        features: {
+          type: 'array',
+          items: { type: 'string', enum: ['A', 'B'] },
+          uniqueItems: true,
+        },
+      },
+    });
+    const meta = form.fields[0]._sourceData as { uniqueItems?: boolean };
+    expect(meta?.uniqueItems).toBe(true);
+  });
+
+  it('maps boolean to boolean field', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        isPublic: { type: 'boolean', title: 'Publicly Accessible' },
+      },
+    });
+    expect(form.fields[0].fieldType).toBe('boolean');
+  });
+
+  it('maps integer to text+number field and preserves constraints', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        userLimit: {
+          type: 'integer',
+          title: 'Max Users',
+          minimum: 1,
+          maximum: 100000,
+        },
+      },
+    });
+    const field = form.fields[0];
+    expect(field.fieldType).toBe('text');
+    expect(field.inputType).toBe('number');
+    const meta = field._sourceData as {
+      mcpType?: string;
+      minimum?: number;
+      maximum?: number;
+    };
+    expect(meta?.mcpType).toBe('integer');
+    expect(meta?.minimum).toBe(1);
+    expect(meta?.maximum).toBe(100000);
+  });
+
+  it('maps string format:email to text+email', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: { email: { type: 'string', format: 'email' } },
+    });
+    expect(form.fields[0].inputType).toBe('email');
+  });
+
+  it('preserves string constraints in _sourceData', () => {
+    const form = importFromMcp({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          minLength: 3,
+          maxLength: 50,
+          pattern: '^[A-Z]',
+        },
+      },
+    });
+    const meta = form.fields[0]._sourceData as {
+      minLength?: number;
+      maxLength?: number;
+      pattern?: string;
+    };
+    expect(meta?.minLength).toBe(3);
+    expect(meta?.maxLength).toBe(50);
+    expect(meta?.pattern).toBe('^[A-Z]');
+  });
+
+  it('stores mcpId and mcpMessage in form _sourceData', () => {
+    const form = importFromMcp(
+      { type: 'object', properties: {} },
+      { mcpId: 'abc-123', mcpMessage: 'Hello' }
+    );
+    const src = form._sourceData as { mcpId?: unknown; mcpMessage?: unknown };
+    expect(src?.mcpId).toBe('abc-123');
+    expect(src?.mcpMessage).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportToMcp
+// ---------------------------------------------------------------------------
+
+describe('exportToMcp', () => {
+  it('produces valid jsonrpc 2.0 envelope', () => {
+    const form = importFromMcp({ type: 'object', properties: {} });
+    const req = exportToMcp(form);
+    expect(req.jsonrpc).toBe('2.0');
+    expect(req.method).toBe('elicitation/create');
+    expect(req.params.mode).toBe('form');
+  });
+
+  it('round-trips a plain string field', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', title: 'Name', minLength: 2, maxLength: 30 },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    expect(exported.properties['name']).toEqual(schema.properties['name']);
+  });
+
+  it('round-trips a string enum (radio) field', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      properties: {
+        appType: {
+          type: 'string',
+          title: 'App Type',
+          enum: ['SaaS', 'Portfolio', 'E-commerce', 'Dashboard'],
+        },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    expect(exported.properties['appType']).toEqual(
+      schema.properties['appType']
+    );
+  });
+
+  it('round-trips an array enum (check) field — emits items.type:string and uniqueItems', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      properties: {
+        features: {
+          type: 'array',
+          title: 'Select Features',
+          items: {
+            type: 'string',
+            enum: ['Authentication', 'Payments', 'Analytics', 'Notifications'],
+          },
+          uniqueItems: true,
+        },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    const prop = exported.properties['features'];
+    expect(prop.type).toBe('array');
+    if (prop.type !== 'array') return;
+    expect(prop.uniqueItems).toBe(true);
+    expect('enum' in prop.items).toBe(true);
+    if (!('enum' in prop.items)) return;
+    expect((prop.items as { type?: string }).type).toBe('string');
+    expect(prop.items.enum).toEqual([
+      'Authentication',
+      'Payments',
+      'Analytics',
+      'Notifications',
+    ]);
+  });
+
+  it('round-trips a boolean field', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      properties: {
+        isPublic: { type: 'boolean', title: 'Publicly Accessible' },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    expect(exported.properties['isPublic']).toEqual(
+      schema.properties['isPublic']
+    );
+  });
+
+  it('round-trips an integer field with minimum/maximum', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      properties: {
+        userLimit: {
+          type: 'integer',
+          title: 'Max Users',
+          minimum: 1,
+          maximum: 100000,
+        },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    expect(exported.properties['userLimit']).toEqual(
+      schema.properties['userLimit']
+    );
+  });
+
+  it('round-trips required array', () => {
+    const schema: McpElicitationSchema = {
+      type: 'object',
+      required: ['appName', 'appType'],
+      properties: {
+        appName: { type: 'string', title: 'App Name' },
+        appType: { type: 'string', title: 'App Type', enum: ['SaaS'] },
+      },
+    };
+    const exported = getFormSchema(exportToMcp(importFromMcp(schema)));
+    expect(exported.required).toEqual(
+      expect.arrayContaining(['appName', 'appType'])
+    );
+  });
+
+  it('full reference schema round-trips without data loss', () => {
+    const form = importFromMcp(referenceSchema, {
+      mcpId: 'webapp-elicitation-001',
+      mcpMessage: 'Fill out the basic web app configuration',
+    });
+    const exported = exportToMcp(form);
+    const schema = getFormSchema(exported);
+
+    // Envelope
+    expect(exported.id).toBe('webapp-elicitation-001');
+    expect(exported.params.mode).toBe('form');
+    if (exported.params.mode !== 'form') return;
+    expect(exported.params.message).toBe(
+      'Fill out the basic web app configuration'
+    );
+
+    // Required
+    expect(schema.required).toEqual(
+      expect.arrayContaining(['appName', 'appType'])
+    );
+
+    // appName — string with minLength/maxLength
+    expect(schema.properties['appName']).toEqual(
+      referenceSchema.properties['appName']
+    );
+
+    // description — string with maxLength
+    expect(schema.properties['description']).toEqual(
+      referenceSchema.properties['description']
+    );
+
+    // appType — string enum
+    expect(schema.properties['appType']).toEqual(
+      referenceSchema.properties['appType']
+    );
+
+    // features — array with items.type:string, uniqueItems
+    const features = schema.properties['features'];
+    expect(features.type).toBe('array');
+    if (features.type !== 'array') return;
+    expect(features.uniqueItems).toBe(true);
+    expect('enum' in features.items).toBe(true);
+    if (!('enum' in features.items)) return;
+    expect((features.items as { type?: string }).type).toBe('string');
+
+    // isPublic — boolean
+    expect(schema.properties['isPublic']).toEqual(
+      referenceSchema.properties['isPublic']
+    );
+
+    // userLimit — integer with minimum/maximum
+    expect(schema.properties['userLimit']).toEqual(
+      referenceSchema.properties['userLimit']
+    );
+  });
+});

--- a/packages/core/src/lib/functions/mcp.ts
+++ b/packages/core/src/lib/functions/mcp.ts
@@ -7,7 +7,7 @@ import type {
 import { generateOptionId } from './ids.js';
 
 // ---------------------------------------------------------------------------
-// MCP Elicitation Types (form mode, draft spec)
+// MCP Elicitation Types (spec 2025-11-25)
 // ---------------------------------------------------------------------------
 
 /** A literal const/title pair used in single- and multi-select enums. */
@@ -25,7 +25,9 @@ export interface McpStringProp {
   maxLength?: number;
   pattern?: string;
   format?: 'email' | 'uri' | 'date' | 'date-time';
+  /** Simple named enum (parallel array to `enum`). Spec 2025-11-25. */
   enum?: string[];
+  enumNames?: string[];
   oneOf?: McpConstOption[];
   default?: string;
 }
@@ -55,7 +57,9 @@ export interface McpArrayProp {
   description?: string;
   minItems?: number;
   maxItems?: number;
-  items: { enum: string[] } | { anyOf: McpConstOption[] };
+  uniqueItems?: boolean;
+  /** Spec 2025-11-25 wraps enum inside `{ type: "string", enum: [...] }` or uses `anyOf`. */
+  items: { type?: string; enum: string[] } | { anyOf: McpConstOption[] };
   default?: string[];
 }
 
@@ -68,19 +72,30 @@ export type McpProperty =
 /** The `requestedSchema` object in an MCP form-mode elicitation request. */
 export interface McpElicitationSchema {
   type: 'object';
+  title?: string;
   properties: Record<string, McpProperty>;
   required?: string[];
 }
 
-/** Full MCP JSON-RPC 2.0 elicitation/create request envelope. */
+/** Full MCP JSON-RPC 2.0 elicitation/create request envelope (spec 2025-11-25). */
 export interface McpElicitationRequest {
   jsonrpc: '2.0';
-  id: number;
+  id: string | number;
   method: 'elicitation/create';
-  params: {
-    message: string;
-    requestedSchema: McpElicitationSchema;
-  };
+  params:
+    | {
+        /** Form mode (default when omitted). */
+        mode?: 'form';
+        message: string;
+        requestedSchema: McpElicitationSchema;
+      }
+    | {
+        /** URL mode — out-of-band interaction, no requestedSchema. */
+        mode: 'url';
+        message: string;
+        url: string;
+        elicitationId: string;
+      };
 }
 
 // ---------------------------------------------------------------------------
@@ -94,16 +109,28 @@ export interface McpElicitationRequest {
  * export preserves the original MCP property names.
  *
  * Field types are mapped as follows:
- * - `string` (plain)         → `text` (+ `inputType` from `format`)
- * - `string` with `enum`     → `radio`
- * - `string` with `oneOf`    → `radio` (options carry display titles)
- * - `number` / `integer`     → `text` + `inputType: 'number'`
- * - `boolean`                → `boolean`
- * - `array` with enum items  → `check` (multi-select)
+ * - `string` (plain)                    → `text` (+ `inputType` from `format`)
+ * - `string` with `enum`/`enumNames`    → `radio`
+ * - `string` with `oneOf`               → `radio` (options carry display titles)
+ * - `number` / `integer`                → `text` + `inputType: 'number'`
+ * - `boolean`                           → `boolean`
+ * - `array` with enum items             → `check` (multi-select)
+ *
+ * All MCP constraints (`default`, `minLength`, `maxLength`, `pattern`,
+ * `minimum`, `maximum`, `minItems`, `maxItems`) are preserved in each
+ * field's `_sourceData` so they survive a round-trip export.
  */
 export function importFromMcp(
   schema: McpElicitationSchema,
-  options?: { formId?: string; title?: string }
+  options?: {
+    formId?: string;
+    title?: string;
+    description?: string;
+    mcpId?: string | number;
+    mcpMessage?: string;
+    /** Top-level envelope `meta` field (non-standard, preserved for round-trip). */
+    mcpMeta?: unknown;
+  }
 ): FormDefinition {
   const existingIds = new Set<string>();
   const requiredKeys = new Set(schema.required ?? []);
@@ -112,11 +139,49 @@ export function importFromMcp(
     mcpPropToField(key, prop, requiredKeys.has(key), existingIds)
   );
 
+  // Preserve MCP envelope + schema metadata for lossless round-trip export.
+  const mcpMeta: Record<string, unknown> = {};
+  if (options?.mcpId !== undefined) mcpMeta['mcpId'] = options.mcpId;
+  if (options?.mcpMessage !== undefined)
+    mcpMeta['mcpMessage'] = options.mcpMessage;
+  if (schema.title !== undefined) mcpMeta['schemaTitle'] = schema.title;
+  if (options?.mcpMeta !== undefined) mcpMeta['meta'] = options.mcpMeta;
+  const hasMcpMeta = Object.keys(mcpMeta).length > 0;
+
   return {
     id: options?.formId ?? 'mcp-form',
     ...(options?.title !== undefined ? { title: options.title } : {}),
+    ...(options?.description !== undefined
+      ? { description: options.description }
+      : {}),
+    ...(hasMcpMeta ? { _sourceData: mcpMeta } : {}),
     fields,
   };
+}
+
+/** Opaque bag of MCP-specific field metadata stored in `_sourceData`. */
+interface McpFieldMeta {
+  description?: string;
+  default?: string | number | boolean | string[];
+  // string constraints
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  // number constraints
+  minimum?: number;
+  maximum?: number;
+  /** Preserves 'number' vs 'integer' distinction across the round-trip. */
+  mcpType?: 'number' | 'integer';
+  // array constraints
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  /**
+   * Full original MCP property definition for types outside the flat-form spec
+   * (nested objects, array-of-objects). Emitted verbatim on export so no data
+   * is lost across the round-trip.
+   */
+  mcpPropDefinition?: unknown;
 }
 
 function mcpPropToField(
@@ -126,34 +191,87 @@ function mcpPropToField(
   existingIds: Set<string>
 ): FieldDefinition {
   const question = (prop as { title?: string }).title;
+
+  // Collect all preservable MCP metadata into _sourceData.
+  const meta: McpFieldMeta = {};
+  if (prop.description !== undefined) meta.description = prop.description;
+
   const shared = {
     id: key,
     ...(question !== undefined ? { question } : {}),
     ...(isRequired ? { required: true as const } : {}),
   };
 
-  if (prop.type === 'array') {
+  if ((prop as { type: string }).type === 'object') {
+    // Nested objects are outside the MCP flat-form spec — import as longtext
+    // so the user can inspect/paste the JSON value. Full definition preserved
+    // in _sourceData so export restores it verbatim.
     return {
       ...shared,
+      _sourceData: { ...meta, mcpPropDefinition: prop },
+      fieldType: 'longtext',
+    };
+  }
+
+  if (prop.type === 'array') {
+    if (prop.default !== undefined) meta.default = prop.default;
+    if (prop.minItems !== undefined) meta.minItems = prop.minItems;
+    if (prop.maxItems !== undefined) meta.maxItems = prop.maxItems;
+    if ((prop as McpArrayProp).uniqueItems !== undefined)
+      meta.uniqueItems = (prop as McpArrayProp).uniqueItems;
+    const options = mcpItemsToOptions(prop.items, existingIds);
+    // Array of objects (no enum/anyOf) is outside spec — fall back to longtext,
+    // full definition preserved for verbatim export.
+    if (options === null) {
+      return {
+        ...shared,
+        _sourceData: { ...meta, mcpPropDefinition: prop },
+        fieldType: 'longtext',
+      };
+    }
+    return {
+      ...shared,
+      ...(Object.keys(meta).length > 0 ? { _sourceData: meta } : {}),
       fieldType: 'check',
-      options: mcpItemsToOptions(prop.items, existingIds),
+      options,
     };
   }
 
   if (prop.type === 'boolean') {
-    return { ...shared, fieldType: 'boolean' };
+    if (prop.default !== undefined) meta.default = prop.default;
+    return {
+      ...shared,
+      ...(Object.keys(meta).length > 0 ? { _sourceData: meta } : {}),
+      fieldType: 'boolean',
+    };
   }
 
   if (prop.type === 'number' || prop.type === 'integer') {
-    return { ...shared, fieldType: 'text', inputType: 'number' };
+    meta.mcpType = prop.type;
+    if (prop.default !== undefined) meta.default = prop.default;
+    if (prop.minimum !== undefined) meta.minimum = prop.minimum;
+    if (prop.maximum !== undefined) meta.maximum = prop.maximum;
+    return {
+      ...shared,
+      ...(Object.keys(meta).length > 0 ? { _sourceData: meta } : {}),
+      fieldType: 'text',
+      inputType: 'number',
+    };
   }
 
-  // At this point prop.type === 'string'
+  // prop.type === 'string'
   const strProp = prop as McpStringProp;
+  if (strProp.default !== undefined) meta.default = strProp.default;
+  if (strProp.minLength !== undefined) meta.minLength = strProp.minLength;
+  if (strProp.maxLength !== undefined) meta.maxLength = strProp.maxLength;
+  if (strProp.pattern !== undefined) meta.pattern = strProp.pattern;
+
+  const metaSpread = Object.keys(meta).length > 0 ? { _sourceData: meta } : {};
 
   if (strProp.oneOf) {
     return {
       ...shared,
+      ...metaSpread,
       fieldType: 'radio',
       options: strProp.oneOf.map(({ const: v, title: t }) =>
         makeOption(v, existingIds, t)
@@ -162,16 +280,22 @@ function mcpPropToField(
   }
 
   if (strProp.enum) {
+    // `enumNames` (parallel array) provides display titles — spec 2025-11-25.
+    const names = strProp.enumNames;
     return {
       ...shared,
+      ...metaSpread,
       fieldType: 'radio',
-      options: strProp.enum.map((v) => makeOption(v, existingIds)),
+      options: strProp.enum.map((v, i) =>
+        makeOption(v, existingIds, names?.[i])
+      ),
     };
   }
 
   // plain string
   return {
     ...shared,
+    ...metaSpread,
     fieldType: 'text',
     ...(strProp.format !== undefined
       ? { inputType: mcpFormatToInputType(strProp.format) }
@@ -179,14 +303,22 @@ function mcpPropToField(
   };
 }
 
+/**
+ * Returns null when items is an array-of-objects (outside MCP flat-form spec).
+ * Returns an empty array for a valid but empty enum.
+ */
 function mcpItemsToOptions(
   items: McpArrayProp['items'],
   existingIds: Set<string>
-): FieldOption[] {
+): FieldOption[] | null {
   if ('anyOf' in items) {
     return items.anyOf.map(({ const: v, title: t }) =>
       makeOption(v, existingIds, t)
     );
+  }
+  if (!Array.isArray(items.enum)) {
+    // items is an object schema (array-of-objects) — not a flat enum.
+    return null;
   }
   return items.enum.map((v) => makeOption(v, existingIds));
 }
@@ -220,20 +352,23 @@ function mcpFormatToInputType(
 // ---------------------------------------------------------------------------
 
 /**
- * Convert an eSheet `FormDefinition` into an MCP elicitation `requestedSchema`.
+ * Convert an eSheet `FormDefinition` into an MCP elicitation request (form mode).
  *
  * Section containers are flattened — their leaf fields are promoted to the
  * top-level properties object. Field types with no MCP equivalent (matrix,
  * ranking, image, html, signature, diagram, display, multitext) are silently
  * skipped.
  *
+ * All MCP constraints stored in `_sourceData` during import are restored so
+ * the output is a lossless round-trip of the original schema.
+ *
  * Field types map as follows:
- * - `text` / `longtext`            → `string` (+ `format` from `inputType`)
- * - `boolean`                      → `boolean`
- * - `radio` / `dropdown`           → `string` enum (with or without titles)
- * - `check` / `multiselectdropdown`→ `array` enum (with or without titles)
- * - `rating`                       → `integer` (min=1, max=option count)
- * - `slider`                       → `number`
+ * - `text` / `longtext`             → `string` (+ `format` from `inputType`)
+ * - `boolean`                       → `boolean`
+ * - `radio` / `dropdown`            → `string` enum (with or without titles)
+ * - `check` / `multiselectdropdown` → `array` enum (with or without titles)
+ * - `rating`                        → `integer` (min=1, max=option count)
+ * - `slider`                        → `number`
  */
 export function exportToMcp(definition: FormDefinition): McpElicitationRequest {
   const properties: Record<string, McpProperty> = {};
@@ -246,16 +381,34 @@ export function exportToMcp(definition: FormDefinition): McpElicitationRequest {
     if (field.required) required.push(field.id);
   }
 
+  const src = definition._sourceData as
+    | {
+        mcpId?: string | number;
+        mcpMessage?: string;
+        schemaTitle?: string;
+        meta?: unknown;
+      }
+    | null
+    | undefined;
+
   const requestedSchema: McpElicitationSchema = { type: 'object', properties };
+  if (src?.schemaTitle !== undefined) requestedSchema.title = src.schemaTitle;
   if (required.length > 0) requestedSchema.required = required;
 
-  const message = definition.description ?? definition.title ?? '';
-  return {
+  const envelopeId = src?.mcpId ?? definition.id;
+  const message =
+    src?.mcpMessage ?? definition.description ?? definition.title ?? '';
+  const envelope: McpElicitationRequest = {
     jsonrpc: '2.0',
-    id: 1,
+    id: envelopeId,
     method: 'elicitation/create',
-    params: { message, requestedSchema },
+    params: { mode: 'form', message, requestedSchema },
   };
+  // Restore non-standard top-level meta if it was preserved during import.
+  if (src?.meta !== undefined) {
+    (envelope as unknown as Record<string, unknown>)['meta'] = src.meta;
+  }
+  return envelope;
 }
 
 /** Recursively flatten sections to their answerable leaf fields. */
@@ -275,42 +428,91 @@ function collectLeafFields(
 
 function fieldToMcpProp(field: FieldDefinition): McpProperty | null {
   const title = field.question;
+  const meta = field._sourceData as McpFieldMeta | null | undefined;
+  const description = meta?.description;
 
   switch (field.fieldType) {
     case 'text':
     case 'longtext': {
+      // If this field was imported from a non-flat MCP type (object or
+      // array-of-objects), restore the original property definition verbatim.
+      if (meta?.mcpPropDefinition !== undefined) {
+        return meta.mcpPropDefinition as McpProperty;
+      }
+      // Restore number/integer fields that were imported as text+inputType:number.
+      if (meta?.mcpType !== undefined) {
+        return {
+          type: meta.mcpType,
+          ...(title !== undefined ? { title } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(meta.minimum !== undefined ? { minimum: meta.minimum } : {}),
+          ...(meta.maximum !== undefined ? { maximum: meta.maximum } : {}),
+          ...(meta.default !== undefined
+            ? { default: meta.default as number }
+            : {}),
+        };
+      }
       const format = inputTypeToMcpFormat(field.inputType);
       return {
         type: 'string',
         ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(meta?.minLength !== undefined ? { minLength: meta.minLength } : {}),
+        ...(meta?.maxLength !== undefined ? { maxLength: meta.maxLength } : {}),
+        ...(meta?.pattern !== undefined ? { pattern: meta.pattern } : {}),
         ...(format !== undefined ? { format } : {}),
+        ...(meta?.default !== undefined
+          ? { default: meta.default as string }
+          : {}),
       };
     }
 
     case 'boolean':
-      return { type: 'boolean', ...(title !== undefined ? { title } : {}) };
+      return {
+        type: 'boolean',
+        ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(meta?.default !== undefined
+          ? { default: meta.default as boolean }
+          : {}),
+      };
 
     case 'radio':
     case 'dropdown': {
       const options = field.options ?? [];
       if (options.length === 0) {
-        return { type: 'string', ...(title !== undefined ? { title } : {}) };
+        return {
+          type: 'string',
+          ...(title !== undefined ? { title } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(meta?.default !== undefined
+            ? { default: meta.default as string }
+            : {}),
+        };
       }
       const hasText = options.some((o) => o.text !== undefined);
       if (hasText) {
         return {
           type: 'string',
           ...(title !== undefined ? { title } : {}),
+          ...(description !== undefined ? { description } : {}),
           oneOf: options.map((o) => ({
             const: o.value,
             title: o.text ?? o.value,
           })),
+          ...(meta?.default !== undefined
+            ? { default: meta.default as string }
+            : {}),
         };
       }
       return {
         type: 'string',
         ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
         enum: options.map((o) => o.value),
+        ...(meta?.default !== undefined
+          ? { default: meta.default as string }
+          : {}),
       };
     }
 
@@ -325,11 +527,20 @@ function fieldToMcpProp(field: FieldDefinition): McpProperty | null {
               title: o.text ?? o.value,
             })),
           }
-        : { enum: options.map((o) => o.value) };
+        : { type: 'string' as const, enum: options.map((o) => o.value) };
       return {
         type: 'array',
         ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(meta?.minItems !== undefined ? { minItems: meta.minItems } : {}),
+        ...(meta?.maxItems !== undefined ? { maxItems: meta.maxItems } : {}),
+        ...(meta?.uniqueItems !== undefined
+          ? { uniqueItems: meta.uniqueItems }
+          : {}),
         items,
+        ...(meta?.default !== undefined
+          ? { default: meta.default as string[] }
+          : {}),
       };
     }
 
@@ -340,11 +551,27 @@ function fieldToMcpProp(field: FieldDefinition): McpProperty | null {
         minimum: 1,
         ...(max !== undefined ? { maximum: max } : {}),
         ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(meta?.default !== undefined
+          ? { default: meta.default as number }
+          : {}),
       };
     }
 
-    case 'slider':
-      return { type: 'number', ...(title !== undefined ? { title } : {}) };
+    case 'slider': {
+      // Restore number vs integer distinction from original import.
+      const numType: 'number' | 'integer' = meta?.mcpType ?? 'number';
+      return {
+        type: numType,
+        ...(title !== undefined ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(meta?.minimum !== undefined ? { minimum: meta.minimum } : {}),
+        ...(meta?.maximum !== undefined ? { maximum: meta.maximum } : {}),
+        ...(meta?.default !== undefined
+          ? { default: meta.default as number }
+          : {}),
+      };
+    }
 
     default:
       // ranking, multitext, singlematrix, multimatrix, image, html,

--- a/packages/core/src/lib/functions/mcp.ts
+++ b/packages/core/src/lib/functions/mcp.ts
@@ -1,0 +1,367 @@
+import type {
+  FormDefinition,
+  FieldDefinition,
+  FieldOption,
+  TextInputType,
+} from '../types.js';
+import { generateOptionId } from './ids.js';
+
+// ---------------------------------------------------------------------------
+// MCP Elicitation Types (form mode, draft spec)
+// ---------------------------------------------------------------------------
+
+/** A literal const/title pair used in single- and multi-select enums. */
+export interface McpConstOption {
+  const: string;
+  title: string;
+}
+
+/** String property — plain text, formatted text, or single-select enum. */
+export interface McpStringProp {
+  type: 'string';
+  title?: string;
+  description?: string;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: 'email' | 'uri' | 'date' | 'date-time';
+  enum?: string[];
+  oneOf?: McpConstOption[];
+  default?: string;
+}
+
+/** Numeric property. */
+export interface McpNumberProp {
+  type: 'number' | 'integer';
+  title?: string;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  default?: number;
+}
+
+/** Boolean property. */
+export interface McpBooleanProp {
+  type: 'boolean';
+  title?: string;
+  description?: string;
+  default?: boolean;
+}
+
+/** Multi-select enum property. */
+export interface McpArrayProp {
+  type: 'array';
+  title?: string;
+  description?: string;
+  minItems?: number;
+  maxItems?: number;
+  items: { enum: string[] } | { anyOf: McpConstOption[] };
+  default?: string[];
+}
+
+export type McpProperty =
+  | McpStringProp
+  | McpNumberProp
+  | McpBooleanProp
+  | McpArrayProp;
+
+/** The `requestedSchema` object in an MCP form-mode elicitation request. */
+export interface McpElicitationSchema {
+  type: 'object';
+  properties: Record<string, McpProperty>;
+  required?: string[];
+}
+
+/** Full MCP JSON-RPC 2.0 elicitation/create request envelope. */
+export interface McpElicitationRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: 'elicitation/create';
+  params: {
+    message: string;
+    requestedSchema: McpElicitationSchema;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import: MCP elicitation schema → FormDefinition
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an MCP elicitation `requestedSchema` into an eSheet `FormDefinition`.
+ *
+ * Field IDs are taken directly from the property key names so that a round-trip
+ * export preserves the original MCP property names.
+ *
+ * Field types are mapped as follows:
+ * - `string` (plain)         → `text` (+ `inputType` from `format`)
+ * - `string` with `enum`     → `radio`
+ * - `string` with `oneOf`    → `radio` (options carry display titles)
+ * - `number` / `integer`     → `text` + `inputType: 'number'`
+ * - `boolean`                → `boolean`
+ * - `array` with enum items  → `check` (multi-select)
+ */
+export function importFromMcp(
+  schema: McpElicitationSchema,
+  options?: { formId?: string; title?: string }
+): FormDefinition {
+  const existingIds = new Set<string>();
+  const requiredKeys = new Set(schema.required ?? []);
+
+  const fields = Object.entries(schema.properties ?? {}).map(([key, prop]) =>
+    mcpPropToField(key, prop, requiredKeys.has(key), existingIds)
+  );
+
+  return {
+    id: options?.formId ?? 'mcp-form',
+    ...(options?.title !== undefined ? { title: options.title } : {}),
+    fields,
+  };
+}
+
+function mcpPropToField(
+  key: string,
+  prop: McpProperty,
+  isRequired: boolean,
+  existingIds: Set<string>
+): FieldDefinition {
+  const question = (prop as { title?: string }).title;
+  const shared = {
+    id: key,
+    ...(question !== undefined ? { question } : {}),
+    ...(isRequired ? { required: true as const } : {}),
+  };
+
+  if (prop.type === 'array') {
+    return {
+      ...shared,
+      fieldType: 'check',
+      options: mcpItemsToOptions(prop.items, existingIds),
+    };
+  }
+
+  if (prop.type === 'boolean') {
+    return { ...shared, fieldType: 'boolean' };
+  }
+
+  if (prop.type === 'number' || prop.type === 'integer') {
+    return { ...shared, fieldType: 'text', inputType: 'number' };
+  }
+
+  // At this point prop.type === 'string'
+  const strProp = prop as McpStringProp;
+
+  if (strProp.oneOf) {
+    return {
+      ...shared,
+      fieldType: 'radio',
+      options: strProp.oneOf.map(({ const: v, title: t }) =>
+        makeOption(v, existingIds, t)
+      ),
+    };
+  }
+
+  if (strProp.enum) {
+    return {
+      ...shared,
+      fieldType: 'radio',
+      options: strProp.enum.map((v) => makeOption(v, existingIds)),
+    };
+  }
+
+  // plain string
+  return {
+    ...shared,
+    fieldType: 'text',
+    ...(strProp.format !== undefined
+      ? { inputType: mcpFormatToInputType(strProp.format) }
+      : {}),
+  };
+}
+
+function mcpItemsToOptions(
+  items: McpArrayProp['items'],
+  existingIds: Set<string>
+): FieldOption[] {
+  if ('anyOf' in items) {
+    return items.anyOf.map(({ const: v, title: t }) =>
+      makeOption(v, existingIds, t)
+    );
+  }
+  return items.enum.map((v) => makeOption(v, existingIds));
+}
+
+function makeOption(
+  value: string,
+  existingIds: Set<string>,
+  text?: string
+): FieldOption {
+  const id = generateOptionId(existingIds);
+  existingIds.add(id);
+  return text !== undefined ? { id, value, text } : { id, value };
+}
+
+function mcpFormatToInputType(
+  format: McpStringProp['format']
+): TextInputType | undefined {
+  const map: Partial<
+    Record<NonNullable<McpStringProp['format']>, TextInputType>
+  > = {
+    email: 'email',
+    uri: 'url',
+    date: 'date',
+    'date-time': 'datetime-local',
+  };
+  return format !== undefined ? map[format] : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Export: FormDefinition → MCP elicitation schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an eSheet `FormDefinition` into an MCP elicitation `requestedSchema`.
+ *
+ * Section containers are flattened — their leaf fields are promoted to the
+ * top-level properties object. Field types with no MCP equivalent (matrix,
+ * ranking, image, html, signature, diagram, display, multitext) are silently
+ * skipped.
+ *
+ * Field types map as follows:
+ * - `text` / `longtext`            → `string` (+ `format` from `inputType`)
+ * - `boolean`                      → `boolean`
+ * - `radio` / `dropdown`           → `string` enum (with or without titles)
+ * - `check` / `multiselectdropdown`→ `array` enum (with or without titles)
+ * - `rating`                       → `integer` (min=1, max=option count)
+ * - `slider`                       → `number`
+ */
+export function exportToMcp(definition: FormDefinition): McpElicitationRequest {
+  const properties: Record<string, McpProperty> = {};
+  const required: string[] = [];
+
+  for (const field of collectLeafFields(definition.fields)) {
+    const prop = fieldToMcpProp(field);
+    if (prop === null) continue;
+    properties[field.id] = prop;
+    if (field.required) required.push(field.id);
+  }
+
+  const requestedSchema: McpElicitationSchema = { type: 'object', properties };
+  if (required.length > 0) requestedSchema.required = required;
+
+  const message = definition.description ?? definition.title ?? '';
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'elicitation/create',
+    params: { message, requestedSchema },
+  };
+}
+
+/** Recursively flatten sections to their answerable leaf fields. */
+function collectLeafFields(
+  fields: readonly FieldDefinition[]
+): FieldDefinition[] {
+  const result: FieldDefinition[] = [];
+  for (const f of fields) {
+    if (f.fieldType === 'section' && f.fields) {
+      result.push(...collectLeafFields(f.fields));
+    } else {
+      result.push(f);
+    }
+  }
+  return result;
+}
+
+function fieldToMcpProp(field: FieldDefinition): McpProperty | null {
+  const title = field.question;
+
+  switch (field.fieldType) {
+    case 'text':
+    case 'longtext': {
+      const format = inputTypeToMcpFormat(field.inputType);
+      return {
+        type: 'string',
+        ...(title !== undefined ? { title } : {}),
+        ...(format !== undefined ? { format } : {}),
+      };
+    }
+
+    case 'boolean':
+      return { type: 'boolean', ...(title !== undefined ? { title } : {}) };
+
+    case 'radio':
+    case 'dropdown': {
+      const options = field.options ?? [];
+      if (options.length === 0) {
+        return { type: 'string', ...(title !== undefined ? { title } : {}) };
+      }
+      const hasText = options.some((o) => o.text !== undefined);
+      if (hasText) {
+        return {
+          type: 'string',
+          ...(title !== undefined ? { title } : {}),
+          oneOf: options.map((o) => ({
+            const: o.value,
+            title: o.text ?? o.value,
+          })),
+        };
+      }
+      return {
+        type: 'string',
+        ...(title !== undefined ? { title } : {}),
+        enum: options.map((o) => o.value),
+      };
+    }
+
+    case 'check':
+    case 'multiselectdropdown': {
+      const options = field.options ?? [];
+      const hasText = options.some((o) => o.text !== undefined);
+      const items = hasText
+        ? {
+            anyOf: options.map((o) => ({
+              const: o.value,
+              title: o.text ?? o.value,
+            })),
+          }
+        : { enum: options.map((o) => o.value) };
+      return {
+        type: 'array',
+        ...(title !== undefined ? { title } : {}),
+        items,
+      };
+    }
+
+    case 'rating': {
+      const max = field.options?.length;
+      return {
+        type: 'integer',
+        minimum: 1,
+        ...(max !== undefined ? { maximum: max } : {}),
+        ...(title !== undefined ? { title } : {}),
+      };
+    }
+
+    case 'slider':
+      return { type: 'number', ...(title !== undefined ? { title } : {}) };
+
+    default:
+      // ranking, multitext, singlematrix, multimatrix, image, html,
+      // signature, diagram, display → no MCP equivalent
+      return null;
+  }
+}
+
+function inputTypeToMcpFormat(
+  inputType?: TextInputType
+): McpStringProp['format'] | undefined {
+  if (inputType === undefined) return undefined;
+  const map: Partial<Record<TextInputType, McpStringProp['format']>> = {
+    email: 'email',
+    url: 'uri',
+    date: 'date',
+    'datetime-local': 'date-time',
+  };
+  return map[inputType];
+}

--- a/packages/core/src/lib/stores/form-store.spec.ts
+++ b/packages/core/src/lib/stores/form-store.spec.ts
@@ -7,7 +7,6 @@ import type {
   FieldType,
   ConditionalRule,
 } from '../types.js';
-import { SCHEMA_TYPE } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,7 +21,7 @@ function field(
 }
 
 function form(fields: FieldDefinition[]): FormDefinition {
-  return { schemaType: SCHEMA_TYPE, id: 'test-form', fields };
+  return { id: 'test-form', fields };
 }
 
 function visibleRule(targetId: string, expected: string): ConditionalRule {
@@ -715,7 +714,6 @@ describe('createFormStore', () => {
         form([field('q1', 'text'), field('q2', 'number')])
       );
       const def = store.getState().hydrateDefinition();
-      expect(def.schemaType).toBe(SCHEMA_TYPE);
       expect(def.fields).toHaveLength(2);
       expect(def.fields[0].id).toBe('q1');
       expect(def.fields[1].id).toBe('q2');

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -56,6 +56,8 @@ export interface FormState {
   readonly instanceId: string;
   /** Top-level form identifier used for import/export and schema validation. */
   readonly formId: string;
+  /** Opaque metadata preserved from the original import source (e.g. MCP envelope fields). */
+  readonly formSourceData?: unknown;
   /** Flat-indexed map — the source of truth for field structure. */
   readonly normalized: NormalizedDefinition;
   /** Current responses keyed by field ID. */
@@ -271,6 +273,7 @@ export function createFormStore(initial?: FormDefinition): FormStore {
     // --- Data ---
     instanceId: `ms-${nextInstanceId++}`,
     formId: initialFormId,
+    formSourceData: initial?._sourceData,
     normalized: initial
       ? normalizeDefinition(initial.fields)
       : EMPTY_NORMALIZED,
@@ -280,6 +283,7 @@ export function createFormStore(initial?: FormDefinition): FormStore {
     loadDefinition: (definition) =>
       set({
         formId: definition.id,
+        formSourceData: definition._sourceData,
         normalized: normalizeDefinition(definition.fields),
         responses: {},
       }),
@@ -706,9 +710,12 @@ export function createFormStore(initial?: FormDefinition): FormStore {
     },
 
     hydrateDefinition: () => {
-      const { normalized, formId } = get();
+      const { normalized, formId, formSourceData } = get();
       return {
         id: formId,
+        ...(formSourceData !== undefined
+          ? { _sourceData: formSourceData }
+          : {}),
         fields: hydrateDefinition(normalized),
       };
     },

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -14,7 +14,6 @@ import type {
   MatrixRow,
   MatrixColumn,
 } from '../types.js';
-import { SCHEMA_TYPE } from '../types.js';
 import { getFieldTypeMeta } from '../registry.js';
 import {
   generateFieldId,
@@ -709,7 +708,6 @@ export function createFormStore(initial?: FormDefinition): FormStore {
     hydrateDefinition: () => {
       const { normalized, formId } = get();
       return {
-        schemaType: SCHEMA_TYPE,
         id: formId,
         fields: hydrateDefinition(normalized),
       };

--- a/packages/core/src/lib/types.spec.ts
+++ b/packages/core/src/lib/types.spec.ts
@@ -1,5 +1,4 @@
 import {
-  SCHEMA_TYPE,
   FIELD_TYPES,
   formDefinitionSchema,
   fieldDefinitionSchema,
@@ -12,10 +11,6 @@ import type {
 } from './types.js';
 
 describe('schema types', () => {
-  it('should export the schema type constant', () => {
-    expect(SCHEMA_TYPE).toBe('mieforms-v1.0');
-  });
-
   it('should export all field types', () => {
     expect(FIELD_TYPES).toContain('text');
     expect(FIELD_TYPES).toContain('section');
@@ -31,14 +26,12 @@ describe('schema types', () => {
     };
 
     const form: FormDefinition = {
-      schemaType: SCHEMA_TYPE,
       id: 'test-form',
       title: 'Test Form',
       fields: [field],
     };
 
     expect(form.fields).toHaveLength(1);
-    expect(form.schemaType).toBe('mieforms-v1.0');
   });
 
   it('should allow constructing a response map', () => {
@@ -82,7 +75,6 @@ describe('schema types', () => {
 
   it('should reject unknown top-level form properties', () => {
     const result = formDefinitionSchema.safeParse({
-      schemaType: SCHEMA_TYPE,
       id: 'comprehensive',
       unknown: true,
       fields: [],

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,15 +1,6 @@
 import { z } from 'zod/mini';
 
 // ---------------------------------------------------------------------------
-// Schema Version
-// ---------------------------------------------------------------------------
-
-/** Supported schema version identifier. */
-export const SCHEMA_TYPE = 'mieforms-v1.0' as const;
-
-export type SchemaType = typeof SCHEMA_TYPE;
-
-// ---------------------------------------------------------------------------
 // Field Types
 // ---------------------------------------------------------------------------
 
@@ -312,7 +303,6 @@ export interface FieldResponse {
 
 /** A complete form definition (no response values). */
 export const formDefinitionSchema = z.strictObject({
-  schemaType: z.literal(SCHEMA_TYPE),
   id: z.string(),
   title: z.optional(z.string()),
   description: z.optional(z.string()),

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -337,6 +337,13 @@ export type AttachmentAnswer = {
   title?: string;
 };
 
+/** A single row answer in a matrix field — contains the selected column(s) as items. */
+export type MatrixRowAnswer = {
+  id: string;
+  value: string;
+  items: Array<{ id: string; value: string }>;
+};
+
 /** All possible answer value shapes in a submission payload. */
 export type AnswerValue =
   | string
@@ -346,6 +353,7 @@ export type AnswerValue =
   | { id: string; value: string }
   | Array<{ id: string; value: string }>
   | RankedAnswer[]
+  | MatrixRowAnswer[]
   | AttachmentAnswer;
 
 /** A single item in the submission payload — one per answerable field. */

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -337,13 +337,6 @@ export type AttachmentAnswer = {
   title?: string;
 };
 
-/** A single row answer in a matrix field — contains the selected column(s) as items. */
-export type MatrixRowAnswer = {
-  id: string;
-  value: string;
-  items: Array<{ id: string; value: string }>;
-};
-
 /** All possible answer value shapes in a submission payload. */
 export type AnswerValue =
   | string
@@ -353,7 +346,7 @@ export type AnswerValue =
   | { id: string; value: string }
   | Array<{ id: string; value: string }>
   | RankedAnswer[]
-  | MatrixRowAnswer[]
+  | ResponseItem[]
   | AttachmentAnswer;
 
 /** A single item in the submission payload — one per answerable field. */

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -307,6 +307,7 @@ export const formDefinitionSchema = z.strictObject({
   title: z.optional(z.string()),
   description: z.optional(z.string()),
   fields: z.array(fieldDefinitionSchema),
+  _sourceData: z.optional(z.unknown()),
 });
 export type FormDefinition = z.infer<typeof formDefinitionSchema>;
 
@@ -347,7 +348,8 @@ export type AnswerValue =
   | Array<{ id: string; value: string }>
   | RankedAnswer[]
   | ResponseItem[]
-  | AttachmentAnswer;
+  | AttachmentAnswer
+  | Record<string, SelectedOption | SelectedOption[]>;
 
 /** A single item in the submission payload — one per answerable field. */
 export interface ResponseItem {

--- a/packages/renderer/src/lib/EsheetRenderer.spec.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.spec.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, act, cleanup } from '@testing-library/react';
-import { SCHEMA_TYPE } from '@esheet/core';
 import { EsheetRenderer, type EsheetRendererHandle } from './EsheetRenderer.js';
 
 afterEach(cleanup);
@@ -24,7 +23,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-1',
             title: 'Test',
             fields: [{ id: 'q1', fieldType: 'text', question: 'Name?' }],
@@ -48,7 +46,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-2',
             title: 'Test',
             fields: [{ id: 'q1', fieldType: 'text', question: 'Name?' }],
@@ -69,7 +66,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-3',
             title: 'Test Form',
             fields: [{ id: 'f1', fieldType: 'text', question: 'Q?' }],
@@ -91,7 +87,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-4',
             title: 'Test',
             fields: [{ id: 'q1', fieldType: 'text', question: 'Q?' }],
@@ -111,7 +106,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-5',
             title: 'Test',
             fields: [
@@ -146,7 +140,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-6',
             title: 'Test',
             fields: [
@@ -176,7 +169,6 @@ describe('EsheetRenderer', () => {
         <EsheetRenderer
           ref={ref}
           formData={{
-            schemaType: SCHEMA_TYPE,
             id: 'test-form-7',
             title: 'Test',
             fields: [

--- a/packages/renderer/src/lib/hooks/useRendererInit.ts
+++ b/packages/renderer/src/lib/hooks/useRendererInit.ts
@@ -50,7 +50,6 @@ export function useRendererInit(
         onValidationError?.(errors);
         // Load empty form instead of crashing
         form.getState().loadDefinition({
-          schemaType: 'mieforms-v1.0',
           id: 'invalid-form',
           title: 'Invalid Form',
           fields: [],
@@ -77,7 +76,6 @@ export function useRendererInit(
       console.error('[EsheetRenderer] Failed to initialize:', error);
       // Load empty form as fallback
       form.getState().loadDefinition({
-        schemaType: 'mieforms-v1.0',
         id: 'error-form',
         title: 'Error',
         fields: [],

--- a/packages/renderer/src/lib/renderer.spec.ts
+++ b/packages/renderer/src/lib/renderer.spec.ts
@@ -1,5 +1,4 @@
 import {
-  SCHEMA_TYPE,
   type FormDefinition,
   type FormResponse,
 } from '@esheet/core';
@@ -8,7 +7,6 @@ import { renderer } from './renderer.js';
 describe('renderer', () => {
   function baseDefinition(): FormDefinition {
     return {
-      schemaType: SCHEMA_TYPE,
       id: 'renderer-test',
       title: 'Renderer Test',
       fields: [
@@ -126,7 +124,6 @@ describe('renderer', () => {
 
   it('computes enabled and required from responses', () => {
     const definition: FormDefinition = {
-      schemaType: SCHEMA_TYPE,
       id: 'renderer-effects',
       title: 'Renderer Effects Test',
       fields: [

--- a/packages/renderer/src/lib/renderer.spec.ts
+++ b/packages/renderer/src/lib/renderer.spec.ts
@@ -1,7 +1,4 @@
-import {
-  type FormDefinition,
-  type FormResponse,
-} from '@esheet/core';
+import { type FormDefinition, type FormResponse } from '@esheet/core';
 import { renderer } from './renderer.js';
 
 describe('renderer', () => {


### PR DESCRIPTION
## Overview

This PR introduces MCP (Model Context Protocol) interoperability to the eSheet system while simplifying the core schema model.

The main addition is a bidirectional conversion layer between MCP elicitation schemas and eSheet `FormDefinition`. This enables importing externally defined schemas into the builder and exporting forms into a standardized JSON-RPC format for downstream systems.

In parallel, the deprecated `schemaType` field has been fully removed across core, builder, renderer, and tests. This reduces ambiguity in the schema model and aligns the system around a single definition structure.

## What Changed

### MCP Import / Export (Core)

* Added `mcp.ts` conversion module

  * `importFromMcp(schema, options?)`

    * Converts MCP `requestedSchema` into `FormDefinition`
    * Supports:

      * string → text
      * enum → radio
      * number/integer → numeric input
      * boolean → boolean
      * array → checkbox
  * `exportToMcp(definition)`

    * Converts `FormDefinition` into JSON-RPC 2.0 elicitation payload
    * Outputs full envelope: `jsonrpc`, `id`, `method`, `params.message`, `params.requestedSchema`
    * Flattens sections and skips unsupported field types

* Exported MCP types:

  * `McpElicitationSchema`
  * `McpElicitationRequest`
  * `McpProperty` and related subtypes

* Exposed all MCP utilities via core `index.ts`

---

### Builder Integration

* Updated `BuilderHeader.tsx` to support MCP workflows

**Import**

* Auto-detects MCP JSON formats:

  * Full JSON-RPC envelope
  * `params` object
  * Raw `requestedSchema`
* Falls back to standard eSheet schema validation if MCP is not detected

**Export**

* Added export format toggle: `esheet` | `mcp`
* MCP export:

  * Skips form ID validation
  * Downloads full JSON-RPC payload immediately
* eSheet export:

  * Retains existing validation and ID confirmation flow

**Export Modal**

* Format-aware UI:

  * Form ID input shown only for eSheet
  * MCP shows descriptive export info instead
  * Confirm button label adapts to selected format

---

### Schema Simplification

* Removed `schemaType` and related constants across:

  * `types.ts`
  * `form-store.ts`
  * Hooks (`useRendererInit`)
  * Builder and renderer tests
  * Fixtures and specs

* Updated all affected tests and usages to align with the simplified schema model

---

## How to Test

### MCP Import

1. Copy an MCP elicitation schema (full JSON-RPC or `requestedSchema`)
2. In builder, use Import
3. Verify:

   * Fields are created correctly based on type mapping
   * Structure is flattened appropriately
   * No validation errors occur

---

### MCP Export

1. Build a form in the builder
2. Click Export
3. Select **MCP** format
4. Confirm export

Verify:

* Downloaded file contains:

  * `jsonrpc: "2.0"`
  * `method: "elicitation/create"`
  * `params.requestedSchema`
* Fields are correctly mapped and flattened
* Unsupported types are omitted safely

---

### eSheet Export (Regression)

1. Export using **eSheet** format
2. Verify:

   * Form ID is required
   * Output matches previous structure
   * Validation behavior unchanged

---

### Schema Cleanup

1. Run full test suite
2. Verify:

   * No references to `schemaType`
   * All tests pass
   * Builder and renderer function normally

---

## Breaking Changes

* Removed `schemaType` from all schema types and related APIs

Consumers relying on `schemaType` must update to the new unified schema structure.

---

#17 