### PR TITLE
feat(renderer): auto-detect MCP elicitation envelope in useRendererInit

### DIFF
--- a/apps/demo/public/mcp.json
+++ b/apps/demo/public/mcp.json
@@ -1,0 +1,49 @@
+{
+  "jsonrpc": "2.0",
+  "id": "webapp-elicitation-001",
+  "method": "elicitation/create",
+  "params": {
+    "message": "Fill out the basic web app configuration",
+    "requestedSchema": {
+      "type": "object",
+      "required": ["appName", "appType"],
+      "properties": {
+        "appName": {
+          "type": "string",
+          "title": "App Name",
+          "minLength": 3,
+          "maxLength": 50
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "maxLength": 200
+        },
+        "appType": {
+          "type": "string",
+          "title": "App Type",
+          "enum": ["SaaS", "Portfolio", "E-commerce", "Dashboard"]
+        },
+        "features": {
+          "type": "array",
+          "title": "Select Features",
+          "items": {
+            "type": "string",
+            "enum": ["Authentication", "Payments", "Analytics", "Notifications"]
+          },
+          "uniqueItems": true
+        },
+        "isPublic": {
+          "type": "boolean",
+          "title": "Publicly Accessible"
+        },
+        "userLimit": {
+          "type": "integer",
+          "title": "Max Users",
+          "minimum": 1,
+          "maximum": 100000
+        }
+      }
+    }
+  }
+}

--- a/packages/builder/src/lib/EsheetBuilder.spec.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.spec.tsx
@@ -6,7 +6,11 @@ import {
   waitFor,
   screen,
 } from '@testing-library/react';
-import { createFormStore, createUIStore } from '@esheet/core';
+import {
+  createFormStore,
+  createUIStore,
+  type FormDefinition,
+} from '@esheet/core';
 import { EsheetBuilder, useFormStore, useUI } from './EsheetBuilder.js';
 import { BuilderHeader } from './components/BuilderHeader.js';
 
@@ -55,7 +59,7 @@ describe('EsheetBuilder', () => {
     }
 
     render(
-      <EsheetBuilder onChange={(def) => changes.push(def)}>
+      <EsheetBuilder onChange={(def: FormDefinition) => changes.push(def)}>
         <Capture />
       </EsheetBuilder>
     );

--- a/packages/renderer/src/lib/hooks/useRendererInit.ts
+++ b/packages/renderer/src/lib/hooks/useRendererInit.ts
@@ -3,10 +3,12 @@ import YAML from 'js-yaml';
 import {
   formatZodValidationError,
   formDefinitionSchema,
+  importFromMcp,
   type FormDefinition,
   type FormResponse,
   type FormStore,
   type UIStore,
+  type McpElicitationRequest,
 } from '@esheet/core';
 
 /**
@@ -37,6 +39,17 @@ export function useRendererInit(
         parsed = isYaml ? YAML.load(trimmed) : JSON.parse(trimmed);
       } else {
         parsed = formData;
+      }
+
+      // Detect MCP elicitation/create envelope and convert to FormDefinition
+      if (isMcpElicitationRequest(parsed)) {
+        const mcpReq = parsed as McpElicitationRequest;
+        if (mcpReq.params.mode !== 'url') {
+          parsed = importFromMcp(mcpReq.params.requestedSchema, {
+            mcpId: mcpReq.id,
+            mcpMessage: mcpReq.params.message,
+          });
+        }
       }
 
       // Validate schema
@@ -83,4 +96,13 @@ export function useRendererInit(
       ui.getState().setMode('preview');
     }
   }, [form, ui, formData, initialResponses, onValidationError]);
+}
+
+/** Type guard — detects an MCP elicitation/create JSON-RPC envelope. */
+function isMcpElicitationRequest(
+  value: unknown
+): value is McpElicitationRequest {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v['jsonrpc'] === '2.0' && v['method'] === 'elicitation/create';
 }


### PR DESCRIPTION
## Overview

This PR adds MCP elicitation envelope support to the renderer initialization flow.

Previously, `useRendererInit` only validated incoming data directly against the eSheet form schema. With this change, the init path now detects MCP `elicitation/create` JSON-RPC payloads and converts them into an eSheet `FormDefinition` before running standard schema validation. This makes it possible to load MCP-based fixtures and integrations without requiring a manual pre-conversion step.

It also includes a small TypeScript cleanup in `EsheetBuilder.spec.tsx` and adds a new `mcp.json` fixture for testing/demo coverage.

## What Changed

* Added MCP imports in `useRendererInit.ts`

  * `importFromMcp`
  * `McpElicitationRequest`

* Added MCP envelope detection before Zod validation in `useRendererInit.ts`

  * Detects payloads with `jsonrpc: "2.0"` and `method: "elicitation/create"`
  * Converts matching payloads through `importFromMcp(...)`
  * Passes the converted result into the existing schema parse flow

* Added `isMcpElicitationRequest()` type guard in `useRendererInit.ts`

  * Keeps MCP detection explicit and typed
  * Prevents the conversion path from affecting normal eSheet schema input

* Updated `EsheetBuilder.spec.tsx`

  * Added `FormDefinition` type import from `@esheet/core`
  * Typed the `def` parameter in the `onChange` callback to fix `TS7006`

* Added `mcp.json`

  * New fixture file for MCP elicitation schema testing and local validation

## How to Test

1. Load the new `mcp.json` fixture through the flow that initializes the renderer.
2. Verify the payload is accepted even though it is an MCP JSON-RPC envelope rather than a raw eSheet schema.
3. Confirm the schema is converted and rendered as a valid eSheet form.
4. Verify existing raw eSheet schema input still initializes normally.
5. Run the test suite and confirm the updated spec passes without the TypeScript implicit `any` error.

## Breaking Changes

No breaking changes.
