### PR TITLE
fix(repo): workspace package resolution for fields exports

### DIFF
--- a/apps/demo/package-lock.json
+++ b/apps/demo/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@esheet/demo",
       "version": "0.0.1",
       "dependencies": {
-        "@esheet/builder": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "@esheet/renderer": "0.0.0 || ^0.0.1-0",
+        "@esheet/builder": "0.0.2-0",
+        "@esheet/fields": "0.0.2-0",
+        "@esheet/renderer": "0.0.2-0",
         "react-router-dom": "^7.11.0"
       }
     },
@@ -70,58 +70,6 @@
         "vite": "^7.0.0",
         "vite-plugin-dts": "~4.5.0",
         "vitest": "4.0.9"
-      }
-    },
-    "node_modules/@esheet/builder": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/builder/-/builder-0.0.1.tgz",
-      "integrity": "sha512-GTSBxoDAHYAnpLRzONGi+UuvnihvnxOj8SSawuPrYNgNBIYES9PrdnAJUoRV9/oxPzBXQRyX30bxwLZhi7ueOA==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "@monaco-editor/react": "^4.7.0",
-        "js-yaml": "^4.1.1",
-        "react": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@esheet/renderer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/renderer/-/renderer-0.0.1.tgz",
-      "integrity": "sha512-W3u/LnN9JrbpdwyvXvQp5e0spVyKMC83aB8GxGsu4cv19X2HO/KnF6TPppcrObWeovejF0Woz2zcxG0EHGMi5Q==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@monaco-editor/loader": {

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -6,9 +6,9 @@
     "name": "demo"
   },
   "dependencies": {
-    "@esheet/builder": "0.x",
-    "@esheet/fields": "0.x",
-    "@esheet/renderer": "0.x",
+    "@esheet/builder": "0.0.2-0",
+    "@esheet/fields": "0.0.2-0",
+    "@esheet/renderer": "0.0.2-0",
     "react-router-dom": "^7.11.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,62 +81,10 @@
       "name": "@esheet/demo",
       "version": "0.0.1",
       "dependencies": {
-        "@esheet/builder": "0.x",
-        "@esheet/fields": "0.x",
-        "@esheet/renderer": "0.x",
+        "@esheet/builder": "0.0.2-0",
+        "@esheet/fields": "0.0.2-0",
+        "@esheet/renderer": "0.0.2-0",
         "react-router-dom": "^7.11.0"
-      }
-    },
-    "apps/demo/node_modules/@esheet/builder": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/builder/-/builder-0.0.1.tgz",
-      "integrity": "sha512-GTSBxoDAHYAnpLRzONGi+UuvnihvnxOj8SSawuPrYNgNBIYES9PrdnAJUoRV9/oxPzBXQRyX30bxwLZhi7ueOA==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "@monaco-editor/react": "^4.7.0",
-        "js-yaml": "^4.1.1",
-        "react": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "apps/demo/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "apps/demo/node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "apps/demo/node_modules/@esheet/renderer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/renderer/-/renderer-0.0.1.tgz",
-      "integrity": "sha512-W3u/LnN9JrbpdwyvXvQp5e0spVyKMC83aB8GxGsu4cv19X2HO/KnF6TPppcrObWeovejF0Woz2zcxG0EHGMi5Q==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
       }
     },
     "apps/docs": {
@@ -39885,8 +39833,8 @@
       "name": "@esheet/builder",
       "version": "0.0.2-0",
       "dependencies": {
-        "@esheet/core": "0.x",
-        "@esheet/fields": "0.x",
+        "@esheet/core": "0.0.2-0",
+        "@esheet/fields": "0.0.2-0",
         "@monaco-editor/react": "^4.7.0",
         "js-yaml": "^4.1.1",
         "react": "^19.2.4",
@@ -39902,27 +39850,6 @@
         "@vitejs/plugin-react": "^5.1.4",
         "jsdom": "^28.1.0",
         "tailwindcss": "^4.2.1"
-      }
-    },
-    "packages/builder/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "packages/builder/node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tslib": "^2.3.0"
       }
     },
     "packages/builder/node_modules/@rolldown/pluginutils": {
@@ -40261,7 +40188,7 @@
       "name": "@esheet/fields",
       "version": "0.0.2-0",
       "dependencies": {
-        "@esheet/core": "0.x",
+        "@esheet/core": "0.0.2-0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "sortablejs": "^1.15.7",
@@ -40274,16 +40201,6 @@
         "@vitejs/plugin-react": "^5.1.4",
         "jsdom": "^28.1.0",
         "tailwindcss": "^4.2.1"
-      }
-    },
-    "packages/fields/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
       }
     },
     "packages/fields/node_modules/@rolldown/pluginutils": {
@@ -40577,8 +40494,8 @@
       "name": "@esheet/renderer",
       "version": "0.0.2-0",
       "dependencies": {
-        "@esheet/core": "0.x",
-        "@esheet/fields": "0.x",
+        "@esheet/core": "0.0.2-0",
+        "@esheet/fields": "0.0.2-0",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -40598,118 +40515,19 @@
       "name": "@esheet/renderer-blaze",
       "version": "0.0.2-0",
       "dependencies": {
-        "@esheet/renderer": "0.x",
+        "@esheet/renderer": "0.0.2-0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tslib": "^2.3.0"
-      }
-    },
-    "packages/renderer-blaze/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "packages/renderer-blaze/node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/renderer-blaze/node_modules/@esheet/renderer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/renderer/-/renderer-0.0.1.tgz",
-      "integrity": "sha512-W3u/LnN9JrbpdwyvXvQp5e0spVyKMC83aB8GxGsu4cv19X2HO/KnF6TPppcrObWeovejF0Woz2zcxG0EHGMi5Q==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
       }
     },
     "packages/renderer-standalone": {
       "name": "@esheet/renderer-standalone",
       "version": "0.0.2-0",
       "dependencies": {
-        "@esheet/renderer": "0.x",
+        "@esheet/renderer": "0.0.2-0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/renderer-standalone/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "packages/renderer-standalone/node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/renderer-standalone/node_modules/@esheet/renderer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/renderer/-/renderer-0.0.1.tgz",
-      "integrity": "sha512-W3u/LnN9JrbpdwyvXvQp5e0spVyKMC83aB8GxGsu4cv19X2HO/KnF6TPppcrObWeovejF0Woz2zcxG0EHGMi5Q==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "@esheet/fields": "0.0.0 || ^0.0.1-0",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/renderer/node_modules/@esheet/core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/core/-/core-0.0.1.tgz",
-      "integrity": "sha512-8ZkNf81hYdVHvRyRf2WfV6JzpylX3F9KCV8Ahe9mv0Zb0O8YBLbc4LvUkAq4SiSpwxCYSD6GEWZ8uZtTBXzANQ==",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11"
-      }
-    },
-    "packages/renderer/node_modules/@esheet/fields": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@esheet/fields/-/fields-0.0.1.tgz",
-      "integrity": "sha512-gOODycU5qmFy/tKFZ/rKdcF+uh9SyyXrZ2m+UvnsmSCFrMIyTF0KKWUXe/pM33hPMGXvvO5z6XaUvhAx6zhhtQ==",
-      "dependencies": {
-        "@esheet/core": "0.0.0 || ^0.0.1-0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
         "tslib": "^2.3.0"
       }
     },

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -38,8 +38,8 @@
     ]
   },
   "dependencies": {
-    "@esheet/core": "0.x",
-    "@esheet/fields": "0.x",
+    "@esheet/core": "0.0.2-0",
+    "@esheet/fields": "0.0.2-0",
     "@monaco-editor/react": "^4.7.0",
     "js-yaml": "^4.1.1",
     "react": "^19.2.4",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@esheet/core": "0.x",
+    "@esheet/core": "0.0.2-0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "sortablejs": "^1.15.7",

--- a/packages/renderer-blaze/package.json
+++ b/packages/renderer-blaze/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "@esheet/renderer": "0.x",
+    "@esheet/renderer": "0.0.2-0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tslib": "^2.3.0"

--- a/packages/renderer-standalone/package.json
+++ b/packages/renderer-standalone/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "@esheet/renderer": "0.x",
+    "@esheet/renderer": "0.0.2-0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tslib": "^2.3.0"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -38,8 +38,8 @@
     ]
   },
   "dependencies": {
-    "@esheet/core": "0.x",
-    "@esheet/fields": "0.x",
+    "@esheet/core": "0.0.2-0",
+    "@esheet/fields": "0.0.2-0",
     "js-yaml": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Fixes the Cloudflare build failure where `@esheet/renderer` and `@esheet/builder` imported `ZodIssuesPanel` from `@esheet/fields`, but Rollup resolved `@esheet/fields` to a stale package artifact whose `dist/index.js` did not export that symbol.

Original error:

```text
"ZodIssuesPanel" is not exported by "node_modules/@esheet/fields/dist/index.js", imported by "src/lib/EsheetRenderer.tsx"
```

A similar failure also appeared in `packages/builder/src/lib/components/FeedbackModal.tsx`.

## Root Cause

`ZodIssuesPanel` already exists in source and is exported from the `@esheet/fields` public barrel. The failure came from clean install/package resolution: internal `@esheet/*` dependencies could resolve stale nested registry artifacts instead of the current workspace package build output.

## Fix

Updated internal `@esheet/*` dependency versions to align with the current workspace prerelease version so clean installs resolve the current workspace packages consistently. The lockfiles were refreshed to remove stale nested `@esheet/*` package entries that could shadow workspace links.

## Verification

- `npm install --ignore-scripts`
- `npm ls @esheet/fields --all --depth=6`
- `npm ls @esheet/builder @esheet/renderer @esheet/core --all --depth=6`
- `npx nx run @esheet/fields:build --outputStyle=static`
- `npx nx run @esheet/renderer:build --outputStyle=static`
- `npx nx run @esheet/builder:build --outputStyle=static`
- `npm run build:cf`
- `npx nx format:check`

All passed locally.