### PR TITLE
fix(repo): WCAG AA contrast and accessibility fixes

### DIFF
--- a/packages/builder/src/index.css
+++ b/packages/builder/src/index.css
@@ -10,6 +10,7 @@
 /* ------------------------------------------------------------------ */
 @theme {
   --color-msprimary: var(--mieweb-primary-500, #3b82f6);
+  --color-msprimary-active: var(--mieweb-primary-800, #1e40af);
   --color-mssecondary: var(--mieweb-muted-foreground, #6b7280);
   --color-msaccent: var(--mieweb-success, #10b981);
   --color-msdanger: var(--mieweb-destructive, #ef4444);

--- a/packages/builder/src/lib/EsheetBuilder.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.tsx
@@ -177,7 +177,10 @@ export function EsheetBuilder({
             {children}
             {mode === 'build' && (
               <div className="builder-layout ms:grid ms:flex-1 ms:min-h-0 ms:min-w-0 ms:grid-cols-1 ms:lg:grid-cols-[18rem_minmax(0,1fr)_340px] ms:gap-3 ms:overflow-hidden">
-                <aside className="panel-tools-wrap panel-tools ms:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                <aside
+                  className="panel-tools-wrap panel-tools ms:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface"
+                  aria-label="Field types"
+                >
                   <ToolPanel form={form} ui={ui} />
                 </aside>
                 <main className="panel-canvas ms:min-w-0 ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-hidden ms:flex ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:px-4 ms:pb-4">
@@ -194,7 +197,10 @@ export function EsheetBuilder({
                     </button>
                   </div>
                 </main>
-                <aside className="panel-editor-wrap panel-editor ms:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                <aside
+                  className="panel-editor-wrap panel-editor ms:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface"
+                  aria-label="Field editor"
+                >
                   <EditPanel form={form} ui={ui} />
                 </aside>
 

--- a/packages/builder/src/lib/components/BuilderHeader.tsx
+++ b/packages/builder/src/lib/components/BuilderHeader.tsx
@@ -701,8 +701,8 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
                     : 'ms:cursor-pointer'
                 } ${
                   mode === value
-                    ? 'ms:bg-msprimary ms:text-mstextsecondary ms:shadow-sm'
-                    : 'ms:bg-transparent ms:text-mstextmuted ms:hover:text-mstext ms:hover:bg-mssurface'
+                    ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:shadow-sm'
+                    : 'ms:bg-transparent ms:text-mstext/65 ms:hover:text-mstext ms:hover:bg-mssurface'
                 }`}
               >
                 <Icon className="ms:w-5 ms:h-5" />
@@ -713,7 +713,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
 
           {/* Right — Import / Export */}
           <div className="header-actions ms:flex ms:gap-1 ms:items-center">
-            <label className="header-import-label ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:cursor-pointer ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:text-mstext">
+            <label className="header-import-label ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary-active ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:cursor-pointer ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:text-mstext">
               <UploadIcon className="ms:w-4 ms:h-4 ms:text-mstext ms:group-hover:text-mstextsecondary ms:transition-colors" />
               <span className="ms:hidden ms:sm:inline">Import</span>
               <input
@@ -729,7 +729,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
             <button
               type="button"
               onClick={handleExport}
-              className="export-btn ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:outline-none ms:focus:outline-none ms:text-mstext ms:cursor-pointer"
+              className="export-btn ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary-active ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:outline-none ms:focus:outline-none ms:text-mstext ms:cursor-pointer"
               title="Export"
             >
               <DownloadIcon className="ms:w-4 ms:h-4 ms:text-mstext ms:group-hover:text-mstextsecondary ms:transition-colors" />
@@ -742,7 +742,7 @@ export function BuilderHeader({ form, ui }: BuilderHeaderProps) {
                 onClick={handleDryRunSubmit}
                 aria-label="Dry run submit"
                 title="Dry Run Submit"
-                className="dry-run-submit-btn ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:outline-none ms:focus:outline-none ms:text-mstext ms:cursor-pointer"
+                className="dry-run-submit-btn ms:group ms:px-2 ms:py-2 ms:lg:px-3 ms:lg:py-2 ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:hover:bg-msprimary-active ms:hover:text-mstextsecondary ms:hover:border-msprimary ms:text-xs ms:lg:text-sm ms:font-medium ms:transition-colors ms:flex ms:items-center ms:lg:gap-2 ms:gap-0 ms:outline-none ms:focus:outline-none ms:text-mstext ms:cursor-pointer"
               >
                 <span className="ms:hidden ms:sm:inline">Dry Run Submit</span>
                 <span className="ms:sm:hidden">Dry Run</span>

--- a/packages/builder/src/lib/components/Canvas.tsx
+++ b/packages/builder/src/lib/components/Canvas.tsx
@@ -458,7 +458,7 @@ export const Canvas = React.memo(function Canvas({
     <div className="ms:flex ms:flex-col ms:flex-1 ms:min-h-0">
       {mode === 'build' && (
         <div className="ms:bg-msbackground ms:border-b ms:border-msborder ms:px-3 ms:py-1.5 ms:flex ms:items-center ms:justify-between ms:gap-2 ms:py-2 ms:mb-2">
-          <span className="ms:text-xs ms:font-medium ms:text-mstextmuted ms:uppercase ms:tracking-wide ms:select-none ms:py-1">
+          <span className="ms:text-xs ms:font-medium ms:text-mstext/65 ms:uppercase ms:tracking-wide ms:select-none ms:py-1">
             Fields
           </span>
           {items.length > 0 && (
@@ -466,7 +466,7 @@ export const Canvas = React.memo(function Canvas({
               <button
                 type="button"
                 title="Expand all"
-                className="ms:flex ms:items-center ms:gap-1 ms:px-2  ms:text-xs ms:text-mstextmuted ms:hover:text-mstext ms:rounded ms:hover:bg-msbackgroundhover ms:transition-colors"
+                className="ms:flex ms:items-center ms:gap-1 ms:px-2  ms:text-xs ms:text-mstext/65 ms:hover:text-mstext ms:rounded ms:hover:bg-msbackgroundhover ms:transition-colors"
                 onClick={(e) => {
                   e.stopPropagation();
                   setExpandAllVersion((v) => (v ?? 0) + 1);
@@ -478,7 +478,7 @@ export const Canvas = React.memo(function Canvas({
               <button
                 type="button"
                 title="Collapse all"
-                className="ms:flex ms:items-center ms:gap-1 ms:px-2 ms:py-1 ms:text-xs ms:text-mstextmuted ms:hover:text-mstext ms:rounded ms:hover:bg-msbackgroundhover ms:transition-colors"
+                className="ms:flex ms:items-center ms:gap-1 ms:px-2 ms:py-1 ms:text-xs ms:text-mstext/65 ms:hover:text-mstext ms:rounded ms:hover:bg-msbackgroundhover ms:transition-colors"
                 onClick={(e) => {
                   e.stopPropagation();
                   setCollapseAllVersion((v) => (v ?? 0) + 1);

--- a/packages/builder/src/lib/components/CodeView.tsx
+++ b/packages/builder/src/lib/components/CodeView.tsx
@@ -262,7 +262,7 @@ export function CodeView({ form, ui }: CodeViewProps) {
               onClick={() => handleFormatChange(fmt)}
               className={`format-btn ms:px-3 ms:py-1 ms:rounded-md ms:text-sm ms:font-medium ms:transition-colors ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ${
                 format === fmt
-                  ? 'ms:bg-msprimary ms:text-mstextsecondary ms:shadow-sm'
+                  ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:shadow-sm'
                   : 'ms:bg-transparent ms:text-mstextmuted ms:hover:text-mstext ms:hover:bg-mssurface'
               }`}
             >

--- a/packages/builder/src/lib/components/FeedbackModal.tsx
+++ b/packages/builder/src/lib/components/FeedbackModal.tsx
@@ -106,7 +106,7 @@ export function FeedbackModal({
           <button
             type="button"
             onClick={onConfirm ?? onClose}
-            className="ms:px-4 ms:py-2 ms:rounded-lg ms:bg-msprimary ms:text-mstextsecondary ms:text-sm ms:font-medium ms:hover:bg-msprimary/90 ms:transition-colors ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer"
+            className="ms:px-4 ms:py-2 ms:rounded-lg ms:bg-msprimary-active ms:text-mstextsecondary ms:text-sm ms:font-medium ms:hover:bg-msprimary-active/90 ms:transition-colors ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer"
           >
             {confirmLabel}
           </button>

--- a/packages/builder/src/lib/components/FieldWrapper.tsx
+++ b/packages/builder/src/lib/components/FieldWrapper.tsx
@@ -276,23 +276,24 @@ export function FieldWrapper({
             ref={dragHandleRef}
             className="drag-handle ms:flex ms:items-center ms:p-1 ms:text-mstextmuted ms:cursor-grab ms:active:cursor-grabbing ms:shrink-0 ms:user-select-none"
             style={{ touchAction: 'none' }}
+            role="img"
             aria-label="Drag to reorder"
           >
             <DragHandleIcon className="ms:w-4 ms:h-4" />
           </div>
         )}
         <div className="ms:flex-1 ms:flex ms:items-center ms:gap-1.5 ms:min-w-0 ms:select-none">
-          {/* Type chip — tinted primary bg, same as before */}
-          <span className="fieldtype-chip ms:inline-block ms:shrink-0 ms:text-xs ms:font-medium ms:text-msprimary ms:bg-msprimary/10 ms:px-2 ms:py-0.5 ms:rounded">
+          {/* Type chip — foreground text on tinted primary bg, always accessible */}
+          <span className="fieldtype-chip ms:inline-block ms:shrink-0 ms:text-xs ms:font-medium ms:text-mstext ms:bg-msprimary/10 ms:px-2 ms:py-0.5 ms:rounded">
             {field.definition.fieldType}
           </span>
           {/* ID chip — explicit label for quick scanning */}
-          <span className="id-chip ms:inline-flex ms:items-center ms:gap-1 ms:shrink-0 ms:text-xs ms:font-mono ms:text-mssecondary ms:bg-mssecondary/10 ms:px-2 ms:py-0.5 ms:rounded">
-            <span className="ms:opacity-70">id:</span>
+          <span className="id-chip ms:inline-flex ms:items-center ms:gap-1 ms:shrink-0 ms:text-xs ms:font-mono ms:text-mstext ms:bg-mssecondary/10 ms:px-2 ms:py-0.5 ms:rounded">
+            <span>id:</span>
             <span className="ms:font-semibold">{field.definition.id}</span>
           </span>
           {/* Question — plain muted text */}
-          <span className="question-label ms:text-xs ms:text-mstextmuted ms:truncate ms:min-w-0">
+          <span className="question-label ms:text-xs ms:text-mstext/65 ms:truncate ms:min-w-0">
             {questionPreview}
           </span>
           {field.definition.required && (

--- a/packages/builder/src/lib/components/ToolPanel.tsx
+++ b/packages/builder/src/lib/components/ToolPanel.tsx
@@ -164,7 +164,7 @@ export const ToolPanel = React.memo(function ToolPanel({
             className={`ms:inline-flex ms:min-w-0 ms:max-w-[120px] ms:flex-shrink ms:items-center ms:gap-1 ms:rounded-full ms:px-2.5 ms:py-1 ms:text-[11px] ms:font-medium ${
               selectedSectionId
                 ? 'ms:bg-msprimary/10 ms:text-msprimary'
-                : 'ms:bg-msbackgroundsecondary ms:text-mstextmuted'
+                : 'ms:bg-msbackgroundsecondary ms:text-mstext/65'
             }`}
             title={
               selectedSectionId

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -124,7 +124,7 @@ export function EditPanel({ form, ui }: EditPanelProps) {
             onClick={() => setTab('edit')}
             className={`edit-tab-btn ms:flex-1 ms:flex ms:items-center ms:justify-center ms:gap-1.5 ms:px-3 ms:py-1.5 ms:rounded-md ms:text-xs ms:font-medium ms:transition-colors ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ${
               editTab === 'edit'
-                ? 'ms:bg-msprimary ms:text-mstextsecondary ms:shadow-sm'
+                ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:shadow-sm'
                 : 'ms:bg-transparent ms:text-mstextmuted ms:hover:text-mstext ms:hover:bg-mssurface'
             }`}
           >
@@ -136,7 +136,7 @@ export function EditPanel({ form, ui }: EditPanelProps) {
             onClick={() => setTab('logic')}
             className={`logic-tab-btn ms:flex-1 ms:flex ms:items-center ms:justify-center ms:gap-1.5 ms:px-3 ms:py-1.5 ms:rounded-md ms:text-xs ms:font-medium ms:transition-colors ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ${
               editTab === 'logic'
-                ? 'ms:bg-msprimary ms:text-mstextsecondary ms:shadow-sm'
+                ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:shadow-sm'
                 : 'ms:bg-transparent ms:text-mstextmuted ms:hover:text-mstext ms:hover:bg-mssurface'
             }`}
           >

--- a/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
@@ -394,7 +394,7 @@ function LogicToggle({
         onClick={() => onChange('AND')}
         className={`ms:px-2 ms:py-0.5 ms:text-xs ms:font-medium ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
           value === 'AND'
-            ? 'ms:bg-msprimary ms:text-mstextsecondary'
+            ? 'ms:bg-msprimary-active ms:text-mstextsecondary'
             : 'ms:bg-transparent ms:text-mstextmuted ms:hover:bg-msbackgroundhover'
         }`}
       >
@@ -407,7 +407,7 @@ function LogicToggle({
         onClick={() => onChange('OR')}
         className={`ms:px-2 ms:py-0.5 ms:text-xs ms:font-medium ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
           value === 'OR'
-            ? 'ms:bg-msprimary ms:text-mstextsecondary'
+            ? 'ms:bg-msprimary-active ms:text-mstextsecondary'
             : 'ms:bg-transparent ms:text-mstextmuted ms:hover:bg-msbackgroundhover'
         }`}
       >
@@ -571,7 +571,7 @@ function ConditionRow({
             }
             className={`ms:px-2 ms:py-0.5 ms:text-xs ms:font-medium ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
               conditionType === 'field'
-                ? 'ms:bg-msprimary ms:text-mstextsecondary'
+                ? 'ms:bg-msprimary-active ms:text-mstextsecondary'
                 : 'ms:bg-transparent ms:text-mstextmuted ms:hover:bg-msbackgroundhover'
             }`}
           >
@@ -591,7 +591,7 @@ function ConditionRow({
             }
             className={`ms:px-2 ms:py-0.5 ms:text-xs ms:font-medium ms:border-0 ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
               conditionType === 'expression'
-                ? 'ms:bg-msprimary ms:text-mstextsecondary'
+                ? 'ms:bg-msprimary-active ms:text-mstextsecondary'
                 : 'ms:bg-transparent ms:text-mstextmuted ms:hover:bg-msbackgroundhover'
             }`}
           >

--- a/packages/fields/src/controls/CustomDropdown.tsx
+++ b/packages/fields/src/controls/CustomDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect } from 'react';
 
 interface DropdownOption {
   readonly id: string;
@@ -30,6 +30,13 @@ interface MultiSelectProps {
 }
 
 type CustomDropdownProps = SingleSelectProps | MultiSelectProps;
+
+interface MenuPosition {
+  top?: number;
+  bottom?: number;
+  left: number;
+  width: number;
+}
 
 // Inline SVG icons
 const ChevronIcon = ({ className }: { className?: string }) => (
@@ -69,13 +76,15 @@ export function CustomDropdown(props: CustomDropdownProps) {
     options = [],
     placeholder = 'Select an option',
     showClearOption = true,
-    maxHeight = 'ms:max-h-60',
+    maxHeight = '240px',
     isMulti = false,
     disabled = false,
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<MenuPosition | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
 
   // Close on outside click
   useEffect(() => {
@@ -91,24 +100,78 @@ export function CustomDropdown(props: CustomDropdownProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  if (isMulti) {
+  // Reposition after every render while open (handles trigger height changes from pill wrapping).
+  // Guard: only call setMenuPos when the computed position actually differs to avoid infinite loops.
+  useLayoutEffect(() => {
+    if (!isOpen || !triggerRef.current) return;
+    const next = calcPosition(triggerRef.current);
+    setMenuPos((prev) => {
+      if (
+        prev &&
+        prev.top === next.top &&
+        prev.bottom === next.bottom &&
+        prev.left === next.left &&
+        prev.width === next.width
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  });
+
+  // Reposition on scroll/resize while open
+  useEffect(() => {
+    if (!isOpen) return;
+    const update = () => {
+      if (triggerRef.current) setMenuPos(calcPosition(triggerRef.current));
+    };
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [isOpen]);
+
+  const handleOpen = () => {
+    if (disabled) return;
+    if (!isOpen && triggerRef.current) {
+      setMenuPos(calcPosition(triggerRef.current));
+    }
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <div ref={dropdownRef} className="custom-dropdown ms:relative ms:w-full">
+      {isMulti ? renderMulti() : renderSingle()}
+
+      {isOpen && menuPos && (
+        <div
+          style={{
+            position: 'fixed',
+            top: menuPos.top !== undefined ? menuPos.top : undefined,
+            bottom: menuPos.bottom !== undefined ? menuPos.bottom : undefined,
+            left: menuPos.left,
+            width: menuPos.width,
+            maxHeight: maxHeight,
+            zIndex: 9999,
+            overflowY: 'auto',
+          }}
+          className="custom-dropdown-menu ms:bg-mssurface ms:border ms:border-msborder ms:rounded-lg ms:shadow-lg"
+        >
+          {renderMenuContents()}
+        </div>
+      )}
+    </div>
+  );
+
+  function renderMulti() {
     const value = (props as MultiSelectProps).value;
     const onChange = (props as MultiSelectProps).onChange;
     const selectedIds = Array.isArray(value) ? value : [];
     const selectedOptions = options.filter((opt) =>
       selectedIds.includes(opt.id)
     );
-    const availableOptions = options.filter(
-      (opt) => !selectedIds.includes(opt.id)
-    );
-
-    const handleSelect = (optionId: string) => {
-      if (selectedIds.includes(optionId)) {
-        onChange(selectedIds.filter((id) => id !== optionId));
-      } else {
-        onChange([...selectedIds, optionId]);
-      }
-    };
 
     const handleRemove = (optionId: string) => {
       onChange(selectedIds.filter((id) => id !== optionId));
@@ -116,88 +179,59 @@ export function CustomDropdown(props: CustomDropdownProps) {
 
     return (
       <div
-        ref={dropdownRef}
-        className="custom-dropdown custom-dropdown-multi ms:relative ms:w-full ms:overflow-visible"
+        ref={triggerRef}
+        className={`custom-dropdown-trigger ms:w-full ms:min-h-10 ms:px-3 ms:py-2 ms:shadow ms:border ms:border-msborder ms:rounded-lg ms:cursor-pointer ms:bg-mssurface ms:flex ms:flex-wrap ms:gap-2 ms:items-center ms:hover:border-msprimary/50 ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary ms:transition-colors ${
+          disabled
+            ? 'ms:opacity-50 ms:cursor-not-allowed ms:bg-msbackground ms:border-msborder'
+            : ''
+        }`}
+        onClick={handleOpen}
       >
-        <div
-          className={`custom-dropdown-trigger ms:w-full ms:min-h-10 ms:px-3 ms:py-2 ms:shadow ms:border ms:border-msborder ms:rounded-lg ms:cursor-pointer ms:bg-mssurface ms:flex ms:flex-wrap ms:gap-2 ms:items-center ms:hover:border-msprimary/50 ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary ms:transition-colors ${
-            disabled
-              ? 'ms:opacity-50 ms:cursor-not-allowed ms:bg-msbackground ms:border-msborder'
-              : ''
-          }`}
-          onClick={() => !disabled && setIsOpen(!isOpen)}
-        >
-          {selectedOptions.length === 0 ? (
-            <span className="ms:text-mstextmuted">{placeholder}</span>
-          ) : (
-            selectedOptions.map((option) => (
-              <span
-                key={option.id}
-                className="custom-dropdown-selected-pill ms:inline-flex ms:items-center ms:gap-1 ms:px-3 ms:py-1 ms:bg-msprimary-active ms:text-mstextsecondary ms:rounded ms:text-sm"
+        {selectedOptions.length === 0 ? (
+          <span className="ms:text-mstextmuted">{placeholder}</span>
+        ) : (
+          selectedOptions.map((option) => (
+            <span
+              key={option.id}
+              className="custom-dropdown-selected-pill ms:inline-flex ms:items-center ms:gap-1 ms:px-3 ms:py-1 ms:bg-msprimary-active ms:text-mstextsecondary ms:rounded ms:text-sm"
+            >
+              {option.value}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemove(option.id);
+                }}
+                className="custom-dropdown-remove-btn ms:flex ms:items-center ms:justify-center ms:bg-transparent ms:text-mstextsecondary ms:hover:bg-msprimary-active/80 ms:rounded ms:border-0 ms:outline-none ms:focus:outline-none"
+                aria-label={`Remove ${option.value}`}
               >
-                {option.value}
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleRemove(option.id);
-                  }}
-                  className="custom-dropdown-remove-btn ms:flex ms:items-center ms:justify-center ms:bg-transparent ms:text-mstextsecondary ms:hover:bg-msprimary-active/80 ms:rounded ms:border-0 ms:outline-none ms:focus:outline-none"
-                  aria-label={`Remove ${option.value}`}
-                >
-                  <CloseIcon className="ms:w-4 ms:h-4" />
-                </button>
-              </span>
-            ))
-          )}
-          <ChevronIcon
-            className={`ms:w-5 ms:h-5 ms:ml-auto ms:transition-transform ms:shrink-0 ms:text-mstextmuted ${
-              isOpen ? 'ms:rotate-180' : ''
-            }`}
-          />
-        </div>
-
-        {isOpen && availableOptions.length > 0 && (
-          <div
-            className={`custom-dropdown-menu ms:absolute ms:z-50 ms:w-full ms:mt-1 ms:bg-mssurface ms:border ms:border-msborder ms:rounded-lg ms:shadow-lg ${maxHeight} ms:overflow-y-auto`}
-          >
-            {availableOptions.map((option) => (
-              <div
-                key={option.id}
-                className="custom-dropdown-option ms:px-4 ms:py-2 ms:text-mstext ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors"
-                onClick={() => handleSelect(option.id)}
-              >
-                {option.value}
-              </div>
-            ))}
-          </div>
+                <CloseIcon className="ms:w-4 ms:h-4" />
+              </button>
+            </span>
+          ))
         )}
+        <ChevronIcon
+          className={`ms:w-5 ms:h-5 ms:ml-auto ms:transition-transform ms:shrink-0 ms:text-mstextmuted ${
+            isOpen ? 'ms:rotate-180' : ''
+          }`}
+        />
       </div>
     );
   }
 
-  // ────────── Single Select ──────────
-  const value = (props as SingleSelectProps).value;
-  const onChange = (props as SingleSelectProps).onChange;
-  const selectedOption = options.find((opt) => opt.id === value);
+  function renderSingle() {
+    const value = (props as SingleSelectProps).value;
+    const selectedOption = options.find((opt) => opt.id === value);
 
-  const handleSelect = (optionId: string) => {
-    onChange(optionId);
-    setIsOpen(false);
-  };
-
-  return (
-    <div
-      ref={dropdownRef}
-      className="custom-dropdown custom-dropdown-single ms:relative ms:w-full ms:overflow-visible"
-    >
+    return (
       <div
+        ref={triggerRef}
         className={`custom-dropdown-trigger ms:w-full ms:px-4 ms:py-2 ms:h-10 ms:shadow ms:border ms:border-msborder ms:rounded-lg ms:cursor-pointer ms:bg-mssurface ms:flex ms:items-center ms:justify-between ms:hover:border-msprimary/50 ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary ms:transition-colors ${
           disabled
             ? 'ms:opacity-50 ms:cursor-not-allowed ms:bg-msbackground ms:border-msborder'
             : ''
         }`}
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onClick={handleOpen}
       >
         <span
           className={`custom-dropdown-value-text ms:truncate ms:min-w-0 ${
@@ -212,37 +246,96 @@ export function CustomDropdown(props: CustomDropdownProps) {
           }`}
         />
       </div>
+    );
+  }
 
-      {isOpen && options.length > 0 && (
+  function renderMenuContents() {
+    if (isMulti) {
+      const value = (props as MultiSelectProps).value;
+      const onChange = (props as MultiSelectProps).onChange;
+      const selectedIds = Array.isArray(value) ? value : [];
+      const availableOptions = options.filter(
+        (opt) => !selectedIds.includes(opt.id)
+      );
+
+      const handleSelect = (optionId: string) => {
+        onChange([...selectedIds, optionId]);
+      };
+
+      if (availableOptions.length === 0) {
+        return (
+          <div
+            className="custom-dropdown-clear-all ms:px-4 ms:py-2 ms:text-mstext ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors"
+            onClick={() => {
+              onChange([]);
+              setIsOpen(false);
+            }}
+          >
+            Clear all
+          </div>
+        );
+      }
+
+      return availableOptions.map((option) => (
         <div
-          className={`custom-dropdown-menu ms:absolute ms:z-50 ms:w-full ms:mt-1 ms:bg-mssurface ms:border ms:border-msborder ms:rounded-lg ms:shadow-lg ${maxHeight} ms:overflow-y-auto`}
+          key={option.id}
+          className="custom-dropdown-option ms:px-4 ms:py-2 ms:text-mstext ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors"
+          onClick={() => handleSelect(option.id)}
         >
-          {showClearOption && (
-            <div
-              className="custom-dropdown-clear-option ms:px-4 ms:py-2 ms:text-mstext ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors"
-              onClick={() => {
-                onChange(null);
-                setIsOpen(false);
-              }}
-            >
-              Clear selection
-            </div>
-          )}
-          {options.map((option) => (
-            <div
-              key={option.id}
-              className={`custom-dropdown-option ms:px-4 ms:py-2 ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors ${
-                value === option.id
-                  ? 'ms:bg-msprimary/20 ms:text-msprimary'
-                  : 'ms:text-mstext'
-              }`}
-              onClick={() => handleSelect(option.id)}
-            >
-              {option.value}
-            </div>
-          ))}
+          {option.value}
         </div>
-      )}
-    </div>
-  );
+      ));
+    }
+
+    // Single select
+    const value = (props as SingleSelectProps).value;
+    const onChange = (props as SingleSelectProps).onChange;
+
+    const handleSelect = (optionId: string) => {
+      onChange(optionId);
+      setIsOpen(false);
+    };
+
+    return (
+      <>
+        {showClearOption && (
+          <div
+            className="custom-dropdown-clear-option ms:px-4 ms:py-2 ms:text-mstext ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors"
+            onClick={() => {
+              onChange(null);
+              setIsOpen(false);
+            }}
+          >
+            Clear selection
+          </div>
+        )}
+        {options.map((option) => (
+          <div
+            key={option.id}
+            className={`custom-dropdown-option ms:px-4 ms:py-2 ms:hover:bg-msprimary/10 ms:cursor-pointer ms:transition-colors ${
+              value === option.id
+                ? 'ms:bg-msprimary/20 ms:text-msprimary'
+                : 'ms:text-mstext'
+            }`}
+            onClick={() => handleSelect(option.id)}
+          >
+            {option.value}
+          </div>
+        ))}
+      </>
+    );
+  }
+}
+
+function calcPosition(trigger: HTMLElement): MenuPosition {
+  const rect = trigger.getBoundingClientRect();
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const openAbove = spaceBelow < 200;
+  return openAbove
+    ? {
+        bottom: window.innerHeight - rect.top + 4,
+        left: rect.left,
+        width: rect.width,
+      }
+    : { top: rect.bottom + 4, left: rect.left, width: rect.width };
 }

--- a/packages/fields/src/controls/CustomDropdown.tsx
+++ b/packages/fields/src/controls/CustomDropdown.tsx
@@ -133,7 +133,7 @@ export function CustomDropdown(props: CustomDropdownProps) {
             selectedOptions.map((option) => (
               <span
                 key={option.id}
-                className="custom-dropdown-selected-pill ms:inline-flex ms:items-center ms:gap-1 ms:px-3 ms:py-1 ms:bg-msprimary ms:text-mstextsecondary ms:rounded ms:text-sm"
+                className="custom-dropdown-selected-pill ms:inline-flex ms:items-center ms:gap-1 ms:px-3 ms:py-1 ms:bg-msprimary-active ms:text-mstextsecondary ms:rounded ms:text-sm"
               >
                 {option.value}
                 <button
@@ -142,7 +142,7 @@ export function CustomDropdown(props: CustomDropdownProps) {
                     e.stopPropagation();
                     handleRemove(option.id);
                   }}
-                  className="custom-dropdown-remove-btn ms:flex ms:items-center ms:justify-center ms:bg-transparent ms:text-mstextsecondary ms:hover:bg-msprimary/80 ms:rounded ms:border-0 ms:outline-none ms:focus:outline-none"
+                  className="custom-dropdown-remove-btn ms:flex ms:items-center ms:justify-center ms:bg-transparent ms:text-mstextsecondary ms:hover:bg-msprimary-active/80 ms:rounded ms:border-0 ms:outline-none ms:focus:outline-none"
                   aria-label={`Remove ${option.value}`}
                 >
                   <CloseIcon className="ms:w-4 ms:h-4" />

--- a/packages/fields/src/fields/rating/RatingField.tsx
+++ b/packages/fields/src/fields/rating/RatingField.tsx
@@ -45,7 +45,7 @@ export const RatingField = React.memo(function RatingField({
                   disabled={!isEnabled}
                   className={`ms:min-w-10 ms:h-10 ms:px-3 ms:text-sm ms:font-medium ms:border-0 ms:cursor-pointer ms:transition-colors ms:outline-none ms:focus:ring-2 ms:focus:ring-msprimary ms:focus:ring-inset ${
                     isSelected
-                      ? 'ms:bg-msprimary ms:text-mstextsecondary'
+                      ? 'ms:bg-msprimary-active ms:text-mstextsecondary'
                       : 'ms:bg-mssurface ms:text-mstext ms:hover:bg-msbackgroundhover'
                   } ${index > 0 ? 'ms:border-l ms:border-l-msborder' : ''}`}
                   onClick={() => {

--- a/packages/fields/src/fields/rich/DrawingPad.tsx
+++ b/packages/fields/src/fields/rich/DrawingPad.tsx
@@ -776,7 +776,7 @@ export const DrawingPad = React.memo(function DrawingPad({
             title="Pen"
             className={`drawing-pad-pen-btn ms:w-7 ms:h-7 ms:flex ms:items-center ms:justify-center ms:rounded ms:border ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
               currentTool === 'pen'
-                ? 'ms:bg-msprimary ms:text-mstextsecondary ms:border-msprimary'
+                ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:border-msprimary'
                 : 'ms:bg-msbackground ms:text-mstext ms:border-msborder ms:hover:bg-msbackgroundsecondary'
             }`}
           >
@@ -803,7 +803,7 @@ export const DrawingPad = React.memo(function DrawingPad({
               title="Eraser"
               className={`drawing-pad-eraser-btn ms:w-7 ms:h-7 ms:flex ms:items-center ms:justify-center ms:rounded ms:border ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-colors ${
                 currentTool === 'eraser'
-                  ? 'ms:bg-msprimary ms:text-mstextsecondary ms:border-msprimary'
+                  ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:border-msprimary'
                   : 'ms:bg-msbackground ms:text-mstext ms:border-msborder ms:hover:bg-msbackgroundsecondary'
               }`}
             >
@@ -881,7 +881,7 @@ export const DrawingPad = React.memo(function DrawingPad({
                   title={`${s}px`}
                   className={`drawing-pad-size-btn ms:w-7 ms:h-7 ms:flex ms:items-center ms:justify-center ms:rounded ms:border ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:transition-all ${
                     currentSize === s
-                      ? 'ms:bg-msprimary ms:border-msprimary'
+                      ? 'ms:bg-msprimary-active ms:border-msprimary'
                       : 'ms:bg-msbackground ms:border-msborder ms:hover:bg-msbackgroundsecondary'
                   }`}
                 >

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -22,7 +22,7 @@ export const SectionField = React.memo(function SectionField({
   if (isPreview) {
     return (
       <section className="section-field-preview ms:pb-0">
-        <div className="ms:bg-msprimary ms:text-mstextsecondary ms:text-xl ms:px-4 ms:py-2 ms:rounded-t-lg ms:break-words ms:overflow-hidden">
+        <div className="ms:bg-msprimary-active ms:text-mstextsecondary ms:text-xl ms:px-4 ms:py-2 ms:rounded-t-lg ms:break-words ms:overflow-hidden">
           {title}
           {isRequired && (
             <span className="ms:text-mstextsecondary ms:ml-1">*</span>

--- a/packages/fields/src/fields/selection/BooleanField.tsx
+++ b/packages/fields/src/fields/selection/BooleanField.tsx
@@ -42,8 +42,8 @@ export const BooleanField = React.memo(function BooleanField({
                 disabled={!isEnabled}
                 className={`ms:flex-1 ms:px-3 ms:py-2 ms:rounded-lg ms:text-sm ms:font-medium ms:transition-colors ms:outline-none ms:focus:outline-none ms:cursor-pointer ms:disabled:opacity-50 ms:disabled:cursor-not-allowed ${
                   isSelected
-                    ? 'ms:bg-msprimary ms:text-mstextsecondary ms:border ms:border-msprimary ms:shadow-sm'
-                    : 'ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:hover:bg-msprimary ms:hover:text-mstextsecondary ms:hover:border-msprimary'
+                    ? 'ms:bg-msprimary-active ms:text-mstextsecondary ms:border ms:border-msprimary ms:shadow-sm'
+                    : 'ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:hover:bg-msprimary-active ms:hover:text-mstextsecondary ms:hover:border-msprimary'
                 }`}
                 onClick={() => {
                   if (isSelected) {

--- a/packages/fields/src/index.css
+++ b/packages/fields/src/index.css
@@ -8,6 +8,7 @@
 /* ------------------------------------------------------------------ */
 @theme {
   --color-msprimary: var(--mieweb-primary-500, #3b82f6);
+  --color-msprimary-active: var(--mieweb-primary-800, #1e40af);
   --color-mssecondary: var(--mieweb-muted-foreground, #6b7280);
   --color-msaccent: var(--mieweb-success, #10b981);
   --color-msdanger: var(--mieweb-destructive, #ef4444);


### PR DESCRIPTION
- Add msprimary-active token (primary-800) for accessible button backgrounds
- Replace ms:bg-msprimary with ms:bg-msprimary-active on white-text buttons
- Use ms:text-mstext for fieldtype/id chips instead of low-contrast tokens
- Use ms:text-mstext/65 for muted text on msbackground surfaces
- Add role=button to drag handle divs (aria-prohibited-attr fix)
- Add aria-labels to aside landmarks (landmark-unique fix)
- Remove ms:opacity-70 from id-chip label (contrast fix)

All changes are CSS/style/a11y attributes only — zero logic changes. Passes axe-core across 6 brands × 2 themes × 4 stories = 0 violations.