### PR TITLE
feat(docs): add Ozwell setup flow and generated docs search index

### DIFF
--- a/apps/demo/src/ozwell-setup.ts
+++ b/apps/demo/src/ozwell-setup.ts
@@ -15,13 +15,38 @@ declare global {
 }
 
 const STORAGE_KEY = 'ozwell_api_key';
-const storedKey = localStorage.getItem(STORAGE_KEY) ?? '';
+const storedKey = sessionStorage.getItem(STORAGE_KEY) ?? '';
+window.OzwellChatConfig = {};
 
 function injectSetupCard(): void {
+  // Floating bubble — sits in the same bottom-right spot Schemie would occupy.
+  // Clicking it toggles the setup card.
+  const bubble = document.createElement('button');
+  bubble.id = 'ozwell-setup-bubble';
+  bubble.title = 'Enable AI assistant';
+  bubble.style.cssText =
+    'position:fixed;bottom:20px;right:20px;z-index:9999;width:56px;height:56px;border-radius:50%;' +
+    'background:#2563eb;color:white;border:none;cursor:pointer;box-shadow:0 4px 14px rgba(37,99,235,.5);' +
+    'display:flex;align-items:center;justify-content:center;';
+  bubble.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>" +
+    "<path stroke='none' d='M0 0h24v24H0z' fill='none'/>" +
+    "<path d='M3 3l18 18'/>" +
+    "<path d='M11 11a1 1 0 0 1 -1 -1m0 -3.968v-2.032a1 1 0 0 1 1 -1h9a1 1 0 0 1 1 1v10l-3 -3h-3'/>" +
+    "<path d='M14 15v2a1 1 0 0 1 -1 1h-7l-3 3v-10a1 1 0 0 1 1 -1h2'/>" +
+    '</svg>';
+
+  // Setup card — hidden until bubble is clicked.
   const card = document.createElement('div');
   card.id = 'ozwell-setup-card';
   card.style.cssText =
-    'position:fixed;bottom:20px;right:20px;z-index:9998;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:16px;box-shadow:0 4px 16px rgba(0,0,0,.15);width:280px;font-family:system-ui,sans-serif;font-size:14px;';
+    'display:none;position:fixed;bottom:88px;right:20px;z-index:9998;background:#fff;' +
+    'border:1px solid #e5e7eb;border-radius:12px;padding:16px;box-shadow:0 4px 16px rgba(0,0,0,.15);' +
+    'width:280px;font-family:system-ui,sans-serif;font-size:14px;';
+
+  bubble.onclick = () => {
+    card.style.display = card.style.display === 'none' ? 'block' : 'none';
+  };
 
   const title = document.createElement('p');
   title.style.cssText = 'margin:0 0 6px;color:#111827;font-weight:600;';
@@ -39,36 +64,69 @@ function injectSetupCard(): void {
   input.style.cssText =
     'width:100%;box-sizing:border-box;border:1px solid #d1d5db;border-radius:6px;padding:6px 10px;font-size:13px;margin-bottom:8px;outline:none;font-family:inherit;';
 
+  const errorMsg = document.createElement('p');
+  errorMsg.style.cssText =
+    'margin:0 0 8px;color:#ef4444;font-size:12px;display:none;';
+
   const btn = document.createElement('button');
   btn.textContent = 'Enable AI assistant';
   btn.style.cssText =
     'background:#2563eb;color:#fff;border:none;border-radius:6px;padding:7px 14px;font-size:13px;cursor:pointer;width:100%;font-family:inherit;';
   btn.onclick = () => {
     const key = input.value.trim();
+    errorMsg.style.display = 'none';
+    input.style.borderColor = '#d1d5db';
+
     if (!key.startsWith('ozw_')) {
       input.style.borderColor = '#ef4444';
+      errorMsg.textContent = 'Key must start with ozw_';
+      errorMsg.style.display = 'block';
       return;
     }
-    localStorage.setItem(STORAGE_KEY, key);
-    window.location.reload();
+
+    btn.disabled = true;
+    btn.textContent = 'Validating…';
+
+    fetch('https://ozwellapi.os.mieweb.org/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 1,
+      }),
+    })
+      .then((res) => {
+        if (res.status === 401 || res.status === 403) {
+          throw new Error('invalid');
+        }
+        sessionStorage.setItem(STORAGE_KEY, key);
+        window.location.reload();
+      })
+      .catch((err: unknown) => {
+        btn.disabled = false;
+        btn.textContent = 'Enable AI assistant';
+        input.style.borderColor = '#ef4444';
+        errorMsg.textContent =
+          err instanceof Error && err.message === 'invalid'
+            ? 'Invalid API key — not authorized.'
+            : 'Could not reach Ozwell server. Check your connection.';
+        errorMsg.style.display = 'block';
+      });
   };
 
   card.appendChild(title);
   card.appendChild(desc);
   card.appendChild(input);
+  card.appendChild(errorMsg);
   card.appendChild(btn);
+  document.body.appendChild(bubble);
   document.body.appendChild(card);
 }
 
-if (storedKey) {
-  window.OzwellChatConfig = {
-    apiKey: storedKey,
-    title: 'Schemie',
-    welcomeMessage:
-      'Hi! Ask me to create, update, or remove fields — or describe a whole form and I will build it.',
-    debug: true,
-  };
-
+function injectWidget(): void {
   // Inject CDN widget — reads OzwellChatConfig set above.
   const script = document.createElement('script');
   script.src = 'https://ozwellapi.os.mieweb.org/embed/ozwell-loader.js';
@@ -78,10 +136,45 @@ if (storedKey) {
   const style = document.createElement('style');
   style.textContent =
     '.ozwell-chat-icon{display:none!important;}' +
-    ".ozwell-chat-button::after{content:'';display:block;width:32px;height:32px;background:url(\"data:image/svg+xml,%3Csvg width='512' height='512' viewBox='0 0 128 128' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='20' y='16' width='88' height='96' rx='14' stroke='white' stroke-width='8'/%3E%3Crect x='34' y='34' width='56' height='12' rx='6' fill='white'/%3E%3Crect x='34' y='58' width='40' height='12' rx='6' fill='white'/%3E%3Crect x='34' y='82' width='56' height='12' rx='6' fill='white'/%3E%3C/svg%3E\") center/contain no-repeat}";
+    ".ozwell-chat-button::after{content:'';display:block;width:24px;height:24px;background:url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M21 14l-3 -3h-7a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1h9a1 1 0 0 1 1 1v10'/%3E%3Cpath d='M14 15v2a1 1 0 0 1 -1 1h-7l-3 3v-10a1 1 0 0 1 1 -1h2'/%3E%3C/svg%3E\") center/contain no-repeat}";
   document.head.appendChild(style);
+}
+
+if (storedKey) {
+  // Validate the stored key before showing the widget — prevents a stale/revoked
+  // key from loading a broken widget. Widget is only injected after server confirms.
+  fetch('https://ozwellapi.os.mieweb.org/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${storedKey}`,
+    },
+    body: JSON.stringify({
+      messages: [{ role: 'user', content: 'hi' }],
+      max_tokens: 1,
+    }),
+  })
+    .then((res) => {
+      if (res.status === 401 || res.status === 403) {
+        throw new Error('invalid');
+      }
+      window.OzwellChatConfig = {
+        ...window.OzwellChatConfig,
+        apiKey: storedKey,
+        title: 'Schemie',
+        welcomeMessage:
+          'Hi! Ask me to create, update, or remove fields — or describe a whole form and I will build it.',
+        debug: true,
+      };
+      injectWidget();
+    })
+    .catch(() => {
+      // Key is invalid or server unreachable — clear it and show setup bubble.
+      sessionStorage.removeItem(STORAGE_KEY);
+      injectSetupCard();
+    });
 } else {
-  // No key stored — show setup card, skip loading the widget entirely.
+  // No key stored — show setup bubble, skip loading the widget entirely.
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', injectSetupCard);
   } else {
@@ -91,7 +184,7 @@ if (storedKey) {
 
 // Call ozwellResetKey() in the browser console to clear the stored key.
 (window as unknown as Record<string, unknown>).ozwellResetKey = () => {
-  localStorage.removeItem(STORAGE_KEY);
+  sessionStorage.removeItem(STORAGE_KEY);
   window.location.reload();
 };
 

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -70,7 +70,7 @@ const config = {
             },
           },
         ],
-      })};_c.apiKey=localStorage.getItem('ozwell_api_key')||'';window.OzwellChatConfig=_c;})();`,
+      })};_c.apiKey=sessionStorage.getItem('ozwell_api_key')||'';window.OzwellChatConfig=_c;})();`,
       attributes: {},
     },
   ],

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -2,18 +2,31 @@
   "name": "app-docs",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "generate-doc-content": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node apps/docs/scripts/generate-doc-content.mjs"
+      },
+      "outputs": ["{projectRoot}/static/doc-content.json"]
+    },
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx nx run app-docs:serve"
-      }
+        "commands": [
+          "node apps/docs/scripts/generate-doc-content.mjs --watch",
+          "npx nx run app-docs:serve"
+        ],
+        "parallel": true
+      },
+      "dependsOn": ["generate-doc-content"]
     },
     "serve": {
       "executor": "nx:run-commands",
       "options": {
         "command": "npx docusaurus start --host 0.0.0.0 --port 3000 --no-open",
         "cwd": "apps/docs"
-      }
+      },
+      "dependsOn": ["generate-doc-content"]
     },
     "build": {
       "executor": "nx:run-commands",
@@ -21,6 +34,7 @@
         "command": "npx docusaurus build",
         "cwd": "apps/docs"
       },
+      "dependsOn": ["generate-doc-content"],
       "outputs": ["{projectRoot}/build"]
     },
     "preview": {

--- a/apps/docs/scripts/generate-doc-content.mjs
+++ b/apps/docs/scripts/generate-doc-content.mjs
@@ -1,0 +1,95 @@
+/**
+ * Generates apps/docs/static/doc-content.json — a flat map of
+ * { "<url-path>": "<plain-text content>" } used by the Ozwell search_docs tool.
+ *
+ * Run manually:  node apps/docs/scripts/generate-doc-content.mjs
+ * Or via nx:     nx run app-docs:generate-doc-content
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, extname, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const docsRoot = join(__dirname, '..', 'docs');
+const outFile = join(__dirname, '..', 'static', 'doc-content.json');
+
+function walk(dir) {
+  const entries = readdirSync(dir);
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...walk(full));
+    } else if (['.md', '.mdx'].includes(extname(entry))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function fileToUrlPath(absPath) {
+  // e.g. docs/getting-started/installation.md → /docs/getting-started/installation
+  const rel = relative(docsRoot, absPath).replace(/\\/g, '/');
+  const withoutExt = rel.replace(/\.(md|mdx)$/, '');
+  // intro.md is the root /docs page in Docusaurus
+  if (basename(withoutExt) === 'intro') {
+    const dir = withoutExt.replace(/\/intro$/, '');
+    return '/docs' + (dir ? '/' + dir : '');
+  }
+  return '/docs/' + withoutExt;
+}
+
+function stripFrontmatter(content) {
+  return content.replace(/^---[\s\S]*?---\n?/, '');
+}
+
+function stripMarkdown(content) {
+  return (
+    content
+      // Remove MDX/JSX tags
+      .replace(/<[^>]+>/g, ' ')
+      // Remove code fences
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/`[^`]+`/g, ' ')
+      // Remove links, images
+      .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Remove headings markers
+      .replace(/^#{1,6}\s+/gm, '')
+      // Remove bold/italic
+      .replace(/(\*{1,2}|_{1,2})([^*_]+)\1/g, '$2')
+      // Collapse whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+function generate() {
+  const files = walk(docsRoot);
+  const content = {};
+  for (const file of files) {
+    const raw = readFileSync(file, 'utf8');
+    const text = stripMarkdown(stripFrontmatter(raw));
+    const urlPath = fileToUrlPath(file);
+    content[urlPath] = text;
+  }
+  writeFileSync(outFile, JSON.stringify(content, null, 2), 'utf8');
+  console.log(
+    `[generate-doc-content] Wrote ${Object.keys(content).length} pages to ${outFile}`,
+  );
+}
+
+generate();
+
+if (process.argv.includes('--watch')) {
+  const { watch } = await import('fs');
+  console.log(`[generate-doc-content] Watching ${docsRoot} for changes…`);
+  let debounce = null;
+  watch(docsRoot, { recursive: true }, (_, filename) => {
+    if (!filename || !['.md', '.mdx'].some((ext) => filename.endsWith(ext))) return;
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      console.log(`[generate-doc-content] ${filename} changed — regenerating…`);
+      generate();
+    }, 300);
+  });
+}

--- a/apps/docs/scripts/generate-doc-content.mjs
+++ b/apps/docs/scripts/generate-doc-content.mjs
@@ -74,7 +74,9 @@ function generate() {
   }
   writeFileSync(outFile, JSON.stringify(content, null, 2), 'utf8');
   console.log(
-    `[generate-doc-content] Wrote ${Object.keys(content).length} pages to ${outFile}`,
+    `[generate-doc-content] Wrote ${
+      Object.keys(content).length
+    } pages to ${outFile}`
   );
 }
 
@@ -85,7 +87,8 @@ if (process.argv.includes('--watch')) {
   console.log(`[generate-doc-content] Watching ${docsRoot} for changes…`);
   let debounce = null;
   watch(docsRoot, { recursive: true }, (_, filename) => {
-    if (!filename || !['.md', '.mdx'].some((ext) => filename.endsWith(ext))) return;
+    if (!filename || !['.md', '.mdx'].some((ext) => filename.endsWith(ext)))
+      return;
     clearTimeout(debounce);
     debounce = setTimeout(() => {
       console.log(`[generate-doc-content] ${filename} changed — regenerating…`);

--- a/apps/docs/static/js/ozwell-tools.js
+++ b/apps/docs/static/js/ozwell-tools.js
@@ -15,7 +15,7 @@
       '.ozwell-chat-header{background:var(--ifm-color-primary,#2563eb)!important;}' +
       /* Replace the broken /favicon.ico img with the eSheet SVG logo */
       '.ozwell-chat-icon{display:none!important;}' +
-      ".ozwell-chat-button::after{content:'';display:block;width:32px;height:32px;background:url(\"data:image/svg+xml,%3Csvg width='512' height='512' viewBox='0 0 128 128' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='20' y='16' width='88' height='96' rx='14' stroke='white' stroke-width='8'/%3E%3Crect x='34' y='34' width='56' height='12' rx='6' fill='white'/%3E%3Crect x='34' y='58' width='40' height='12' rx='6' fill='white'/%3E%3Crect x='34' y='82' width='56' height='12' rx='6' fill='white'/%3E%3C/svg%3E\") center/contain no-repeat}";
+      ".ozwell-chat-button::after{content:'';display:block;width:24px;height:24px;background:url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M21 14l-3 -3h-7a1 1 0 0 1 -1 -1v-6a1 1 0 0 1 1 -1h9a1 1 0 0 1 1 1v10'/%3E%3Cpath d='M14 15v2a1 1 0 0 1 -1 1h-7l-3 3v-10a1 1 0 0 1 1 -1h2'/%3E%3C/svg%3E\") center/contain no-repeat}";
     document.head.appendChild(style);
 
     // Inject brand colors into the widget iframe (Send button, user messages, input focus).
@@ -100,43 +100,56 @@
     const pathLower = path.toLowerCase();
     const contentLower = (content || '').toLowerCase();
     let score = 0;
-    for (let i = 0; i < queryWords.length; i++) {
-      const word = queryWords[i];
+    for (var i = 0; i < queryWords.length; i++) {
+      var word = queryWords[i];
       if (pathLower.indexOf(word) !== -1) score += 3; // path match is a strong signal
-      if (contentLower.indexOf(word) !== -1) score += 1;
+      // Count all occurrences in content (frequency beats presence)
+      var pos = 0;
+      while ((pos = contentLower.indexOf(word, pos)) !== -1) {
+        score += 1;
+        pos += word.length;
+      }
     }
+    // Boost intro/overview pages for general queries
+    if (/\/(intro|overview|index|readme)/.test(pathLower) || path === '/docs') score += 5;
     return score;
   }
 
-  // Find the best matching page and return its content in one shot
+  // Find the top matching pages and return their content
   function searchDocs(query) {
     return getDocContent().then(function (content) {
-      const queryWords = query
+      var queryWords = query
         .toLowerCase()
         .replace(/[^a-z0-9\s]/g, ' ')
         .split(/\s+/)
         .filter(Boolean);
-      const pages = Object.keys(content);
-      let bestPath = null;
-      let bestScore = -1;
-      for (let i = 0; i < pages.length; i++) {
-        const s = scorePage(pages[i], content[pages[i]], queryWords);
-        if (s > bestScore) {
-          bestScore = s;
-          bestPath = pages[i];
-        }
-      }
-      if (!bestPath || bestScore === 0) {
+      var pages = Object.keys(content);
+      var scored = pages
+        .map(function (p) {
+          return { path: p, score: scorePage(p, content[p], queryWords) };
+        })
+        .filter(function (p) {
+          return p.score > 0;
+        })
+        .sort(function (a, b) {
+          return b.score - a.score;
+        });
+      if (scored.length === 0) {
         return {
           success: false,
           error: 'No matching page found for: ' + query,
           available_pages: pages,
         };
       }
+      var top = scored.slice(0, 3);
       return {
         success: true,
-        path: bestPath,
-        content: content[bestPath].slice(0, 8000),
+        pages: top.map(function (p) {
+          return {
+            path: p.path,
+            content: content[p.path].slice(0, 4000),
+          };
+        }),
       };
     });
   }
@@ -187,20 +200,55 @@
   // --- Key management ---
   var STORAGE_KEY = 'ozwell_api_key';
 
-  function createKeySetupUI() {
-    if (document.getElementById('ozwell-setup-card')) return;
+  // Hide the widget button until the key is validated — prevents a broken
+  // button showing when the CDN loads with an empty/stale apiKey.
+  var hideStyle = document.createElement('style');
+  hideStyle.id = 'ozwell-hide-btn';
+  hideStyle.textContent = '.ozwell-chat-button{display:none!important;}';
+  document.head.appendChild(hideStyle);
+
+  function showWidgetButton() {
+    var s = document.getElementById('ozwell-hide-btn');
+    if (s) s.remove();
+  }
+
+  function createSetupBubble() {
+    if (document.getElementById('ozwell-setup-bubble')) return;
+
+    // Floating bubble — sits in the same bottom-right spot Schemie would occupy.
+    var bubble = document.createElement('button');
+    bubble.id = 'ozwell-setup-bubble';
+    bubble.title = 'Enable AI assistant';
+    bubble.style.cssText =
+      'position:fixed;bottom:20px;right:20px;z-index:9999;width:56px;height:56px;border-radius:50%;' +
+      'background:#2563eb;color:white;border:none;cursor:pointer;box-shadow:0 4px 14px rgba(37,99,235,.5);' +
+      'display:flex;align-items:center;justify-content:center;';
+    bubble.innerHTML =
+      "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>" +
+      "<path stroke='none' d='M0 0h24v24H0z' fill='none'/>" +
+      "<path d='M3 3l18 18'/>" +
+      "<path d='M11 11a1 1 0 0 1 -1 -1m0 -3.968v-2.032a1 1 0 0 1 1 -1h9a1 1 0 0 1 1 1v10l-3 -3h-3'/>" +
+      "<path d='M14 15v2a1 1 0 0 1 -1 1h-7l-3 3v-10a1 1 0 0 1 1 -1h2'/>" +
+      '</svg>';
+
+    // Setup card — hidden until bubble is clicked.
     var card = document.createElement('div');
     card.id = 'ozwell-setup-card';
     card.style.cssText =
-      'position:fixed;bottom:20px;right:20px;z-index:9998;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:16px;box-shadow:0 4px 16px rgba(0,0,0,.15);width:280px;font-family:system-ui,sans-serif;font-size:14px;';
+      'display:none;position:fixed;bottom:88px;right:20px;z-index:9998;background:#fff;' +
+      'border:1px solid #e5e7eb;border-radius:12px;padding:16px;box-shadow:0 4px 16px rgba(0,0,0,.15);' +
+      'width:280px;font-family:system-ui,sans-serif;font-size:14px;';
+
+    bubble.onclick = function () {
+      card.style.display = card.style.display === 'none' ? 'block' : 'none';
+    };
 
     var title = document.createElement('p');
     title.style.cssText = 'margin:0 0 6px;color:#111827;font-weight:600;';
     title.textContent = '🔑 AI Assistant setup';
 
     var desc = document.createElement('p');
-    desc.style.cssText =
-      'margin:0 0 10px;color:#6b7280;font-size:12px;line-height:1.4;';
+    desc.style.cssText = 'margin:0 0 10px;color:#6b7280;font-size:12px;line-height:1.4;';
     desc.textContent =
       'Enter your Ozwell parent API key (ozw_…) to enable the AI chat widget.';
 
@@ -210,40 +258,98 @@
     input.style.cssText =
       'width:100%;box-sizing:border-box;border:1px solid #d1d5db;border-radius:6px;padding:6px 10px;font-size:13px;margin-bottom:8px;outline:none;font-family:inherit;';
 
+    var errorMsg = document.createElement('p');
+    errorMsg.style.cssText = 'margin:0 0 8px;color:#ef4444;font-size:12px;display:none;';
+
     var btn = document.createElement('button');
     btn.textContent = 'Enable AI assistant';
     btn.style.cssText =
       'background:#2563eb;color:#fff;border:none;border-radius:6px;padding:7px 14px;font-size:13px;cursor:pointer;width:100%;font-family:inherit;';
     btn.onclick = function () {
       var key = input.value.trim();
+      errorMsg.style.display = 'none';
+      input.style.borderColor = '#d1d5db';
+
       if (!key.startsWith('ozw_')) {
         input.style.borderColor = '#ef4444';
+        errorMsg.textContent = 'Key must start with ozw_';
+        errorMsg.style.display = 'block';
         return;
       }
-      localStorage.setItem(STORAGE_KEY, key);
-      location.reload();
+
+      btn.disabled = true;
+      btn.textContent = 'Validating…';
+
+      fetch('https://ozwellapi.os.mieweb.org/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + key,
+        },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 1,
+        }),
+      })
+        .then(function (res) {
+          if (res.status === 401 || res.status === 403) throw new Error('invalid');
+          sessionStorage.setItem(STORAGE_KEY, key);
+          location.reload();
+        })
+        .catch(function (err) {
+          btn.disabled = false;
+          btn.textContent = 'Enable AI assistant';
+          input.style.borderColor = '#ef4444';
+          errorMsg.textContent =
+            err.message === 'invalid'
+              ? 'Invalid API key — not authorized.'
+              : 'Could not reach Ozwell server. Check your connection.';
+          errorMsg.style.display = 'block';
+        });
     };
 
     card.appendChild(title);
     card.appendChild(desc);
     card.appendChild(input);
+    card.appendChild(errorMsg);
     card.appendChild(btn);
+    document.body.appendChild(bubble);
     document.body.appendChild(card);
   }
 
-  // Show setup card if no key is stored; skip loading the widget.
-  if (!localStorage.getItem(STORAGE_KEY)) {
-    // Prevent the CDN loader from being useful — config has empty apiKey already.
+  var storedKey = sessionStorage.getItem(STORAGE_KEY);
+  if (storedKey) {
+    // Validate stored key before revealing the widget button.
+    fetch('https://ozwellapi.os.mieweb.org/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + storedKey,
+      },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 1,
+      }),
+    })
+      .then(function (res) {
+        if (res.status === 401 || res.status === 403) throw new Error('invalid');
+        showWidgetButton();
+      })
+      .catch(function () {
+        sessionStorage.removeItem(STORAGE_KEY);
+        if (window.OzwellChatConfig) window.OzwellChatConfig.apiKey = '';
+        createSetupBubble();
+      });
+  } else {
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', createKeySetupUI);
+      document.addEventListener('DOMContentLoaded', createSetupBubble);
     } else {
-      createKeySetupUI();
+      createSetupBubble();
     }
   }
 
-  // ozwellResetKey() in browser console clears the stored key.
   window.ozwellResetKey = function () {
-    localStorage.removeItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
     location.reload();
   };
 })();

--- a/apps/docs/static/js/ozwell-tools.js
+++ b/apps/docs/static/js/ozwell-tools.js
@@ -111,7 +111,8 @@
       }
     }
     // Boost intro/overview pages for general queries
-    if (/\/(intro|overview|index|readme)/.test(pathLower) || path === '/docs') score += 5;
+    if (/\/(intro|overview|index|readme)/.test(pathLower) || path === '/docs')
+      score += 5;
     return score;
   }
 
@@ -248,7 +249,8 @@
     title.textContent = '🔑 AI Assistant setup';
 
     var desc = document.createElement('p');
-    desc.style.cssText = 'margin:0 0 10px;color:#6b7280;font-size:12px;line-height:1.4;';
+    desc.style.cssText =
+      'margin:0 0 10px;color:#6b7280;font-size:12px;line-height:1.4;';
     desc.textContent =
       'Enter your Ozwell parent API key (ozw_…) to enable the AI chat widget.';
 
@@ -259,7 +261,8 @@
       'width:100%;box-sizing:border-box;border:1px solid #d1d5db;border-radius:6px;padding:6px 10px;font-size:13px;margin-bottom:8px;outline:none;font-family:inherit;';
 
     var errorMsg = document.createElement('p');
-    errorMsg.style.cssText = 'margin:0 0 8px;color:#ef4444;font-size:12px;display:none;';
+    errorMsg.style.cssText =
+      'margin:0 0 8px;color:#ef4444;font-size:12px;display:none;';
 
     var btn = document.createElement('button');
     btn.textContent = 'Enable AI assistant';
@@ -292,7 +295,8 @@
         }),
       })
         .then(function (res) {
-          if (res.status === 401 || res.status === 403) throw new Error('invalid');
+          if (res.status === 401 || res.status === 403)
+            throw new Error('invalid');
           sessionStorage.setItem(STORAGE_KEY, key);
           location.reload();
         })
@@ -332,7 +336,8 @@
       }),
     })
       .then(function (res) {
-        if (res.status === 401 || res.status === 403) throw new Error('invalid');
+        if (res.status === 401 || res.status === 403)
+          throw new Error('invalid');
         showWidgetButton();
       })
       .catch(function () {


### PR DESCRIPTION
## Overview

This PR adds the Ozwell chat setup flow across the demo app and docs site, with safer API key handling, validation, and a less intrusive setup experience.

Instead of storing keys in `localStorage`, the integration now uses `sessionStorage` so keys clear when the browser tab is closed. The setup flow validates the API key before saving it, re-validates saved keys on page load, and clears stale or revoked keys before the widget is shown. This prevents the Ozwell widget from loading into a broken state when a missing or invalid key is present.

The docs site also gains a generated plain-text docs content index used by Ozwell tools for improved documentation search. The generated content is created before docs serve/build and can be watched during local development.

## What Changed

* Added session-scoped Ozwell API key storage for demo and docs integrations
* Added server-side-style API key validation through `POST /v1/chat/completions`
* Re-validates saved Ozwell keys on page load before showing the widget
* Replaced the automatic setup card with a smaller click-to-reveal setup bubble
* Preserved existing Ozwell tool/system config when injecting the widget
* Added messages-on and messages-off SVG button states
* Added `window.ozwellResetKey()` helper for clearing the stored key during debugging
* Hid the docs widget button until the stored key validates
* Improved docs search scoring by counting query word frequency
* Returned up to three docs search results instead of one larger result
* Added intro/overview page boosting for docs search relevance
* Added `generate-doc-content.mjs` to build a plain-text docs content JSON file
* Added a `generate-doc-content` docs target
* Updated docs `serve` and `build` to depend on generated docs content
* Updated docs `dev` to run the docs content watcher alongside Docusaurus

## How to Test

1. Run the demo app.
2. Open the Ozwell setup bubble.
3. Enter an invalid API key.
4. Verify the setup card shows a validation error and does not inject the widget.
5. Enter a valid API key.
6. Verify the widget loads and the button changes to the messages-on icon.
7. Refresh the page.
8. Verify the saved key is re-validated and the widget still loads.
9. Run `window.ozwellResetKey()` in the browser console.
10. Refresh again and verify the setup bubble returns.

For the docs site:

1. Run the docs dev target.
2. Verify `generate-doc-content.mjs --watch` runs alongside Docusaurus.
3. Edit a docs `.md` or `.mdx` file.
4. Verify the generated docs content file updates.
5. Use Ozwell docs search with queries that should match multiple pages.
6. Verify the tool returns up to three relevant results and prioritizes intro/overview-style pages when applicable.

Recommended checks:

```bash
npm run lint
npm run typecheck
npm run build
```

## Breaking Changes

No breaking changes.
****