### PR TITLE
docs(docs): updates docs and add adapters section

### DIFF
--- a/apps/demo/src/components/Navbar.tsx
+++ b/apps/demo/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Button,
   Modal,
@@ -18,7 +18,7 @@ const landingUrl = isDev ? 'http://localhost:3000/' : '/';
 const docsUrl = isDev ? 'http://localhost:3000/docs/intro' : '/docs/intro';
 const demoUrl = isDev ? 'http://localhost:3001/' : '/demo/';
 
-export function Navbar({ children }: { children?: ReactNode }) {
+export function Navbar() {
   const { theme, setTheme } = useTheme();
   const { brand, setBrand, brands } = useBrand();
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -53,7 +53,7 @@ export function Navbar({ children }: { children?: ReactNode }) {
             href={demoUrl}
             className="text-sm text-muted-foreground hover:text-primary-600 no-underline transition-colors"
           >
-            Demo
+            Playground
           </a>
         </div>
         <div className="ml-auto flex items-center">
@@ -68,13 +68,6 @@ export function Navbar({ children }: { children?: ReactNode }) {
           </Button>
         </div>
       </div>
-
-      {/* Actions row — children from page (Select, buttons, etc.) */}
-      {children && (
-        <div className="demo-navbar-actions flex flex-wrap items-center gap-2 px-4 py-2 border-t border-border sm:border-t-0 sm:py-0 sm:absolute sm:top-0 sm:left-1/2 sm:-translate-x-1/2 sm:h-14 sm:flex-nowrap sm:max-w-2xl sm:w-full">
-          {children}
-        </div>
-      )}
 
       <Modal open={settingsOpen} onOpenChange={setSettingsOpen}>
         <ModalHeader>

--- a/apps/demo/src/components/Navbar.tsx
+++ b/apps/demo/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import {
   Button,
   Modal,
@@ -22,6 +22,10 @@ export function Navbar({ children }: { children?: ReactNode }) {
   const { theme, setTheme } = useTheme();
   const { brand, setBrand, brands } = useBrand();
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  useEffect(() => {
+    if (theme === 'system') setTheme('light');
+  }, [theme, setTheme]);
 
   return (
     <nav className="demo-navbar bg-card border-b border-border sticky top-0 z-50">
@@ -81,13 +85,10 @@ export function Navbar({ children }: { children?: ReactNode }) {
           <Select
             label="Theme"
             value={theme}
-            onValueChange={(val) =>
-              setTheme(val as 'light' | 'dark' | 'system')
-            }
+            onValueChange={(val) => setTheme(val as 'light' | 'dark')}
             options={[
               { value: 'light', label: 'Light' },
               { value: 'dark', label: 'Dark' },
-              { value: 'system', label: 'System' },
             ]}
           />
           <Select

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -66,6 +66,11 @@ body {
   @apply bg-neutral-50 text-neutral-800 dark:bg-neutral-900 dark:text-neutral-100;
 }
 
+/* Invert logo SVG in dark mode */
+[data-theme='dark'] .demo-navbar img[alt='eSheet logo'] {
+  filter: invert(1);
+}
+
 /* Override Chrome autofill background in dark mode */
 [data-theme='dark'] input:-webkit-autofill,
 [data-theme='dark'] input:-webkit-autofill:hover,

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -4,8 +4,8 @@ import {
   useBuilderMcpToolHandler,
   BUILDER_TOOL_DEFINITIONS,
   BUILDER_SYSTEM_PROMPT,
+  type FormDefinition,
 } from '@esheet/builder';
-import type { FormDefinition } from '@esheet/core';
 import { Navbar } from '../components/Navbar.js';
 import { updateOzwellTools } from '../ozwell-setup.js';
 

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -44,7 +44,7 @@ export function BuilderView() {
   return (
     <div className="demo-builder-view w-full h-screen flex flex-col">
       <Navbar />
-      <div className="flex-1 overflow-y-auto ms:bg-msbackground">
+      <div className="flex-1 overflow-y-auto bg-background">
         <div className="w-full flex justify-center px-2 pt-5">
           <EsheetBuilder
             definition={INITIAL_DEF}

--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -9,7 +9,22 @@ import {
   type FormResponseEnvelope,
 } from '@esheet/renderer';
 import { Navbar } from '../components/Navbar';
-import { Button, Select } from '@mieweb/ui';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Select,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@mieweb/ui';
+import { ClipboardList } from 'lucide-react';
 import { updateOzwellTools } from '../ozwell-setup.js';
 
 interface SubmitResult {
@@ -75,7 +90,7 @@ export function RendererView() {
   const [definition, setDefinition] = useState<unknown>(null);
   const rendererRef = useRef<EsheetRendererHandle>(null);
 
-  const [showDefinition, setShowDefinition] = useState(false);
+  const [activeTab, setActiveTab] = useState<'form' | 'definition'>('form');
 
   const resetFormKey = useCallback(() => {
     setFormKey((prev) => prev + 1);
@@ -147,7 +162,147 @@ export function RendererView() {
 
   return (
     <>
-      <Navbar>
+      <Navbar />
+
+      <input
+        id="renderer-file-import"
+        type="file"
+        accept=".json"
+        onChange={handleFileImport}
+        className="hidden"
+      />
+
+      {submitResult && (
+        <div className="bg-muted py-4 px-4">
+          <Alert
+            variant={submitResult.kind === 'success' ? 'success' : 'danger'}
+            className="max-w-4xl mx-auto"
+          >
+            <AlertTitle>{submitResult.title}</AlertTitle>
+            <AlertDescription>
+              <p>{submitResult.message}</p>
+              {submitResult.items && submitResult.items.length > 0 && (
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm">
+                  {submitResult.items.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              )}
+              {submitResult.detail && (
+                <p className="mt-3 text-sm">{submitResult.detail}</p>
+              )}
+              {submitResult.data && (
+                <pre className="mt-3 p-3 bg-background/50 rounded-lg text-xs overflow-auto max-h-96 border border-border">
+                  {JSON.stringify(submitResult.data, null, 2)}
+                </pre>
+              )}
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <div className="demo-renderer-content bg-background pt-6 pb-20 min-h-[calc(100vh-3.5rem)]">
+        {rawInput == null ? (
+          <div className="flex flex-col items-center justify-center min-h-[calc(100vh-10rem)] gap-6">
+            <div className="text-center max-w-md">
+              <ClipboardList
+                className="mx-auto mb-4 text-muted-foreground"
+                size={48}
+                strokeWidth={1.5}
+              />
+              <h2 className="text-2xl font-semibold text-foreground mb-3">
+                No Form Loaded
+              </h2>
+              <p className="text-muted-foreground mb-6">
+                Select an example from the dropdown, or import your own JSON
+                definition.
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {TEST_SCHEMAS.slice(0, 3).map((s) => (
+                  <Button
+                    key={s.value}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleLoadSchema(s.value)}
+                  >
+                    {s.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as 'form' | 'definition')}
+          >
+            <div className="sticky top-14 z-30 bg-card border-b border-border">
+              <div className="max-w-4xl mx-auto px-4 flex items-center gap-2 h-11">
+                <TabsList>
+                  <TabsTrigger value="form">Form</TabsTrigger>
+                  <TabsTrigger value="definition">Definition</TabsTrigger>
+                </TabsList>
+                <div className="ml-auto flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      document.getElementById('renderer-file-import')?.click()
+                    }
+                  >
+                    Import JSON
+                  </Button>
+                  {rawInput != null && (
+                    <Button onClick={handleSubmit} variant="primary" size="sm">
+                      Submit
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <TabsContent value="form">
+              <div className="max-w-4xl mx-auto px-4 pt-6">
+                <EsheetRenderer
+                  key={formKey}
+                  formDataInput={rawInput}
+                  ref={rendererRef}
+                  onRendererToolsReady={onRendererToolsReady}
+                  onReady={() => {
+                    const def = rendererRef.current
+                      ?.getFormStore()
+                      .getState()
+                      .hydrateDefinition();
+                    if (def) setDefinition(def);
+                  }}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="definition">
+              <div className="max-w-4xl mx-auto px-4 pt-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-sm font-semibold">
+                      eSheet FormDefinition
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <pre className="text-xs overflow-auto max-h-[60vh]">
+                      {definition
+                        ? JSON.stringify(definition, null, 2)
+                        : '(loading…)'}
+                    </pre>
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
+          </Tabs>
+        )}
+      </div>
+
+      {/* Sticky bottom bar — preset select only */}
+      <div className="fixed bottom-0 left-0 right-0 z-40 bg-card border-t border-border px-4 py-2 flex items-center gap-2">
         <Select
           value={selectedSchema}
           onValueChange={(val: string) => {
@@ -160,136 +315,6 @@ export function RendererView() {
           placeholder="Load example…"
           className="w-48"
         />
-
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            document.getElementById('renderer-file-import')?.click()
-          }
-        >
-          Import JSON
-        </Button>
-        <input
-          id="renderer-file-import"
-          type="file"
-          accept=".json"
-          onChange={handleFileImport}
-          className="hidden"
-        />
-
-        {rawInput != null && (
-          <button
-            onClick={() => setShowDefinition((prev) => !prev)}
-            className="px-3 py-1.5 text-sm font-medium bg-slate-500 hover:bg-slate-600 text-white rounded-lg transition-colors whitespace-nowrap"
-          >
-            {showDefinition ? 'Hide' : 'Show'} Definition
-          </button>
-        )}
-
-        {rawInput != null && (
-          <Button
-            onClick={handleSubmit}
-            variant="primary"
-            size="sm"
-            className="ml-auto"
-          >
-            Submit
-          </Button>
-        )}
-      </Navbar>
-
-      {submitResult && (
-        <div className="bg-muted pt-4">
-          <div
-            role={submitResult.kind === 'success' ? 'status' : 'alert'}
-            aria-live={submitResult.kind === 'success' ? 'polite' : undefined}
-            aria-atomic="true"
-            className={[
-              'max-w-4xl mx-auto rounded-2xl border px-4 py-4 shadow-sm',
-              submitResult.kind === 'success'
-                ? 'border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100'
-                : 'border-rose-200 bg-rose-50 text-rose-950 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-100',
-            ].join(' ')}
-          >
-            <h2 className="text-base font-semibold">{submitResult.title}</h2>
-            <p className="mt-1 text-sm">{submitResult.message}</p>
-            {submitResult.items && submitResult.items.length > 0 && (
-              <ul className="mt-3 list-disc space-y-1 pl-5 text-sm">
-                {submitResult.items.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            )}
-            {submitResult.detail && (
-              <p className="mt-3 text-sm text-slate-700 dark:text-slate-300">
-                {submitResult.detail}
-              </p>
-            )}
-            {submitResult.data && (
-              <pre className="mt-3 p-3 bg-white/50 dark:bg-white/10 rounded-lg text-xs overflow-auto max-h-96 border border-emerald-200 dark:border-emerald-800">
-                {JSON.stringify(submitResult.data, null, 2)}
-              </pre>
-            )}
-          </div>
-        </div>
-      )}
-
-      <div className="demo-renderer-content bg-gray-100 dark:bg-neutral-900 pt-6 pb-20 min-h-[calc(100vh-3.5rem)]">
-        {/* SurveyJS conversion errors removed */}
-        {rawInput == null ? (
-          <div className="flex flex-col items-center justify-center min-h-[calc(100vh-10rem)] gap-6">
-            <div className="text-center max-w-md">
-              <h2 className="text-2xl font-semibold text-foreground mb-3">
-                No Form Loaded
-              </h2>
-              <p className="text-muted-foreground mb-6">
-                Select an example from the dropdown above, or import your own
-                JSON form definition.
-              </p>
-            </div>
-          </div>
-        ) : (
-          <div
-            className={
-              showDefinition
-                ? 'grid grid-cols-1 lg:grid-cols-2 gap-4 max-w-7xl mx-auto px-4'
-                : 'max-w-4xl mx-auto px-4'
-            }
-          >
-            <div>
-              <EsheetRenderer
-                key={formKey}
-                formDataInput={rawInput}
-                ref={rendererRef}
-                onRendererToolsReady={onRendererToolsReady}
-                onReady={() => {
-                  const def = rendererRef.current
-                    ?.getFormStore()
-                    .getState()
-                    .hydrateDefinition();
-                  if (def) setDefinition(def);
-                }}
-              />
-            </div>
-            {showDefinition && (
-              <div className="lg:sticky lg:top-20 lg:self-start space-y-4">
-                <div className="bg-white dark:bg-neutral-800 rounded-lg border border-slate-200 dark:border-neutral-700 shadow-sm">
-                  <div className="px-4 py-2 border-b border-slate-200 dark:border-neutral-700 bg-slate-50 dark:bg-neutral-900 rounded-t-lg">
-                    <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">
-                      eSheet FormDefinition
-                    </h3>
-                  </div>
-                  <pre className="p-4 text-xs overflow-auto max-h-[40vh] text-slate-800 dark:text-slate-200">
-                    {definition
-                      ? JSON.stringify(definition, null, 2)
-                      : '(loading…)'}
-                  </pre>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
       </div>
     </>
   );

--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -5,8 +5,9 @@ import {
   useRendererMcpToolHandler,
   RENDERER_TOOL_DEFINITIONS,
   RENDERER_SYSTEM_PROMPT,
+  type FormDefinition,
+  type FormResponseEnvelope,
 } from '@esheet/renderer';
-import type { FormDefinition, FormResponseEnvelope } from '@esheet/core';
 import { Navbar } from '../components/Navbar';
 import { Button, Select } from '@mieweb/ui';
 import { updateOzwellTools } from '../ozwell-setup.js';

--- a/apps/docs/docs/adapters/mcp.md
+++ b/apps/docs/docs/adapters/mcp.md
@@ -1,0 +1,162 @@
+---
+sidebar_position: 3
+---
+
+# MCP Adapter
+
+Convert between MCP (Model Context Protocol) elicitation requests and eSheet `FormDefinition`. Enables AI agents to request structured input via the MCP elicitation spec (2025-11-25).
+
+## Functions
+
+| Function                  | Signature                                                                   | Description                  |
+| ------------------------- | --------------------------------------------------------------------------- | ---------------------------- |
+| `importFromMcp`           | `(schema: McpElicitationSchema, options?: ImportOptions) => FormDefinition` | Import MCP to eSheet         |
+| `exportToMcp`             | `(form: FormDefinition) => McpElicitationRequest`                           | Export eSheet to MCP request |
+| `isMcpElicitationRequest` | `(value: unknown) => value is McpElicitationRequest`                        | Type guard for detection     |
+
+## Import from MCP
+
+```typescript
+import { importFromMcp } from '@esheet/adapters';
+
+const mcpSchema = {
+  type: 'object',
+  title: 'User Preferences',
+  properties: {
+    name: { type: 'string', title: 'Full Name' },
+    notifications: { type: 'boolean', title: 'Enable notifications?' },
+    theme: {
+      type: 'string',
+      title: 'Theme',
+      oneOf: [
+        { const: 'light', title: 'Light Mode' },
+        { const: 'dark', title: 'Dark Mode' },
+      ],
+    },
+  },
+  required: ['name'],
+};
+
+const formDefinition = importFromMcp(mcpSchema, {
+  formId: 'user-prefs',
+  title: 'User Preferences',
+  description: 'Configure your settings',
+});
+```
+
+### Import Options
+
+```typescript
+interface ImportOptions {
+  formId?: string; // Form ID (default: 'mcp-form')
+  title?: string; // Form title
+  description?: string; // Form description
+  mcpId?: string | number; // Preserved for round-trip
+  mcpMessage?: string; // Preserved for round-trip
+  mcpMeta?: unknown; // Non-standard envelope fields
+}
+```
+
+## Export to MCP
+
+```typescript
+import { exportToMcp } from '@esheet/adapters';
+
+const mcpRequest = exportToMcp(formDefinition);
+```
+
+Returns a full MCP JSON-RPC 2.0 `elicitation/create` request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "...",
+  "method": "elicitation/create",
+  "params": {
+    "mode": "form",
+    "message": "...",
+    "requestedSchema": { ... }
+  }
+}
+```
+
+## Type Guard
+
+```typescript
+import { isMcpElicitationRequest, importFromMcp } from '@esheet/adapters';
+
+if (isMcpElicitationRequest(unknownValue)) {
+  const form = importFromMcp(unknownValue.params.requestedSchema);
+}
+```
+
+Returns `true` if value is a valid MCP elicitation request envelope.
+
+## Field Type Mapping
+
+### MCP → eSheet
+
+| MCP Type             | MCP Modifiers                 | eSheet Field Type                      |
+| -------------------- | ----------------------------- | -------------------------------------- |
+| `string`             | plain                         | `text`                                 |
+| `string`             | `format: 'email'`             | `text` + `inputType: 'email'`          |
+| `string`             | `format: 'uri'`               | `text` + `inputType: 'url'`            |
+| `string`             | `format: 'date'`              | `text` + `inputType: 'date'`           |
+| `string`             | `format: 'date-time'`         | `text` + `inputType: 'datetime-local'` |
+| `string`             | `enum` or `oneOf`             | `radio`                                |
+| `number` / `integer` | —                             | `text` + `inputType: 'number'`         |
+| `boolean`            | —                             | `boolean`                              |
+| `array`              | `items.enum` or `items.anyOf` | `check`                                |
+| `object`             | nested                        | `longtext` (fallback)                  |
+
+### eSheet → MCP
+
+| eSheet Field Type                      | MCP Type                  | Notes                                |
+| -------------------------------------- | ------------------------- | ------------------------------------ |
+| `text` / `longtext`                    | `string`                  | Restores `format` from `inputType`   |
+| `boolean`                              | `boolean`                 | —                                    |
+| `radio` / `dropdown`                   | `string` + `enum`/`oneOf` | Uses `oneOf` if options have text    |
+| `check` / `multiselectdropdown`        | `array`                   | Items with `enum`/`anyOf`            |
+| `rating`                               | `integer`                 | `minimum: 1`, `maximum: optionCount` |
+| `slider`                               | `number`                  | Preserves `number` vs `integer`      |
+| `ranking`, `multitext`, `matrix`, etc. | **Skipped**               | No MCP equivalent                    |
+
+## Constraint Preservation
+
+MCP constraints are preserved in `_sourceData` for round-trip fidelity:
+
+### String Constraints
+
+- `minLength`, `maxLength`
+- `pattern` (regex)
+- `format` (email, uri, date, date-time)
+
+### Number Constraints
+
+- `minimum`, `maximum`
+- `exclusiveMinimum`, `exclusiveMaximum`
+
+### Array Constraints
+
+- `minItems`, `maxItems`
+- `uniqueItems`
+
+## Types
+
+| Type                    | Description                                                               |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `McpElicitationSchema`  | The `requestedSchema` object in MCP requests                              |
+| `McpElicitationRequest` | Full JSON-RPC 2.0 envelope with `method: 'elicitation/create'`            |
+| `McpProperty`           | Union: `McpStringProp \| McpNumberProp \| McpBooleanProp \| McpArrayProp` |
+| `McpStringProp`         | String property with optional `format`, `enum`, `oneOf`                   |
+| `McpNumberProp`         | Number/integer property with optional `minimum`, `maximum`                |
+| `McpBooleanProp`        | Boolean property                                                          |
+| `McpArrayProp`          | Array property with `items.enum` or `items.anyOf`                         |
+| `McpConstOption`        | `{ const: string; title: string }` for enum options                       |
+
+## Usage Notes
+
+- Fields without MCP equivalents (ranking, multitext, matrices) are skipped during export
+- Import creates unique field IDs from MCP property names
+- Export generates a complete JSON-RPC envelope, not just the schema
+- Use `mcpId` and `mcpMessage` options to preserve envelope data during round-trips

--- a/apps/docs/docs/adapters/overview.md
+++ b/apps/docs/docs/adapters/overview.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 1
+---
+
+# Adapters Overview
+
+The `@esheet/adapters` package provides bidirectional converters between eSheet `FormDefinition` and external form schema formats like SurveyJS and MCP elicitation requests.
+
+## Installation
+
+```bash
+npm install @esheet/adapters
+```
+
+## Available Adapters
+
+| Adapter  | Import Function      | Export Function    | Type Guard                | Description                              |
+| -------- | -------------------- | ------------------ | ------------------------- | ---------------------------------------- |
+| SurveyJS | `importFromSurveyJS` | `exportToSurveyJS` | `isSurveyJSSchema`        | Convert to/from SurveyJS form schemas    |
+| MCP      | `importFromMcp`      | `exportToMcp`      | `isMcpElicitationRequest` | Convert to/from MCP elicitation requests |
+
+## Common Pattern
+
+All adapters follow a bidirectional import/export pattern:
+
+```typescript
+import { importFromSurveyJS, exportToSurveyJS } from '@esheet/adapters';
+
+// Import: External format → eSheet
+const formDefinition = importFromSurveyJS(surveyJSSchema);
+
+// Export: eSheet → External format
+const surveyJSSchema = exportToSurveyJS(formDefinition);
+```
+
+## Auto-Detection
+
+Use type guards to detect the schema format when handling unknown input:
+
+```typescript
+import {
+  isSurveyJSSchema,
+  isMcpElicitationRequest,
+  importFromSurveyJS,
+  importFromMcp,
+} from '@esheet/adapters';
+import type { FormDefinition } from '@esheet/core';
+
+function detectAndConvert(unknownSchema: unknown): FormDefinition | null {
+  if (isSurveyJSSchema(unknownSchema)) {
+    return importFromSurveyJS(unknownSchema);
+  }
+  if (isMcpElicitationRequest(unknownSchema)) {
+    return importFromMcp(unknownSchema.params.requestedSchema);
+  }
+  return null;
+}
+```
+
+## Round-Trip Fidelity
+
+Adapters preserve original metadata in `_sourceData` to enable lossless round-trips:
+
+```typescript
+const form = importFromSurveyJS(surveyJSSchema);
+// form.fields[0]._sourceData contains original SurveyJS element
+
+const exported = exportToSurveyJS(form);
+// Original field names, types, and properties restored
+```
+
+## All Exports
+
+```typescript
+import {
+  // SurveyJS Adapter
+  importFromSurveyJS,
+  convertSurveyJS, // Alias
+  convertSurveyJSToESheet, // Alias
+  exportToSurveyJS,
+  isSurveyJSSchema,
+  SURVEYJS_SYSTEM_PROMPT,
+
+  // MCP Adapter
+  importFromMcp,
+  exportToMcp,
+  isMcpElicitationRequest,
+
+  // Types
+  type SurveyJSDetectionSchema,
+  type McpElicitationSchema,
+  type McpElicitationRequest,
+  type McpProperty,
+  type McpStringProp,
+  type McpNumberProp,
+  type McpBooleanProp,
+  type McpArrayProp,
+  type McpConstOption,
+} from '@esheet/adapters';
+```
+
+See the [SurveyJS Adapter](./surveyjs.md) and [MCP Adapter](./mcp.md) pages for detailed documentation.

--- a/apps/docs/docs/adapters/surveyjs.md
+++ b/apps/docs/docs/adapters/surveyjs.md
@@ -143,7 +143,8 @@ SurveyJS conditional properties convert to eSheet `rules`:
 // Converts to eSheet rule:
 {
   effect: 'visible',
-  conditions: [{ fieldId: 'country', operator: 'equals', value: 'USA' }]
+  logic: 'AND',
+  conditions: [{ conditionType: 'field', targetId: 'country', operator: 'equals', expected: 'USA' }]
 }
 ```
 
@@ -156,6 +157,7 @@ Expressions with arithmetic or multiple fields convert to expression conditions:
 // Converts to eSheet rule:
 {
   effect: 'visible',
+  logic: 'AND',
   conditions: [{
     conditionType: 'expression',
     expression: '{price} * {quantity} > 100'

--- a/apps/docs/docs/adapters/surveyjs.md
+++ b/apps/docs/docs/adapters/surveyjs.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 2
+---
+
+# SurveyJS Adapter
+
+Convert between SurveyJS form schemas and eSheet `FormDefinition`. Useful for leveraging AI models that have better training data for SurveyJS output, then converting to eSheet format.
+
+## Functions
+
+| Function                  | Signature                                              | Description               |
+| ------------------------- | ------------------------------------------------------ | ------------------------- |
+| `importFromSurveyJS`      | `(schema: SurveyJSSchema) => FormDefinition`           | Import SurveyJS to eSheet |
+| `convertSurveyJS`         | Alias for `importFromSurveyJS`                         | —                         |
+| `convertSurveyJSToESheet` | Alias for `importFromSurveyJS`                         | —                         |
+| `exportToSurveyJS`        | `(form: FormDefinition) => SurveyJSSchema`             | Export eSheet to SurveyJS |
+| `isSurveyJSSchema`        | `(value: unknown) => value is SurveyJSDetectionSchema` | Type guard for detection  |
+
+## Import from SurveyJS
+
+```typescript
+import { importFromSurveyJS } from '@esheet/adapters';
+
+const surveyJSSchema = {
+  title: 'Customer Feedback',
+  pages: [
+    {
+      name: 'page1',
+      elements: [
+        { type: 'text', name: 'name', title: 'Your Name', isRequired: true },
+        {
+          type: 'rating',
+          name: 'satisfaction',
+          title: 'How satisfied are you?',
+        },
+      ],
+    },
+  ],
+};
+
+const formDefinition = importFromSurveyJS(surveyJSSchema);
+```
+
+All three function names are equivalent:
+
+- `importFromSurveyJS` — Named export matching MCP convention
+- `convertSurveyJS` — Alias
+- `convertSurveyJSToESheet` — Primary implementation
+
+## Export to SurveyJS
+
+```typescript
+import { exportToSurveyJS } from '@esheet/adapters';
+
+const surveyJSSchema = exportToSurveyJS(formDefinition);
+```
+
+Preserves original metadata from `_sourceData` for lossless round-trip when possible.
+
+## Type Guard
+
+```typescript
+import { isSurveyJSSchema, importFromSurveyJS } from '@esheet/adapters';
+
+if (isSurveyJSSchema(unknownSchema)) {
+  const form = importFromSurveyJS(unknownSchema);
+}
+```
+
+Returns `true` if value has `pages` or `elements` array but NOT eSheet's `fields` property.
+
+## AI System Prompt
+
+For AI-assisted SurveyJS schema generation:
+
+```typescript
+import { SURVEYJS_SYSTEM_PROMPT } from '@esheet/adapters';
+
+// Use in your AI system prompt configuration
+```
+
+The prompt instructs AI to:
+
+- Output valid SurveyJS JSON (raw, without markdown fences)
+- Use proper field type selection
+- Structure forms with pages and elements
+- Follow common SurveyJS patterns
+
+## Field Type Mapping
+
+### SurveyJS → eSheet
+
+| SurveyJS Type                      | eSheet Field Type     |
+| ---------------------------------- | --------------------- |
+| `text`                             | `text`                |
+| `comment`                          | `longtext`            |
+| `radiogroup`                       | `radio`               |
+| `checkbox`                         | `check`               |
+| `dropdown`                         | `dropdown`            |
+| `tagbox`                           | `multiselectdropdown` |
+| `boolean`                          | `boolean`             |
+| `rating`                           | `rating`              |
+| `ranking`                          | `ranking`             |
+| `matrix`                           | `singlematrix`        |
+| `matrixdropdown` / `matrixdynamic` | `multimatrix`         |
+| `signaturepad`                     | `signature`           |
+| `image`                            | `image`               |
+| `html` / `expression`              | `html`                |
+| `imagepicker`                      | `radio`               |
+| `file`                             | `text`                |
+| `panel` / `paneldynamic`           | `section`             |
+| `multipletext`                     | `multitext`           |
+
+### Input Type Mapping
+
+SurveyJS text field `inputType` maps to eSheet `TextInputType`:
+
+| SurveyJS inputType | eSheet inputType |
+| ------------------ | ---------------- |
+| `email`            | `email`          |
+| `tel`              | `tel`            |
+| `url`              | `url`            |
+| `date`             | `date`           |
+| `datetime-local`   | `datetime-local` |
+| `time`             | `time`           |
+| `number`           | `number`         |
+| `password`         | `password`       |
+
+## Conditional Logic Conversion
+
+SurveyJS conditional properties convert to eSheet `rules`:
+
+| SurveyJS Property | eSheet Rule Effect |
+| ----------------- | ------------------ |
+| `visibleIf`       | `visible`          |
+| `enableIf`        | `enable`           |
+| `requiredIf`      | `required`         |
+
+### Simple Expressions
+
+```typescript
+// SurveyJS: { visibleIf: "{country} = 'USA'" }
+// Converts to eSheet rule:
+{
+  effect: 'visible',
+  conditions: [{ fieldId: 'country', operator: 'equals', value: 'USA' }]
+}
+```
+
+### Complex Expressions
+
+Expressions with arithmetic or multiple fields convert to expression conditions:
+
+```typescript
+// SurveyJS: { visibleIf: "{price} * {quantity} > 100" }
+// Converts to eSheet rule:
+{
+  effect: 'visible',
+  conditions: [{
+    conditionType: 'expression',
+    expression: '{price} * {quantity} > 100'
+  }]
+}
+```
+
+## Round-Trip Fidelity
+
+Original SurveyJS metadata is preserved in `_sourceData`:
+
+```typescript
+const form = importFromSurveyJS(surveyJSSchema);
+// form.fields[0]._sourceData = { elementType: 'text', name: 'q1', ... }
+
+const exported = exportToSurveyJS(form);
+// Original element type, name, and expressions restored
+```
+
+## Types
+
+| Type                      | Description                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `SurveyJSDetectionSchema` | Minimal schema shape for detection: `{ pages?: unknown[]; elements?: unknown[] }` |

--- a/apps/docs/docs/advanced/mcp-integration.md
+++ b/apps/docs/docs/advanced/mcp-integration.md
@@ -179,7 +179,7 @@ function App() {
 
   return (
     <EsheetRenderer
-      definition={definition}
+      formDataInput={definition}
       onRendererToolsReady={onRendererToolsReady}
     />
   );

--- a/apps/docs/docs/advanced/mcp-integration.md
+++ b/apps/docs/docs/advanced/mcp-integration.md
@@ -1,0 +1,316 @@
+---
+sidebar_position: 4
+---
+
+# MCP / AI Tool Integration
+
+eSheet provides Model Context Protocol (MCP) compatible tool definitions and hooks for integrating AI assistants with the builder and renderer.
+
+## Overview
+
+The MCP integration allows AI assistants to:
+
+- **Builder:** Add fields, modify properties, reorder elements, manage options/rows/columns, add logic rules, fill preview responses
+- **Renderer:** Fill field responses, get form state, validate submissions, clear responses
+
+## Builder Integration
+
+### Exports
+
+```typescript
+import {
+  // MCP tool execution
+  executeToolCall,
+  // Tool definitions array (25 tools)
+  BUILDER_TOOL_DEFINITIONS,
+  // System prompt constant
+  BUILDER_SYSTEM_PROMPT,
+  // React hook for handling AI tool calls
+  useBuilderMcpToolHandler,
+  // Types
+  type ToolDefinition,
+  type UseBuilderMcpToolHandlerOptions,
+} from '@esheet/builder';
+```
+
+### Using `onBuilderToolsReady`
+
+The `useBuilderMcpToolHandler` hook returns a callback for the builder's `onBuilderToolsReady` prop. It listens for custom events on a target element and routes them to the appropriate MCP tool.
+
+```tsx
+import { EsheetBuilder, useBuilderMcpToolHandler } from '@esheet/builder';
+
+function App() {
+  const onBuilderToolsReady = useBuilderMcpToolHandler({
+    eventName: 'ozwell-tool-call',
+    target: document, // Optional, defaults to document
+  });
+
+  return <EsheetBuilder onBuilderToolsReady={onBuilderToolsReady} />;
+}
+```
+
+#### Options
+
+```typescript
+interface UseBuilderMcpToolHandlerOptions {
+  /** The DOM element to listen on for tool-call events. Defaults to document. */
+  target?: EventTarget;
+  /** The event name to listen for, e.g. 'ozwell-tool-call'. */
+  eventName: string;
+}
+```
+
+### Available Builder Tools
+
+The `BUILDER_TOOL_DEFINITIONS` array contains 25 tools for form building operations:
+
+#### Form Overview Tools
+
+| Tool               | Description                                                                                                                                                                             | Parameters                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `get_form_summary` | **CALL FIRST.** Returns `{formId, fieldCount, fields}` with condensed field info (id, fieldType, question, required, optionCount, rowCount, columnCount, editWith, hasRules, hasValue). | None                                         |
+| `get_field`        | Get full details of one field including options/rows/columns with IDs.                                                                                                                  | `fieldQuestion?: string`, `fieldId?: string` |
+| `get_definition`   | Export complete form as JSON definition tree with all fields, options, rows, columns, and logic rules.                                                                                  | None                                         |
+| `get_field_types`  | List all available field types with key, label, category, and capabilities.                                                                                                             | None                                         |
+| `get_field_spec`   | Get full spec for a specific field type: capabilities, defaults, placeholder hints.                                                                                                     | `fieldType: string` (required)               |
+
+#### Field CRUD Tools
+
+| Tool           | Description                                                                                  | Parameters                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `create_field` | Add one field. Supports all field types including sections with parentId.                    | `fieldType: string`, `question: string`, `required?: boolean`, `options?: {value}[]`, `afterFieldId?: string`, `parentId?: string`, `properties?: object` |
+| `update_field` | Change scalar field properties (question, required, inputType, min, max, step, placeholder). | `fieldQuestion?: string`, `fieldId?: string`, `updates: object`                                                                                           |
+| `delete_field` | Delete a field by question or ID.                                                            | `fieldQuestion?: string`, `fieldId?: string`                                                                                                              |
+| `move_field`   | Reorder a field to a new index position (0-based).                                           | `fieldQuestion?: string`, `fieldId?: string`, `toIndex: number`, `toParentId?: string`                                                                    |
+| `reset_form`   | Clear all fields.                                                                            | None                                                                                                                                                      |
+
+#### Option Management Tools
+
+For radio, check, dropdown, rating, ranking, slider, multitext fields. **NOT for matrix fields.**
+
+| Tool            | Description                              | Parameters                                                                                                  |
+| --------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `add_option`    | Add an option.                           | `fieldQuestion?: string`, `fieldId?: string`, `value?: string`                                              |
+| `update_option` | Update the label of an existing option.  | `fieldQuestion?: string`, `fieldId?: string`, `optionId?: string`, `currentValue?: string`, `value: string` |
+| `remove_option` | Remove an option by ID or current label. | `fieldQuestion?: string`, `fieldId?: string`, `optionId?: string`, `currentValue?: string`                  |
+
+#### Matrix Row/Column Tools
+
+For singlematrix and multimatrix fields only.
+
+| Tool            | Description                     | Parameters                                                                                                  |
+| --------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `add_row`       | Add a row to a matrix field.    | `fieldQuestion?: string`, `fieldId?: string`, `value?: string`                                              |
+| `update_row`    | Update a matrix row label.      | `fieldQuestion?: string`, `fieldId?: string`, `rowId?: string`, `currentValue?: string`, `value: string`    |
+| `remove_row`    | Remove a matrix row by ID.      | `fieldQuestion?: string`, `fieldId?: string`, `rowId: string`                                               |
+| `add_column`    | Add a column to a matrix field. | `fieldQuestion?: string`, `fieldId?: string`, `value?: string`                                              |
+| `update_column` | Update a matrix column label.   | `fieldQuestion?: string`, `fieldId?: string`, `columnId?: string`, `currentValue?: string`, `value: string` |
+| `remove_column` | Remove a matrix column by ID.   | `fieldQuestion?: string`, `fieldId?: string`, `columnId: string`                                            |
+
+#### Response/Preview Tools
+
+| Tool              | Description                                                                            | Parameters                                                 |
+| ----------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `fill_field`      | Set a preview response for ONE field. Returns `{result, filledCount, unfilledFields}`. | `fieldQuestion?: string`, `fieldId?: string`, `value: any` |
+| `get_responses`   | Get current response values.                                                           | None                                                       |
+| `clear_responses` | Clear all responses.                                                                   | None                                                       |
+
+#### Form Metadata Tools
+
+| Tool          | Description                   | Parameters   |
+| ------------- | ----------------------------- | ------------ |
+| `set_form_id` | Update the top-level form ID. | `id: string` |
+
+#### Conditional Logic Tools
+
+| Tool                  | Description                                                                                 | Parameters                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add_field_rule`      | Add a conditional logic rule based on another field's response.                             | `fieldQuestion?: string`, `fieldId?: string`, `effect: 'visible'\|'enable'\|'required'`, `logic: 'AND'\|'OR'`, `conditions: {targetId, operator, expected}[]` |
+| `add_expression_rule` | Add a conditional rule using a custom expression. Field IDs must be wrapped in `{fieldId}`. | `fieldQuestion?: string`, `fieldId?: string`, `effect: 'visible'\|'enable'\|'required'`, `expression: string`                                                 |
+| `remove_rule`         | Remove a conditional logic rule by 0-based index.                                           | `fieldQuestion?: string`, `fieldId?: string`, `ruleIndex: number`                                                                                             |
+
+### Supported Field Types
+
+`text`, `longtext`, `multitext`, `radio`, `check`, `boolean`, `dropdown`, `multiselectdropdown`, `rating`, `ranking`, `slider`, `singlematrix`, `multimatrix`, `image`, `html`, `signature`, `diagram`, `display`, `section`
+
+### Hook: useBuilderMcpToolHandler
+
+```typescript
+function useBuilderMcpToolHandler(
+  options: UseBuilderMcpToolHandlerOptions
+): (tools: BuilderTools) => void;
+```
+
+The hook returns a function that accepts `BuilderTools` (provided by the builder via `onBuilderToolsReady`). When an event matching `eventName` is dispatched, the hook extracts the tool name and arguments from the event detail and calls `executeToolCall`.
+
+---
+
+## Renderer Integration
+
+### Exports
+
+```typescript
+import {
+  // MCP tool execution
+  executeToolCall,
+  // Tool definitions array (7 tools)
+  RENDERER_TOOL_DEFINITIONS,
+  // System prompt constant
+  RENDERER_SYSTEM_PROMPT,
+  // React hook for handling AI tool calls
+  useRendererMcpToolHandler,
+  // Types
+  type ToolDefinition,
+  type UseRendererMcpToolHandlerOptions,
+  type RendererTools,
+} from '@esheet/renderer';
+```
+
+### Using `onRendererToolsReady`
+
+```tsx
+import { EsheetRenderer, useRendererMcpToolHandler } from '@esheet/renderer';
+
+function App() {
+  const onRendererToolsReady = useRendererMcpToolHandler({
+    eventName: 'ozwell-tool-call',
+  });
+
+  return (
+    <EsheetRenderer
+      definition={definition}
+      onRendererToolsReady={onRendererToolsReady}
+    />
+  );
+}
+```
+
+### Available Renderer Tools
+
+The `RENDERER_TOOL_DEFINITIONS` array contains 7 tools for form filling operations:
+
+| Tool                 | Description                                                                                                                           | Parameters                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `get_form`           | Returns visible fields split into filled vs unfilled. Response: `{formId, totalFields, filledCount, unfilledFields, filledFieldIds}`. | None                                                       |
+| `get_form_raw`       | Returns ALL fields regardless of visibility, conditional rules, or enabled state.                                                     | None                                                       |
+| `get_responses`      | Get current raw response values for all fields.                                                                                       | None                                                       |
+| `get_valid_response` | Run form validation. Returns full response if valid, or null plus field-level errors if validation fails.                             | None                                                       |
+| `fill_field`         | Set a response value for ONE visible field. Returns `{result, filledCount, unfilledFields}`.                                          | `fieldId?: string`, `fieldQuestion?: string`, `value: any` |
+| `clear_responses`    | Clear all current form responses.                                                                                                     | None                                                       |
+| `get_form_tree`      | Get full rendered field tree including visibility, enabled, and required state.                                                       | None                                                       |
+
+---
+
+## Fill Field Format Rules
+
+Both Builder and Renderer MCP tools enforce these value formats for `fill_field`:
+
+| Field Type                                             | Value Format                                | Example                             |
+| ------------------------------------------------------ | ------------------------------------------- | ----------------------------------- |
+| `radio` / `dropdown` / `boolean` / `rating` / `slider` | Single string matching an option value      | `"Yes"`, `"Option A"`               |
+| `check` / `multiselectdropdown`                        | Array of strings matching option values     | `["Option A", "Option B"]`          |
+| `ranking`                                              | Ordered array of option value strings       | `["First", "Second", "Third"]`      |
+| `multitext`                                            | Array of strings, one per option slot       | `["John", "Doe"]`                   |
+| `singlematrix`                                         | Object: `{ "Row Label": "Column Label" }`   | `{"Satisfaction": "Very Good"}`     |
+| `multimatrix`                                          | Object: `{ "Row Label": ["Col1", "Col2"] }` | `{"Features": ["Speed", "Design"]}` |
+| `text` (date)                                          | `YYYY-MM-DD`                                | `"2026-05-21"`                      |
+| `text` (datetime-local)                                | `YYYY-MM-DDTHH:mm`                          | `"2026-05-21T14:30"`                |
+| `text` (month)                                         | `YYYY-MM`                                   | `"2026-05"`                         |
+| `text` (time)                                          | `HH:mm` (24-hour)                           | `"14:30"`                           |
+
+:::warning
+Wrong formats are rejected with an error. Always use the `valueFormat` property from the field schema.
+:::
+
+---
+
+## Expression Rule Syntax
+
+The `add_expression_rule` tool accepts safe sandbox expressions with these rules:
+
+### Field References
+
+Field IDs **MUST** be wrapped in curly braces: `{fieldId}`
+
+### Available Operators
+
+- Arithmetic: `+`, `-`, `*`, `/`, `%`
+- Comparison: `==`, `!=`, `===`, `!==`, `>`, `>=`, `<`, `<=`
+- Logical: `&&`, `||`, `!`
+- Property access: `.length`, `.count` on field refs
+
+### NOT Available
+
+Function calls (`parseInt`, `parseFloat`, `.includes`, etc.), bare field names, loops, assignments
+
+### Examples
+
+```javascript
+// Valid expressions
+{f1} > 4 && {f2} < 3
+{f3}.length > 0
+{f4} == "Yes"
+
+// Invalid expressions
+parseInt({f1}) > 4  // No function calls
+f1 > 4              // Missing braces
+```
+
+---
+
+## Condition Operators
+
+For `add_field_rule` conditions:
+
+| Operator             | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `equals`             | Value equals expected                        |
+| `notEquals`          | Value does not equal expected                |
+| `contains`           | String contains substring                    |
+| `includes`           | Array includes value (for multi-select)      |
+| `empty`              | Value is empty/null (no expected needed)     |
+| `notEmpty`           | Value is not empty/null (no expected needed) |
+| `greaterThan`        | Numeric comparison                           |
+| `greaterThanOrEqual` | Numeric comparison                           |
+| `lessThan`           | Numeric comparison                           |
+| `lessThanOrEqual`    | Numeric comparison                           |
+
+---
+
+## System Prompts
+
+eSheet exports system prompts optimized for AI assistants:
+
+### Builder System Prompt
+
+```typescript
+import { BUILDER_SYSTEM_PROMPT } from '@esheet/builder';
+```
+
+Includes field type guidance, workflow instructions (call `get_form_summary` first, use `reset_form` when building from scratch), matrix vs option tool distinctions, section nesting, preview fill workflow, and text format rules.
+
+### Renderer System Prompt
+
+```typescript
+import { RENDERER_SYSTEM_PROMPT } from '@esheet/renderer';
+```
+
+Includes fill workflow (iterate on `unfilledFields`), format rules for all field types, and guidance on using `get_form_raw`, `get_form_tree`, and `get_valid_response`.
+
+---
+
+## Direct Tool Execution
+
+For advanced integrations, you can call `executeToolCall` directly:
+
+```typescript
+import { executeToolCall, type BuilderTools } from '@esheet/builder';
+
+// builderTools is provided via onBuilderToolsReady callback
+const result = executeToolCall(
+  'create_field',
+  { fieldType: 'text', question: 'Your name' },
+  builderTools
+);
+```

--- a/apps/docs/docs/advanced/store-architecture.md
+++ b/apps/docs/docs/advanced/store-architecture.md
@@ -47,7 +47,7 @@ The primary data store holding the form definition, normalized field index, and 
 | `hydrateDefinition()`     | Export as nested FormDefinition tree   |
 | `hydrateResponse()`       | Export responses joined with questions |
 
-## Normalized State
+## UIStore
 
 Manages UI state for the builder (mode, selection, tabs).
 

--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -260,20 +260,21 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 | Export                             | Description                                                      |
 | ---------------------------------- | ---------------------------------------------------------------- |
 | `EsheetRendererProps`              | Renderer component props                                         |
-| `EsheetRendererHandle`             | Ref handle type (`getRawResponse`, `getFormStore`, `getUIStore`) |
+| `EsheetRendererHandle`             | Ref handle type (`getRawResponse`, `getValidResponse`, `getFormStore`, `getUIStore`) |
 | `RendererTools`                    | Type for renderer MCP tool names                                 |
 | `ToolDefinition`                   | MCP tool definition type                                         |
 | `UseRendererMcpToolHandlerOptions` | Options for `useRendererMcpToolHandler`                          |
 
 ### EsheetRendererProps
 
-| Prop                   | Type                | Default | Description                             |
-| ---------------------- | ------------------- | ------- | --------------------------------------- |
-| `definition`           | `FormDefinition`    | --      | Form definition to render               |
-| `responses`            | `FormResponse`      | `{}`    | Initial response values                 |
-| `strict`               | `boolean`           | `false` | Enable strict validation mode           |
-| `onReady`              | `() => void`        | --      | Called when renderer is initialized     |
-| `onRendererToolsReady` | `(handler) => void` | --      | Called with MCP tool handler when ready |
+| Prop                   | Type                                    | Default    | Description                                                                        |
+| ---------------------- | --------------------------------------- | ---------- | ---------------------------------------------------------------------------------- |
+| `formDataInput`        | `unknown`                               | _required_ | Form definition (object, JSON string, YAML string, MCP, SurveyJS)                 |
+| `className`            | `string`                                | `''`        | Additional CSS class for the root container                                        |
+| `initialResponses`     | `FormResponse`                          | --         | Pre-fill response data                                                             |
+| `strict`               | `boolean`                               | `false`    | Disable auto-detection, require a valid FormDefinition                             |
+| `onReady`              | `() => void`                            | --         | Called when the renderer is initialized                                            |
+| `onRendererToolsReady` | `(tools: RendererTools) => void`        | --         | Called with MCP tool handler when ready                                            |
 
 ---
 

--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -10,37 +10,62 @@ Quick reference of all public exports from each eSheet package.
 
 ### Types
 
-| Export                       | Kind       | Description                                                                      |
-| ---------------------------- | ---------- | -------------------------------------------------------------------------------- |
-| `FormDefinition`             | Interface  | Top-level form structure                                                         |
-| `FieldDefinition`            | Interface  | Single field structure                                                           |
-| `FieldResponse`              | Interface  | Response values for a field                                                      |
-| `FormResponse`               | Type alias | `Record<string, FieldResponse>`                                                  |
-| `SelectedOption`             | Interface  | `{ id, value }` for selected options                                             |
-| `FieldType`                  | Type       | Union of 19 field type strings                                                   |
-| `TextInputType`              | Type       | Union of 9 text input variants                                                   |
-| `FieldOption`                | Interface  | Option in a choice field                                                         |
-| `MatrixRow` / `MatrixColumn` | Interface  | Matrix dimensions                                                                |
-| `ConditionalRule`            | Interface  | Conditional rule structure                                                       |
-| `Condition`                  | Interface  | Single condition                                                                 |
-| `ConditionOperator`          | Type       | Union of 10 operators                                                            |
-| `ConditionalEffect`          | Type       | `'visible' \| 'enable' \| 'required'`                                            |
-| `LogicMode`                  | Type       | `'AND' \| 'OR'`                                                                  |
-| `FieldCategory`              | Type       | Field grouping category                                                          |
-| `AnswerType`                 | Type       | How a field stores its answer                                                    |
-| `FieldTypeMeta`              | Interface  | Field type metadata                                                              |
-| `FieldTypeRegistry`          | Type       | Registry map                                                                     |
-| `FieldComponentProps`        | Interface  | Props contract for field components                                              |
-| `HydratedResponseItem`       | Interface  | `{ id, text, answer }` — one per answerable field, returned by `hydrateResponse` |
-| `FieldNode`                  | Interface  | Node in normalized definition tree                                               |
-| `NormalizedDefinition`       | Interface  | Flat normalized representation of a form                                         |
-| `AddFieldOptions`            | Interface  | Options for `FormStore.addField()`                                               |
+| Export                               | Kind       | Description                                                                      |
+| ------------------------------------ | ---------- | -------------------------------------------------------------------------------- |
+| `FormDefinition`                     | Interface  | Top-level form structure                                                         |
+| `FieldDefinition`                    | Interface  | Single field structure                                                           |
+| `FieldResponse`                      | Interface  | Response values for a field                                                      |
+| `FormResponse`                       | Type alias | `Record<string, FieldResponse>`                                                  |
+| `SelectedOption`                     | Interface  | `{ id, value }` for selected options                                             |
+| `FieldType`                          | Type       | Union of 19 field type strings                                                   |
+| `TextInputType`                      | Type       | Union of 9 text input variants                                                   |
+| `FieldOption`                        | Interface  | Option in a choice field                                                         |
+| `MatrixRow` / `MatrixColumn`         | Interface  | Matrix dimensions                                                                |
+| `ConditionalRule`                    | Interface  | Conditional rule structure                                                       |
+| `Condition`                          | Interface  | Single condition                                                                 |
+| `ConditionOperator`                  | Type       | Union of 10 operators                                                            |
+| `ConditionalEffect`                  | Type       | `'visible' \| 'enable' \| 'required'`                                            |
+| `LogicMode`                          | Type       | `'AND' \| 'OR'`                                                                  |
+| `FieldCategory`                      | Type       | Field grouping category                                                          |
+| `AnswerType`                         | Type       | How a field stores its answer                                                    |
+| `FieldTypeMeta`                      | Interface  | Field type metadata                                                              |
+| `FieldTypeRegistry`                  | Type       | Registry map                                                                     |
+| `FieldComponentProps`                | Interface  | Props contract for field components                                              |
+| `ResponseItem`                       | Interface  | `{ id, text, answer }` — one per answerable field, returned by `hydrateResponse` |
+| `FieldNode`                          | Interface  | Node in normalized definition tree                                               |
+| `OptionBearingFieldDefinition`       | Type       | Union of field definitions that have `options`                                   |
+| `NormalizedDefinition`               | Interface  | Flat normalized representation of a form                                         |
+| `AddFieldOptions`                    | Interface  | Options for `FormStore.addField()`                                               |
+| `TextFieldDefinition`                | Interface  | Definition for text fields                                                       |
+| `LongtextFieldDefinition`            | Interface  | Definition for longtext fields                                                   |
+| `MultitextFieldDefinition`           | Interface  | Definition for multitext fields                                                  |
+| `RadioFieldDefinition`               | Interface  | Definition for radio fields                                                      |
+| `CheckFieldDefinition`               | Interface  | Definition for check fields                                                      |
+| `BooleanFieldDefinition`             | Interface  | Definition for boolean fields                                                    |
+| `DropdownFieldDefinition`            | Interface  | Definition for dropdown fields                                                   |
+| `MultiselectDropdownFieldDefinition` | Interface  | Definition for multiselect dropdown fields                                       |
+| `RatingFieldDefinition`              | Interface  | Definition for rating fields                                                     |
+| `RankingFieldDefinition`             | Interface  | Definition for ranking fields                                                    |
+| `SliderFieldDefinition`              | Interface  | Definition for slider fields                                                     |
+| `SingleMatrixFieldDefinition`        | Interface  | Definition for single-select matrix fields                                       |
+| `MultiMatrixFieldDefinition`         | Interface  | Definition for multi-select matrix fields                                        |
+| `ImageFieldDefinition`               | Interface  | Definition for image fields                                                      |
+| `HtmlFieldDefinition`                | Interface  | Definition for HTML fields                                                       |
+| `SignatureFieldDefinition`           | Interface  | Definition for signature fields                                                  |
+| `DiagramFieldDefinition`             | Interface  | Definition for diagram fields                                                    |
+| `DisplayFieldDefinition`             | Interface  | Definition for display fields                                                    |
+| `SectionFieldDefinition`             | Interface  | Definition for section fields                                                    |
+
+### Type Predicates
+
+| Export       | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `hasOptions` | Type predicate for fields with `options` property |
 
 ### Constants
 
 | Export                | Description                        |
 | --------------------- | ---------------------------------- |
-| `SCHEMA_TYPE`         | `'mieforms-v1.0'`                  |
 | `FIELD_TYPES`         | Array of 19 field type strings     |
 | `TEXT_INPUT_TYPES`    | Array of 9 text input type strings |
 | `CONDITION_OPERATORS` | Array of 10 operator strings       |
@@ -78,15 +103,16 @@ Quick reference of all public exports from each eSheet package.
 
 ### Utilities
 
-| Export                                   | Description                                                                          |
-| ---------------------------------------- | ------------------------------------------------------------------------------------ |
-| `normalizeDefinition(def)`               | Convert tree → flat normalized state                                                 |
-| `hydrateDefinition(normalized)`          | Convert flat → nested tree                                                           |
-| `hydrateResponse(normalized, responses)` | Walk normalized definition and return `HydratedResponseItem[]` for export/submission |
-| `generateFieldId(fieldType)`             | Generate a unique field ID                                                           |
-| `generateOptionId()`                     | Generate a unique option ID                                                          |
-| `generateRowId()`                        | Generate a unique matrix row ID                                                      |
-| `generateColumnId()`                     | Generate a unique matrix column ID                                                   |
+| Export                                   | Description                                                                  |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `normalizeDefinition(def)`               | Convert tree → flat normalized state                                         |
+| `hydrateDefinition(normalized)`          | Convert flat → nested tree                                                   |
+| `hydrateResponse(normalized, responses)` | Walk normalized definition and return `ResponseItem[]` for export/submission |
+| `generateFieldId(fieldType)`             | Generate a unique field ID                                                   |
+| `generateOptionId()`                     | Generate a unique option ID                                                  |
+| `generateRowId()`                        | Generate a unique matrix row ID                                              |
+| `generateColumnId()`                     | Generate a unique matrix column ID                                           |
+| `formatZodValidationError(error)`        | Format Zod validation errors into readable strings                           |
 
 ### Registry
 
@@ -96,7 +122,6 @@ Quick reference of all public exports from each eSheet package.
 | `registerFieldElements(elements)` | Batch-register UI element classes for field types |
 | `getFieldTypeMeta(key)`           | Get field type metadata                           |
 | `getRegisteredFieldTypes()`       | List all registered types                         |
-| `resetFieldTypeRegistry()`        | Reset to built-in types                           |
 
 ---
 
@@ -137,13 +162,12 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 
 ### Registry
 
-| Export                            | Description                                       |
-| --------------------------------- | ------------------------------------------------- |
-| `registerCustomFieldTypes(types)` | Register custom field types with components       |
-| `registerFieldComponents(map)`    | Register a map of field type -> React component   |
-| `getFieldComponent(fieldType)`    | Get the React component for a field type          |
-| `getRegisteredComponentKeys()`    | List all registered field component keys          |
-| `resetComponentRegistry()`        | Reset the component registry to built-in defaults |
+| Export                            | Description                                     |
+| --------------------------------- | ----------------------------------------------- |
+| `registerCustomFieldTypes(types)` | Register custom field types with components     |
+| `registerFieldComponents(map)`    | Register a map of field type -> React component |
+| `getFieldComponent(fieldType)`    | Get the React component for a field type        |
+| `getRegisteredComponentKeys()`    | List all registered field component keys        |
 
 ### Context
 
@@ -169,23 +193,40 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 
 ### Hooks & Context
 
-| Export              | Description                   |
-| ------------------- | ----------------------------- |
-| `useFormStore()`    | Access FormStore from context |
-| `useUI()`           | Access UIStore from context   |
-| `useInstanceId()`   | Get unique instance ID        |
-| `FormStoreContext`  | FormStore React context       |
-| `UIContext`         | UIStore React context         |
-| `InstanceIdContext` | Instance ID React context     |
+| Export                | Description                           |
+| --------------------- | ------------------------------------- |
+| `useFormStore()`      | Access FormStore from context         |
+| `useUI()`             | Access UIStore from context           |
+| `useInstanceId()`     | Get unique instance ID                |
+| `FormStoreContext`    | FormStore React context               |
+| `UIContext`           | UIStore React context                 |
+| `InstanceIdContext`   | Instance ID React context             |
+| `useFormApi()`        | Hook returning imperative form API    |
+| `useUiApi()`          | Hook returning imperative UI API      |
+| `useVisibleRootIds()` | Hook returning visible root field IDs |
+
+### MCP Integration
+
+| Export                     | Description                               |
+| -------------------------- | ----------------------------------------- |
+| `executeToolCall`          | Execute a builder tool call               |
+| `BUILDER_TOOL_DEFINITIONS` | Array of MCP tool definitions for builder |
+| `BUILDER_SYSTEM_PROMPT`    | System prompt describing builder tools    |
+| `useBuilderMcpToolHandler` | Hook for handling MCP tool calls in React |
 
 ### Types
 
-| Export                    | Description                                    |
-| ------------------------- | ---------------------------------------------- |
-| `EsheetBuilderProps`      | Builder component props                        |
-| `CodeViewProps`           | Props for `CodeView`                           |
-| `FieldWrapperProps`       | Props for `FieldWrapper`                       |
-| `FieldWrapperRenderProps` | Render props passed to `FieldWrapper` children |
+| Export                            | Description                                    |
+| --------------------------------- | ---------------------------------------------- |
+| `EsheetBuilderProps`              | Builder component props                        |
+| `CodeViewProps`                   | Props for `CodeView`                           |
+| `FieldWrapperProps`               | Props for `FieldWrapper`                       |
+| `FieldWrapperRenderProps`         | Render props passed to `FieldWrapper` children |
+| `FormApi`                         | Imperative form API interface                  |
+| `FieldResponseMap`                | Map of field IDs to responses                  |
+| `UiApi`                           | Imperative UI API interface                    |
+| `ToolDefinition`                  | MCP tool definition type                       |
+| `UseBuilderMcpToolHandlerOptions` | Options for `useBuilderMcpToolHandler`         |
 
 ---
 
@@ -205,12 +246,34 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 | ------------------- | --------------------------------------------- |
 | `useRendererInit()` | Initialize renderer with form data (advanced) |
 
+### MCP Integration
+
+| Export                      | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `executeToolCall`           | Execute a renderer tool call               |
+| `RENDERER_TOOL_DEFINITIONS` | Array of MCP tool definitions for renderer |
+| `RENDERER_SYSTEM_PROMPT`    | System prompt describing renderer tools    |
+| `useRendererMcpToolHandler` | Hook for handling MCP tool calls in React  |
+
 ### Types
 
-| Export                 | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| `EsheetRendererProps`  | Renderer component props                                      |
-| `EsheetRendererHandle` | Ref handle type (`getResponse`, `getFormStore`, `getUIStore`) |
+| Export                             | Description                                                      |
+| ---------------------------------- | ---------------------------------------------------------------- |
+| `EsheetRendererProps`              | Renderer component props                                         |
+| `EsheetRendererHandle`             | Ref handle type (`getRawResponse`, `getFormStore`, `getUIStore`) |
+| `RendererTools`                    | Type for renderer MCP tool names                                 |
+| `ToolDefinition`                   | MCP tool definition type                                         |
+| `UseRendererMcpToolHandlerOptions` | Options for `useRendererMcpToolHandler`                          |
+
+### EsheetRendererProps
+
+| Prop                   | Type                | Default | Description                             |
+| ---------------------- | ------------------- | ------- | --------------------------------------- |
+| `definition`           | `FormDefinition`    | --      | Form definition to render               |
+| `responses`            | `FormResponse`      | `{}`    | Initial response values                 |
+| `strict`               | `boolean`           | `false` | Enable strict validation mode           |
+| `onReady`              | `() => void`        | --      | Called when renderer is initialized     |
+| `onRendererToolsReady` | `(handler) => void` | --      | Called with MCP tool handler when ready |
 
 ---
 
@@ -239,3 +302,15 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 | `registerBlazeTemplate(templateName?)` | Register a Blaze template wrapper for the renderer. Returns `false` when required Blaze globals are not available, otherwise `true`. |
 
 `registerBlazeTemplate` uses `esheetRenderer` as the default template name when no argument is provided.
+
+---
+
+## @esheet/adapters
+
+Bidirectional converters for SurveyJS and MCP elicitation formats.
+
+See the **[Adapters](/docs/adapters/overview)** section in the sidebar for detailed documentation including:
+
+- [Adapters Overview](/docs/adapters/overview) — Installation, auto-detection, and all exports
+- [SurveyJS Adapter](/docs/adapters/surveyjs) — Import/export, type mapping, conditional logic
+- [MCP Adapter](/docs/adapters/mcp) — Import/export, constraints, type mapping

--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -257,24 +257,24 @@ All 19 field components: `TextField`, `LongTextField`, `MultiTextField`, `RadioF
 
 ### Types
 
-| Export                             | Description                                                      |
-| ---------------------------------- | ---------------------------------------------------------------- |
-| `EsheetRendererProps`              | Renderer component props                                         |
+| Export                             | Description                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| `EsheetRendererProps`              | Renderer component props                                                             |
 | `EsheetRendererHandle`             | Ref handle type (`getRawResponse`, `getValidResponse`, `getFormStore`, `getUIStore`) |
-| `RendererTools`                    | Type for renderer MCP tool names                                 |
-| `ToolDefinition`                   | MCP tool definition type                                         |
-| `UseRendererMcpToolHandlerOptions` | Options for `useRendererMcpToolHandler`                          |
+| `RendererTools`                    | Type for renderer MCP tool names                                                     |
+| `ToolDefinition`                   | MCP tool definition type                                                             |
+| `UseRendererMcpToolHandlerOptions` | Options for `useRendererMcpToolHandler`                                              |
 
 ### EsheetRendererProps
 
-| Prop                   | Type                                    | Default    | Description                                                                        |
-| ---------------------- | --------------------------------------- | ---------- | ---------------------------------------------------------------------------------- |
-| `formDataInput`        | `unknown`                               | _required_ | Form definition (object, JSON string, YAML string, MCP, SurveyJS)                 |
-| `className`            | `string`                                | `''`        | Additional CSS class for the root container                                        |
-| `initialResponses`     | `FormResponse`                          | --         | Pre-fill response data                                                             |
-| `strict`               | `boolean`                               | `false`    | Disable auto-detection, require a valid FormDefinition                             |
-| `onReady`              | `() => void`                            | --         | Called when the renderer is initialized                                            |
-| `onRendererToolsReady` | `(tools: RendererTools) => void`        | --         | Called with MCP tool handler when ready                                            |
+| Prop                   | Type                             | Default    | Description                                                       |
+| ---------------------- | -------------------------------- | ---------- | ----------------------------------------------------------------- |
+| `formDataInput`        | `unknown`                        | _required_ | Form definition (object, JSON string, YAML string, MCP, SurveyJS) |
+| `className`            | `string`                         | `''`       | Additional CSS class for the root container                       |
+| `initialResponses`     | `FormResponse`                   | --         | Pre-fill response data                                            |
+| `strict`               | `boolean`                        | `false`    | Disable auto-detection, require a valid FormDefinition            |
+| `onReady`              | `() => void`                     | --         | Called when the renderer is initialized                           |
+| `onRendererToolsReady` | `(tools: RendererTools) => void` | --         | Called with MCP tool handler when ready                           |
 
 ---
 

--- a/apps/docs/docs/builder/code-view.md
+++ b/apps/docs/docs/builder/code-view.md
@@ -30,7 +30,7 @@ You can paste a complete JSON form definition into Code View:
 
 ```json
 {
-  "schemaType": "mieforms-v1.0",
+  "id": "my-form",
   "title": "My Form",
   "fields": [
     {

--- a/apps/docs/docs/builder/exporting.md
+++ b/apps/docs/docs/builder/exporting.md
@@ -29,7 +29,7 @@ The exported `FormDefinition` contains only structural data:
 
 ```json
 {
-  "schemaType": "mieforms-v1.0",
+  "id": "my-form",
   "title": "My Form",
   "description": "Optional description",
   "fields": [
@@ -46,7 +46,7 @@ The exported `FormDefinition` contains only structural data:
 
 **What's included:**
 
-- Schema version
+- Form identifier (id)
 - Form title and description
 - All field definitions with their properties
 - Conditional rules

--- a/apps/docs/docs/conditional-logic.md
+++ b/apps/docs/docs/conditional-logic.md
@@ -102,6 +102,82 @@ Access a specific property of the target field's response before comparing:
 }
 ```
 
+## Expression Syntax Reference
+
+Expression conditions (`conditionType: 'expression'`) support a JavaScript-like syntax for complex logic.
+
+### Field References
+
+Use `{fieldId}` to reference a field's answer value:
+
+```json
+{
+  "conditionType": "expression",
+  "expression": "{weight} > 100"
+}
+```
+
+### Property Accessors in Expressions
+
+Access properties on field values:
+
+- `{fieldId}.length` — Length of text or array
+- `{fieldId}.count` — Number of selected items (alias for length)
+
+```json
+{
+  "conditionType": "expression",
+  "expression": "{symptoms}.length >= 3"
+}
+```
+
+### Supported Operators
+
+| Category        | Operators                        | Example                            |
+| --------------- | -------------------------------- | ---------------------------------- |
+| Comparison      | `==`, `!=`, `>`, `>=`, `<`, `<=` | `{age} >= 18`                      |
+| Strict equality | `===`, `!==`                     | `{status} === "active"`            |
+| Logical         | `&&`, `\|\|`                     | `{a} > 0 && {b} > 0`               |
+| Negation        | `!`                              | `!{hasAllergies}`                  |
+| Arithmetic      | `+`, `-`, `*`, `/`, `%`          | `{weight} / ({height} * {height})` |
+| Grouping        | `()`                             | `({a} + {b}) * 2`                  |
+
+### Literal Values
+
+- Numbers: `123`, `3.14`, `-5`
+- Strings: `"text"` or `'text'`
+- Booleans: `true`, `false`
+- Null: `null`
+
+### Complex Expression Examples
+
+**BMI calculation check:**
+
+```json
+{
+  "conditionType": "expression",
+  "expression": "{weight} / (({height}/100) * ({height}/100)) > 25"
+}
+```
+
+**Multiple field check:**
+
+```json
+{
+  "conditionType": "expression",
+  "expression": "{field1} > 0 && {field2} > 0 && {field3} != null"
+}
+```
+
+**String comparison:**
+
+```json
+{
+  "conditionType": "expression",
+  "expression": "{status} == 'approved' || {override} == true"
+}
+```
+
 ## Examples
 
 ### Show a field when a specific option is selected

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -19,6 +19,7 @@ Choose the scenario that matches your app:
 | React builder + renderer | `npm install @esheet/builder @esheet/renderer react react-dom` | `@esheet/core` only for direct core APIs/types                                                          |
 | Standalone renderer      | `npm install @esheet/renderer-standalone`                      | `@esheet/core` only if importing core types/APIs directly in host app code                              |
 | Blaze renderer           | `npm install @esheet/renderer-blaze`                           | `@esheet/core` only if importing core types/APIs directly in host app code                              |
+| Schema adapters          | `npm install @esheet/adapters`                                 | `@esheet/core` only if importing core types directly; typically used with renderer or builder           |
 
 :::info
 `@esheet/renderer` and `@esheet/builder` include `@esheet/core` and `@esheet/fields` transitively — no need to install them separately unless your app imports them directly.
@@ -74,6 +75,14 @@ console.log(mountStandaloneRenderer);
 import { registerBlazeTemplate } from '@esheet/renderer-blaze';
 
 console.log(registerBlazeTemplate);
+```
+
+### Schema adapters
+
+```ts
+import { importFromSurveyJS, importFromMcp } from '@esheet/adapters';
+
+console.log(importFromSurveyJS, importFromMcp);
 ```
 
 ## Next Steps

--- a/apps/docs/docs/getting-started/quickstart-builder.md
+++ b/apps/docs/docs/getting-started/quickstart-builder.md
@@ -44,7 +44,7 @@ import { EsheetBuilder } from '@esheet/builder';
 import type { FormDefinition } from '@esheet/core';
 
 const initialForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'patient-intake',
   title: 'Patient Intake',
   description: 'Basic patient information form',
   fields: [
@@ -88,13 +88,14 @@ function App() {
 
 ## Props
 
-| Prop          | Type                            | Default     | Description                       |
-| ------------- | ------------------------------- | ----------- | --------------------------------- |
-| `definition`  | `FormDefinition`                | `undefined` | Initial form definition to load   |
-| `onChange`    | `(def: FormDefinition) => void` | --          | Called when the form changes      |
-| `dragEnabled` | `boolean`                       | `true`      | Enable drag-and-drop reordering   |
-| `className`   | `string`                        | `''`        | Additional CSS class              |
-| `children`    | `ReactNode`                     | --          | Content rendered below the header |
+| Prop                  | Type                            | Default     | Description                             |
+| --------------------- | ------------------------------- | ----------- | --------------------------------------- |
+| `definition`          | `FormDefinition`                | `undefined` | Initial form definition to load         |
+| `onChange`            | `(def: FormDefinition) => void` | --          | Called when the form changes            |
+| `dragEnabled`         | `boolean`                       | `true`      | Enable drag-and-drop reordering         |
+| `className`           | `string`                        | `''`        | Additional CSS class                    |
+| `children`            | `ReactNode`                     | --          | Content rendered below the header       |
+| `onBuilderToolsReady` | `(handler) => void`             | --          | Called with MCP tool handler when ready |
 
 ## Builder Modes
 

--- a/apps/docs/docs/getting-started/quickstart-renderer.md
+++ b/apps/docs/docs/getting-started/quickstart-renderer.md
@@ -59,8 +59,15 @@ function App() {
   const rendererRef = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = rendererRef.current?.getRawResponse();
-    console.log('Form responses:', responses);
+    const result = rendererRef.current?.getValidResponse();
+    if (!result) return;
+
+    if (result.errors.length > 0) {
+      console.log('Validation errors:', result.errors);
+      return;
+    }
+
+    console.log('Valid form responses:', result.response);
   };
 
   return (
@@ -145,11 +152,12 @@ The renderer accepts form definitions as objects, JSON strings, or YAML strings:
 
 ## Ref API (`EsheetRendererHandle`)
 
-| Method             | Returns        | Description                            |
-| ------------------ | -------------- | -------------------------------------- |
-| `getRawResponse()` | `FormResponse` | Current response values for all fields |
-| `getFormStore()`   | `FormStore`    | The underlying form state store        |
-| `getUIStore()`     | `UIStore`      | The underlying UI state store          |
+| Method               | Returns                                                         | Description                            |
+| -------------------- | --------------------------------------------------------------- | -------------------------------------- |
+| `getRawResponse()`   | `FormResponse`                                                  | Current response values for all fields |
+| `getValidResponse()` | `{ response: FormResponse \| null, errors: ValidationError[] }` | Validate + get responses               |
+| `getFormStore()`     | `FormStore`                                                     | The underlying form state store        |
+| `getUIStore()`       | `UIStore`                                                       | The underlying UI state store          |
 
 ## What's Next
 

--- a/apps/docs/docs/getting-started/quickstart-renderer.md
+++ b/apps/docs/docs/getting-started/quickstart-renderer.md
@@ -25,7 +25,7 @@ import type { EsheetRendererHandle } from '@esheet/renderer';
 import type { FormDefinition } from '@esheet/core';
 
 const myForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'feedback-survey',
   title: 'Feedback Survey',
   fields: [
     {
@@ -59,13 +59,13 @@ function App() {
   const rendererRef = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = rendererRef.current?.getResponse();
+    const responses = rendererRef.current?.getRawResponse();
     console.log('Form responses:', responses);
   };
 
   return (
     <div>
-      <EsheetRenderer ref={rendererRef} formData={myForm} />
+      <EsheetRenderer ref={rendererRef} formDataInput={myForm} />
       <button onClick={handleSubmit}>Submit</button>
     </div>
   );
@@ -80,7 +80,7 @@ The renderer exposes an imperative API via `ref`:
 const ref = useRef<EsheetRendererHandle>(null);
 
 // Get all responses
-const responses = ref.current?.getResponse();
+const responses = ref.current?.getRawResponse();
 // => { name: { answer: 'John' }, rating: { selected: { id: 'r4', value: '4' } }, ... }
 
 // Access the underlying stores (advanced)
@@ -114,7 +114,7 @@ Pass `initialResponses` to pre-populate the form:
 ```tsx
 <EsheetRenderer
   ref={rendererRef}
-  formData={myForm}
+  formDataInput={myForm}
   initialResponses={{
     name: { answer: 'Jane Doe' },
     rating: { selected: { id: 'r4', value: '4' } },
@@ -128,28 +128,28 @@ The renderer accepts form definitions as objects, JSON strings, or YAML strings:
 
 ```tsx
 // JSON string
-<EsheetRenderer formData='{"schemaType":"mieforms-v1.0","fields":[...]}' />
+<EsheetRenderer formDataInput='{"id":"my-form","fields":[...]}' />
 
 // YAML string
-<EsheetRenderer formData={yamlString} />
+<EsheetRenderer formDataInput={yamlString} />
 ```
 
 ## Props
 
 | Prop               | Type                        | Default    | Description                               |
 | ------------------ | --------------------------- | ---------- | ----------------------------------------- |
-| `formData`         | `FormDefinition \| string`  | _required_ | Form definition (object, JSON, or YAML)   |
+| `formDataInput`    | `FormDefinition \| string`  | _required_ | Form definition (object, JSON, or YAML)   |
 | `className`        | `string`                    | `''`       | Additional CSS class for the root         |
 | `initialResponses` | `FormResponse`              | --         | Pre-fill response data                    |
 | `ref`              | `Ref<EsheetRendererHandle>` | --         | Imperative handle for response collection |
 
 ## Ref API (`EsheetRendererHandle`)
 
-| Method           | Returns        | Description                            |
-| ---------------- | -------------- | -------------------------------------- |
-| `getResponse()`  | `FormResponse` | Current response values for all fields |
-| `getFormStore()` | `FormStore`    | The underlying form state store        |
-| `getUIStore()`   | `UIStore`      | The underlying UI state store          |
+| Method             | Returns        | Description                            |
+| ------------------ | -------------- | -------------------------------------- |
+| `getRawResponse()` | `FormResponse` | Current response values for all fields |
+| `getFormStore()`   | `FormStore`    | The underlying form state store        |
+| `getUIStore()`     | `UIStore`      | The underlying UI state store          |
 
 ## What's Next
 

--- a/apps/docs/docs/getting-started/quickstart-standalone.md
+++ b/apps/docs/docs/getting-started/quickstart-standalone.md
@@ -37,7 +37,7 @@ const mountElement = document.getElementById('renderer-mount');
 
 if (mountElement) {
   const standalone = mountStandaloneRenderer(mountElement, {
-    formData: demoForm,
+    formDataInput: demoForm,
   });
 
   console.log('Current response:', standalone.getResponse());

--- a/apps/docs/docs/getting-started/quickstart-standalone.md
+++ b/apps/docs/docs/getting-started/quickstart-standalone.md
@@ -21,7 +21,7 @@ import { mountStandaloneRenderer } from '@esheet/renderer-standalone';
 import type { FormDefinition } from '@esheet/core';
 
 const demoForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'standalone-demo',
   title: 'Standalone Renderer Demo',
   fields: [
     {

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -9,7 +9,7 @@ slug: /intro
 
 ## 📦 Package Overview
 
-eSheet is organized as six focused, composable packages:
+eSheet is organized as seven focused, composable packages:
 
 ### ⚙️ @esheet/core
 
@@ -48,6 +48,15 @@ Lightweight form renderer for end-users. Perfect for surveys, questionnaires, an
 - Conditional logic evaluation and field visibility control
 - Response collection via API
 - Pre-fill support for partial responses
+
+### 🔌 @esheet/adapters
+
+Schema conversion utilities for interoperability with external systems:
+
+- Import/export SurveyJS schemas
+- Import/export MCP (Model Context Protocol) elicitation requests
+- System prompts for AI-assisted conversions
+- Auto-detection of schema formats
 
 ### 🧩 @esheet/renderer-standalone
 
@@ -96,6 +105,7 @@ Choose the scenario that matches your app:
 | React builder + renderer | `npm install @esheet/builder @esheet/renderer react react-dom` | `@esheet/core` only for direct core APIs/types                                                          |
 | Standalone renderer      | `npm install @esheet/renderer-standalone`                      | `@esheet/core` only if importing core types/APIs directly in host app code                              |
 | Blaze renderer           | `npm install @esheet/renderer-blaze`                           | `@esheet/core` only if importing core types/APIs directly in host app code                              |
+| Schema adapters          | `npm install @esheet/adapters`                                 | `@esheet/core` only if importing core types directly; typically used with renderer or builder           |
 
 `@esheet/renderer` and `@esheet/builder` include `@esheet/core` and `@esheet/fields` transitively — no need to install them separately for normal usage. Install them directly only when your app imports them directly.
 
@@ -108,6 +118,7 @@ Choose the scenario that matches your app:
 - ✏️ [Builder Quick Start](./getting-started/quickstart-builder)
 - 🧩 [Standalone Quick Start](./getting-started/quickstart-standalone)
 - 🔥 [Blaze Quick Start](./getting-started/quickstart-blaze)
-- 📋 [Schema Format](./schema-format)
+- � [Schema Adapters](./adapters)
+- �📋 [Schema Format](./schema-format)
 - 🧩 [Field Types](./field-types)
 - 🔀 [Conditional Logic](./conditional-logic)

--- a/apps/docs/docs/renderer/overview.md
+++ b/apps/docs/docs/renderer/overview.md
@@ -31,13 +31,13 @@ function SurveyPage() {
   const ref = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = ref.current?.getResponse();
+    const responses = ref.current?.getRawResponse();
     // Send responses to your API
   };
 
   return (
     <div>
-      <EsheetRenderer ref={ref} formData={formDefinition} />
+      <EsheetRenderer ref={ref} formDataInput={formDefinition} />
       <button onClick={handleSubmit}>Submit</button>
     </div>
   );
@@ -48,18 +48,18 @@ function SurveyPage() {
 
 | Prop               | Type                        | Default    | Description                                                         |
 | ------------------ | --------------------------- | ---------- | ------------------------------------------------------------------- |
-| `formData`         | `FormDefinition \| string`  | _required_ | Form definition as a JavaScript object, JSON string, or YAML string |
+| `formDataInput`    | `FormDefinition \| string`  | _required_ | Form definition as a JavaScript object, JSON string, or YAML string |
 | `className`        | `string`                    | `''`       | Additional CSS class for the root container                         |
 | `initialResponses` | `FormResponse`              | --         | Pre-fill the form with existing response data                       |
 | `ref`              | `Ref<EsheetRendererHandle>` | --         | Imperative handle for accessing responses and stores                |
 
 ## Ref API (`EsheetRendererHandle`)
 
-| Method           | Returns        | Description                                    |
-| ---------------- | -------------- | ---------------------------------------------- |
-| `getResponse()`  | `FormResponse` | Get current response values for all fields     |
-| `getFormStore()` | `FormStore`    | Get the underlying form state store (advanced) |
-| `getUIStore()`   | `UIStore`      | Get the underlying UI state store (advanced)   |
+| Method             | Returns        | Description                                    |
+| ------------------ | -------------- | ---------------------------------------------- |
+| `getRawResponse()` | `FormResponse` | Get current response values for all fields     |
+| `getFormStore()`   | `FormStore`    | Get the underlying form state store (advanced) |
+| `getUIStore()`     | `UIStore`      | Get the underlying UI state store (advanced)   |
 
 ## Features
 
@@ -77,13 +77,13 @@ The `formData` prop accepts three formats:
 
 ```tsx
 // 1. JavaScript object
-<EsheetRenderer formData={formDefinitionObject} />
+<EsheetRenderer formDataInput={formDefinitionObject} />
 
 // 2. JSON string
-<EsheetRenderer formData='{"schemaType":"mieforms-v1.0","fields":[...]}' />
+<EsheetRenderer formDataInput='{"id":"my-form","fields":[...]}' />
 
 // 3. YAML string
-<EsheetRenderer formData={yamlString} />
+<EsheetRenderer formDataInput={yamlString} />
 ```
 
 The renderer auto-detects the format and parses accordingly.

--- a/apps/docs/docs/renderer/overview.md
+++ b/apps/docs/docs/renderer/overview.md
@@ -31,8 +31,13 @@ function SurveyPage() {
   const ref = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = ref.current?.getRawResponse();
-    // Send responses to your API
+    const result = ref.current?.getValidResponse();
+    if (!result) return;
+    if (result.errors.length > 0) {
+      // show errors to user
+      return;
+    }
+    // Send result.response to your API
   };
 
   return (
@@ -55,11 +60,12 @@ function SurveyPage() {
 
 ## Ref API (`EsheetRendererHandle`)
 
-| Method             | Returns        | Description                                    |
-| ------------------ | -------------- | ---------------------------------------------- |
-| `getRawResponse()` | `FormResponse` | Get current response values for all fields     |
-| `getFormStore()`   | `FormStore`    | Get the underlying form state store (advanced) |
-| `getUIStore()`     | `UIStore`      | Get the underlying UI state store (advanced)   |
+| Method               | Returns                                                         | Description                                    |
+| -------------------- | --------------------------------------------------------------- | ---------------------------------------------- |
+| `getRawResponse()`   | `FormResponse`                                                  | Get current response values for all fields     |
+| `getValidResponse()` | `{ response: FormResponse \| null, errors: ValidationError[] }` | Validate + get responses                       |
+| `getFormStore()`     | `FormStore`                                                     | Get the underlying form state store (advanced) |
+| `getUIStore()`       | `UIStore`                                                       | Get the underlying UI state store (advanced)   |
 
 ## Features
 

--- a/apps/docs/docs/renderer/responses.md
+++ b/apps/docs/docs/renderer/responses.md
@@ -21,7 +21,7 @@ function MyForm() {
   const ref = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = ref.current?.getResponse();
+    const responses = ref.current?.getRawResponse();
     if (!responses) return;
 
     // responses is Record<string, FieldResponse>
@@ -30,7 +30,7 @@ function MyForm() {
 
   return (
     <>
-      <EsheetRenderer ref={ref} formData={myForm} />
+      <EsheetRenderer ref={ref} formDataInput={myForm} />
       <button onClick={handleSubmit}>Submit</button>
     </>
   );
@@ -98,7 +98,7 @@ const existingResponses = {
 
 <EsheetRenderer
   ref={ref}
-  formData={myForm}
+  formDataInput={myForm}
   initialResponses={existingResponses}
 />;
 ```

--- a/apps/docs/docs/renderer/responses.md
+++ b/apps/docs/docs/renderer/responses.md
@@ -21,11 +21,13 @@ function MyForm() {
   const ref = useRef<EsheetRendererHandle>(null);
 
   const handleSubmit = () => {
-    const responses = ref.current?.getRawResponse();
-    if (!responses) return;
-
-    // responses is Record<string, FieldResponse>
-    console.log(responses);
+    const result = ref.current?.getValidResponse();
+    if (!result) return;
+    if (result.errors.length > 0) {
+      console.log('Validation errors:', result.errors);
+      return;
+    }
+    console.log('Valid responses:', result.response);
   };
 
   return (
@@ -147,5 +149,5 @@ const isRequired = state.isRequired('field_id');
 ```
 
 :::warning
-Direct store access is an advanced API. The store's internal structure may change between versions. Prefer using `getResponse()` for standard response collection.
+Direct store access is an advanced API. The store's internal structure may change between versions. Prefer using `getRawResponse()` (or `getValidResponse()` for validated submission) for standard response collection.
 :::

--- a/apps/docs/docs/renderer/validation.md
+++ b/apps/docs/docs/renderer/validation.md
@@ -29,7 +29,7 @@ const handleSubmit = () => {
   }
 
   // Form is valid -- proceed with submission
-  const responses = ref.current.getResponse();
+  const responses = ref.current.getRawResponse();
   submitToServer(responses);
 };
 ```
@@ -110,13 +110,13 @@ function ValidatedForm({ formData }) {
     }
 
     setErrors([]);
-    const responses = ref.current.getResponse();
+    const responses = ref.current.getRawResponse();
     // Submit responses...
   };
 
   return (
     <div>
-      <EsheetRenderer ref={ref} formData={formData} />
+      <EsheetRenderer ref={ref} formDataInput={formData} />
       {errors.length > 0 && (
         <div style={{ color: 'red', margin: '1rem 0' }}>
           <p>Please fix the following errors:</p>

--- a/apps/docs/docs/renderer/validation.md
+++ b/apps/docs/docs/renderer/validation.md
@@ -18,19 +18,15 @@ import { validateForm, validateField } from '@esheet/core';
 
 ```tsx
 const handleSubmit = () => {
-  const formStore = ref.current?.getFormStore();
-  if (!formStore) return;
+  const result = ref.current?.getValidResponse();
+  if (!result) return;
 
-  const errors = formStore.getState().getErrors();
-
-  if (errors.length > 0) {
-    console.log('Validation errors:', errors);
+  if (result.errors.length > 0) {
+    console.log('Validation errors:', result.errors);
     return;
   }
 
-  // Form is valid -- proceed with submission
-  const responses = ref.current.getRawResponse();
-  submitToServer(responses);
+  submitToServer(result.response!);
 };
 ```
 
@@ -72,7 +68,11 @@ This means users are never blocked by fields they can't see or interact with.
 Validation errors are returned as an array:
 
 ```typescript
-interface FieldError {
+// Import from @esheet/renderer or @esheet/core:
+import type { ValidationError } from '@esheet/renderer';
+
+// Shape:
+interface ValidationError {
   fieldId: string;
   message: string;
 }
@@ -99,18 +99,16 @@ function ValidatedForm({ formData }) {
   const [errors, setErrors] = useState([]);
 
   const handleSubmit = () => {
-    const formStore = ref.current?.getFormStore();
-    if (!formStore) return;
+    const result = ref.current?.getValidResponse();
+    if (!result) return;
 
-    const validationErrors = formStore.getState().getErrors();
-
-    if (validationErrors.length > 0) {
-      setErrors(validationErrors);
+    if (result.errors.length > 0) {
+      setErrors(result.errors);
       return;
     }
 
     setErrors([]);
-    const responses = ref.current.getRawResponse();
+    submitToServer(result.response!);
     // Submit responses...
   };
 

--- a/apps/docs/docs/schema-format.md
+++ b/apps/docs/docs/schema-format.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Schema Format
 
-eSheet uses a JSON schema format identified by `schemaType: 'mieforms-v1.0'`. This page documents the complete structure.
+eSheet uses a JSON schema format identified by the `id` field. This page documents the complete structure.
 
 ## Form Definition
 
@@ -12,8 +12,8 @@ The top-level object that describes an entire form:
 
 ```typescript
 interface FormDefinition {
-  /** Schema version -- always 'mieforms-v1.0' */
-  schemaType: 'mieforms-v1.0';
+  /** Unique form identifier */
+  id: string;
   /** Optional form title */
   title?: string;
   /** Optional form description */
@@ -27,7 +27,7 @@ interface FormDefinition {
 
 ```json
 {
-  "schemaType": "mieforms-v1.0",
+  "id": "patient-intake-form",
   "title": "Patient Intake Form",
   "description": "Please fill out all required fields",
   "fields": [

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -37,11 +37,17 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Adapters',
+      items: ['adapters/overview', 'adapters/surveyjs', 'adapters/mcp'],
+    },
+    {
+      type: 'category',
       label: 'Advanced',
       items: [
         'advanced/custom-field-types',
         'advanced/store-architecture',
         'advanced/expression-system',
+        'advanced/mcp-integration',
       ],
     },
     'api-reference',

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -4,6 +4,9 @@
 @source "../**/*.{js,jsx,ts,tsx,md,mdx}";
 @source "../../docs/**/*.{md,mdx}";
 
+/* Make Tailwind's dark: variant respond to Docusaurus's data-theme="dark" */
+@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
+
 /* Infima color overrides */
 :root {
   --ifm-navbar-height: 56px;
@@ -96,6 +99,10 @@
   width: auto;
 }
 
+[data-theme='dark'] .navbar__logo img {
+  filter: invert(1);
+}
+
 .theme-layout-navbar-left .navbar__brand {
   margin-left: 0.5rem;
 }
@@ -107,7 +114,17 @@
   color: #475569;
 }
 
+[data-theme='dark'] .navbar__item.navbar__link,
+[data-theme='dark'] .navbar__item.navbar__link--active {
+  color: #94a3b8;
+}
+
 .navbar__item.navbar__link:hover,
 .navbar__item.navbar__link--active:hover {
   color: #2563eb;
+}
+
+[data-theme='dark'] .navbar__item.navbar__link:hover,
+[data-theme='dark'] .navbar__item.navbar__link--active:hover {
+  color: #60a5fa;
 }

--- a/apps/docs/src/pages/index.js
+++ b/apps/docs/src/pages/index.js
@@ -4,21 +4,138 @@ import Layout from '@theme/Layout';
 
 const features = [
   {
+    icon: '🔧',
     title: 'Visual Builder',
     description:
       'Drag and drop field authoring with logic controls, schema editing, and live preview in one flow.',
   },
   {
+    icon: '⚡',
     title: 'Runtime Renderer',
     description:
       'Render dynamic forms with conditional interactions and response capture for production workflows.',
   },
   {
+    icon: '🧩',
     title: 'Extensible Core',
     description:
       'Compose package layers with a TypeScript core and React UI packages for custom field ecosystems.',
   },
 ];
+
+// ─── Shared primitives ───────────────────────────────────────────────────────
+
+function SectionLabel({ children }) {
+  return (
+    <p className="m-0 text-xs font-bold uppercase tracking-[0.14em] text-blue-600 dark:text-blue-400">
+      {children}
+    </p>
+  );
+}
+
+function SectionHeading({ children }) {
+  return (
+    <h2 className="m-0 mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-50 sm:text-4xl">
+      {children}
+    </h2>
+  );
+}
+
+function SectionSubtext({ children }) {
+  return (
+    <p className="mt-4 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-400">
+      {children}
+    </p>
+  );
+}
+
+// ─── Hero code mockup ─────────────────────────────────────────────────────────
+
+function WindowChrome({ label }) {
+  return (
+    <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-50 px-4 py-2.5 dark:border-white/8 dark:bg-[#111113]">
+      <span className="h-2.5 w-2.5 rounded-full bg-red-400/80" />
+      <span className="h-2.5 w-2.5 rounded-full bg-amber-400/80" />
+      <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/80" />
+      <span className="ml-2 text-[11px] font-medium text-slate-400 dark:text-slate-500">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function CodeMockup() {
+  return (
+    <div className="flex flex-col gap-3 lg:max-w-none">
+      {/* Schema window */}
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-md dark:border-white/10 dark:bg-[#2a2a2d]">
+        <WindowChrome label="esheet-schema.json" />
+        <pre className="m-0 overflow-x-auto bg-transparent p-4 text-[12.5px] leading-[1.7]">
+          <code className="font-mono text-slate-600 dark:text-slate-300">
+            {`{
+  "fields": [
+    {
+      "type": "text",
+      "label": "Full Name",
+      "required": true
+    },
+    {
+      "type": "radio",
+      "label": "Status",
+      "options": ["Active", "Inactive"]
+    }
+  ]
+}`}
+          </code>
+        </pre>
+      </div>
+
+      {/* Connector */}
+      <div className="flex items-center gap-3 px-1">
+        <div className="h-px flex-1 bg-slate-200 dark:bg-white/10" />
+        <code className="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-[11px] font-semibold text-blue-700 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-300">
+          {'<EsheetRenderer />'}
+        </code>
+        <div className="h-px flex-1 bg-slate-200 dark:bg-white/10" />
+      </div>
+
+      {/* Preview window */}
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-md dark:border-white/10 dark:bg-[#2a2a2d]">
+        <WindowChrome label="Preview" />
+        <div className="flex flex-col gap-4 p-4">
+          <div>
+            <p className="m-0 mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Full Name <span className="text-red-400">*</span>
+            </p>
+            <div className="h-8 w-full rounded-md border border-slate-200 bg-slate-50 dark:border-white/10 dark:bg-[#1b1b1d]" />
+          </div>
+          <div>
+            <p className="m-0 mb-2 text-[11px] font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              Status
+            </p>
+            <div className="flex gap-5">
+              <span className="flex items-center gap-2 text-xs text-slate-700 dark:text-slate-300">
+                <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 border-blue-600 dark:border-blue-400">
+                  <span className="h-1.5 w-1.5 rounded-full bg-blue-600 dark:bg-blue-400" />
+                </span>
+                Active
+              </span>
+              <span className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+                <span className="h-3.5 w-3.5 shrink-0 rounded-full border-2 border-slate-300 dark:border-slate-600" />
+                Inactive
+              </span>
+            </div>
+          </div>
+          <div className="flex justify-end border-t border-slate-100 pt-3 dark:border-white/5">
+            <span className="rounded-md bg-blue-600 px-4 py-1.5 text-[11px] font-semibold text-white dark:bg-blue-500">
+              Submit
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const quickStarts = [
   {
@@ -81,6 +198,13 @@ const packages = [
     url: 'https://www.npmjs.com/package/@esheet/fields',
   },
   {
+    name: '@esheet/adapters',
+    type: 'Adapters',
+    summary:
+      'Bidirectional converters between eSheet schemas and SurveyJS, MCP, and other formats.',
+    url: 'https://www.npmjs.com/package/@esheet/adapters',
+  },
+  {
     name: '@esheet/renderer-blaze',
     type: 'Runtime',
     summary: 'Blaze template runtime package for form rendering.',
@@ -130,285 +254,109 @@ function resolveDemoUrl(siteConfig) {
   return siteConfig.customFields?.demoUrl || '/demo/';
 }
 
+// ─── Sections ────────────────────────────────────────────────────────────────
+
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
   const demoUrl = resolveDemoUrl(siteConfig);
   return (
-    <header className="relative overflow-hidden bg-gradient-to-b from-sky-50 via-blue-50 to-white text-slate-900 dark:from-sky-50 dark:via-blue-50 dark:to-white dark:text-slate-900">
-      <div className="pointer-events-none absolute inset-0 opacity-60">
-        <div className="absolute -left-24 top-12 h-64 w-64 rounded-full bg-blue-400/20 blur-3xl" />
-        <div className="absolute right-0 top-0 h-72 w-72 rounded-full bg-sky-300/20 blur-3xl" />
-        <div className="absolute bottom-8 right-24 h-40 w-40 rounded-full bg-indigo-300/15 blur-2xl" />
-      </div>
-
-      <div className="relative mx-auto max-w-6xl px-5 pb-16 pt-16 md:pt-20 lg:pb-20">
-        <div className="grid items-end gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+    <header className="bg-white pb-20 pt-16 dark:bg-[#1b1b1d]">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="grid items-center gap-14 lg:grid-cols-2">
+          {/* Left: content */}
           <div>
-            <p className="mb-2 text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-              Documentation
+            <p className="m-0 mb-3 text-xs font-bold uppercase tracking-[0.15em] text-blue-600 dark:text-blue-400">
+              Open Source · TypeScript · React
             </p>
-            <h1 className="m-0 text-5xl font-black leading-[0.95] tracking-[-0.04em] text-slate-950 dark:text-slate-950 sm:text-6xl lg:text-7xl">
+            <h1 className="m-0 text-5xl font-black leading-[1.05] tracking-[-0.04em] text-slate-900 dark:text-slate-50 sm:text-6xl">
               {siteConfig.title}
             </h1>
-            <p className="mt-4 max-w-xl text-xl leading-snug text-slate-700 dark:text-slate-700">
+            <p className="mt-5 text-xl leading-relaxed text-slate-600 dark:text-slate-400">
               {siteConfig.tagline}
             </p>
-            <p className="mt-4 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-600">
-              Build schema-driven forms with modular packages for authoring and
-              runtime rendering.
+            <p className="mt-3 max-w-lg text-base leading-relaxed text-slate-500 dark:text-slate-500">
+              Build schema-driven forms with modular packages for visual
+              authoring and runtime rendering.
             </p>
 
-            <div className="mt-7 flex flex-wrap gap-3">
+            <div className="mt-8 flex flex-wrap items-center gap-3">
               <Link
-                className="inline-flex items-center rounded-full bg-blue-700 px-7 py-3 text-base font-bold text-white no-underline shadow-[0_12px_28px_rgba(29,78,216,0.35)] transition hover:-translate-y-0.5 hover:bg-blue-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-6 py-3 text-sm font-semibold text-white no-underline shadow-sm transition hover:-translate-y-px hover:bg-blue-700 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400"
                 to="/docs/intro"
               >
-                Get Started
+                Get Started{' '}
+                <span aria-hidden="true" className="opacity-70">
+                  →
+                </span>
               </Link>
               <a
-                className="inline-flex items-center rounded-full border border-blue-600/60 bg-blue-100/70 px-7 py-3 text-base font-bold text-blue-800 no-underline backdrop-blur transition hover:-translate-y-0.5 hover:bg-blue-200/80 hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-600/60 dark:bg-blue-100/70 dark:text-blue-800 dark:hover:bg-blue-200/80"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-700 no-underline shadow-sm transition hover:-translate-y-px hover:border-slate-300 hover:text-slate-900 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:border-white/20 dark:hover:bg-white/8 dark:hover:text-slate-100"
                 href={demoUrl}
               >
                 Live Demo
               </a>
             </div>
 
-            <a
-              className="mt-5 inline-block font-semibold text-blue-700 no-underline transition hover:text-blue-800 hover:underline dark:text-blue-700 dark:hover:text-blue-800"
-              href="#docs-packages"
-            >
-              Explore Packages
-            </a>
-
-            <dl className="mt-8 grid gap-3 sm:grid-cols-3">
+            {/* Package trio */}
+            <div className="mt-10 grid grid-cols-3 divide-x divide-slate-200 overflow-hidden rounded-xl border border-slate-200 dark:divide-white/10 dark:border-white/10">
               {[
-                { value: 'Builder', label: 'authoring surface' },
+                { value: 'Builder', label: 'visual authoring' },
                 { value: 'Renderer', label: 'runtime delivery' },
-                { value: 'Core', label: 'shared schema model' },
+                { value: 'Core', label: 'shared schema' },
               ].map((entry) => (
                 <div
                   key={entry.value}
-                  className="rounded-2xl border border-blue-300/50 bg-white/70 p-4 backdrop-blur dark:border-blue-300/50 dark:bg-white/70"
+                  className="bg-slate-50 px-4 py-3 dark:bg-white/5"
                 >
-                  <dt className="text-sm font-bold text-slate-900 dark:text-slate-900">
+                  <p className="m-0 text-sm font-bold text-slate-800 dark:text-slate-100">
                     {entry.value}
-                  </dt>
-                  <dd className="mt-1 text-xs text-slate-600 dark:text-slate-600">
+                  </p>
+                  <p className="m-0 mt-0.5 text-xs text-slate-500 dark:text-slate-400">
                     {entry.label}
-                  </dd>
+                  </p>
                 </div>
               ))}
-            </dl>
-          </div>
-
-          <div className="relative min-h-[24rem]">
-            <div className="absolute left-0 top-4 w-[78%] rounded-3xl border border-blue-300/60 bg-white/75 p-5 shadow-xl backdrop-blur dark:border-blue-300/60 dark:bg-white/75">
-              <p className="text-xs font-bold uppercase tracking-[0.1em] text-blue-700 dark:text-blue-700">
-                System Flow
-              </p>
-              <div className="mt-3 grid gap-2">
-                {['authoring', 'schema', 'runtime'].map((item) => (
-                  <span
-                    key={item}
-                    className="inline-flex w-fit min-w-36 items-center rounded-full bg-blue-100/90 px-4 py-2 text-sm font-semibold text-slate-900 dark:bg-blue-100/90 dark:text-slate-900"
-                  >
-                    {item}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            <div className="absolute right-0 top-24 w-[82%] rounded-3xl border border-blue-300/60 bg-white/80 p-5 shadow-xl backdrop-blur dark:border-blue-300/60 dark:bg-white/80">
-              <p className="text-xs font-bold uppercase tracking-[0.1em] text-blue-700 dark:text-blue-700">
-                Package Map
-              </p>
-              <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-100/90 p-3 text-sm leading-7 text-slate-700 dark:bg-slate-100/90 dark:text-slate-700">
-                <code>
-                  {
-                    'schema -> builder -> renderer\nlogic -> response -> export\nmodular packages -> practical docs'
-                  }
-                </code>
-              </pre>
-            </div>
-
-            <div className="absolute bottom-0 left-6 w-[72%] rounded-3xl border border-blue-300/60 bg-gradient-to-br from-blue-100/80 to-sky-100/70 p-5 shadow-xl backdrop-blur dark:border-blue-300/60 dark:from-blue-100/80 dark:to-sky-100/70 dark:bg-transparent">
-              <p className="text-xs font-bold uppercase tracking-[0.1em] text-blue-700 dark:text-blue-700">
-                Focus
-              </p>
-              <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-700">
-                Builder and renderer lead the path, while supporting packages
-                stay visible as implementation detail.
-              </p>
             </div>
           </div>
+
+          {/* Right: code mockup */}
+          <CodeMockup />
         </div>
       </div>
     </header>
   );
 }
 
-function Feature({ title, description }) {
-  return (
-    <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-lg dark:border-slate-200 dark:bg-white">
-      <h3 className="m-0 text-lg font-bold text-slate-900 dark:text-slate-900">
-        {title}
-      </h3>
-      <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-600">
-        {description}
-      </p>
-    </article>
-  );
-}
-
-function QuickStartSection() {
-  return (
-    <section className="bg-white py-14 dark:bg-white">
-      <div className="mx-auto max-w-6xl px-5">
-        <p className="text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-          Install
-        </p>
-        <h2 className="mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-900">
-          Quick Start
-        </h2>
-        <p className="mt-3 max-w-2xl text-slate-600 dark:text-slate-600">
-          Start with builder and renderer first, then add runtime variants when
-          needed.
-        </p>
-
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
-          {quickStarts.map((entry, index) => (
-            <Link
-              key={entry.title}
-              to={entry.href}
-              className={`group relative block rounded-2xl border p-5 no-underline transition hover:-translate-y-0.5 hover:shadow-lg ${
-                index < 2
-                  ? 'border-blue-300 bg-gradient-to-br from-blue-50 to-white dark:border-blue-300 dark:from-blue-50 dark:to-white'
-                  : 'border-slate-200 bg-slate-50 dark:border-slate-200 dark:bg-slate-50'
-              }`}
-            >
-              <p className="m-0 text-xs font-bold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-500">
-                {entry.level}
-              </p>
-              <h3 className="mt-2 text-lg font-bold text-slate-900 dark:text-slate-900">
-                {entry.title}
-              </h3>
-              <pre className="mt-3 overflow-x-auto rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-200 dark:bg-white dark:text-slate-700">
-                <code>{entry.install}</code>
-              </pre>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-600">
-                {entry.description}
-              </p>
-              <span className="absolute right-4 top-4 text-blue-700 opacity-0 transition group-hover:translate-x-0.5 group-hover:opacity-100 dark:text-blue-700">
-                →
-              </span>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function HomepageFeatures() {
   return (
-    <section className="bg-slate-50 py-14 dark:bg-slate-50">
-      <div className="mx-auto max-w-6xl px-5">
-        <p className="text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-          Overview
-        </p>
-        <h2 className="mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-900">
-          Key Features
-        </h2>
-        <p className="mt-3 max-w-2xl text-slate-600 dark:text-slate-600">
-          Everything needed to design, integrate, and run forms in modern app
-          flows.
-        </p>
-        <div className="mt-6 grid gap-4 md:grid-cols-3">
-          {features.map((props) => (
-            <Feature key={props.title} {...props} />
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
+    <section className="bg-slate-50 py-16 dark:bg-[#242526]">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionLabel>Overview</SectionLabel>
+        <SectionHeading>Key Features</SectionHeading>
+        <SectionSubtext>
+          Everything needed to design, integrate, and run forms in modern
+          application workflows.
+        </SectionSubtext>
 
-function PackagesSection() {
-  return (
-    <section id="docs-packages" className="bg-white py-14 dark:bg-white">
-      <div className="mx-auto max-w-6xl px-5">
-        <p className="text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-          Modules
-        </p>
-        <h2 className="mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-900">
-          NPM Packages
-        </h2>
-        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {packages.map((entry) => (
-            <a
-              key={entry.name}
-              href={entry.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group rounded-2xl border border-slate-200 bg-white p-5 no-underline transition hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-lg dark:border-slate-200 dark:bg-white"
-            >
-              <p className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-500 group-hover:text-blue-700">
-                {entry.type}
-              </p>
-              <h3 className="mt-2 text-base font-bold text-slate-900 group-hover:text-blue-700 dark:text-slate-900">
-                {entry.name}
-              </h3>
-              <p className="mt-2 text-sm text-slate-600 dark:text-slate-600">
-                {entry.summary}
-              </p>
-              <span className="mt-3 inline-flex items-center font-semibold text-blue-700 opacity-0 transition group-hover:translate-x-0.5 group-hover:opacity-100 dark:text-blue-700">
-                View on npm →
-              </span>
-            </a>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ResourcesSection() {
-  return (
-    <section className="bg-slate-50 py-14 dark:bg-slate-50">
-      <div className="mx-auto max-w-6xl px-5">
-        <p className="text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-          Learn More
-        </p>
-        <h2 className="mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-900">
-          Resources
-        </h2>
-        <div className="mt-6 grid gap-4 md:grid-cols-3">
-          {resources.map((resource) => (
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          {features.map((feature) => (
             <article
-              key={resource.label}
-              className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-200 dark:bg-white"
+              key={feature.title}
+              className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md dark:border-white/10 dark:bg-[#2a2a2d] dark:hover:border-blue-500/20"
             >
-              <p className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-500">
-                {resource.type}
-              </p>
-              <h3 className="mt-2 text-base font-bold text-slate-900 dark:text-slate-900">
-                {resource.label}
+              <span
+                className="text-2xl leading-none"
+                role="img"
+                aria-hidden="true"
+              >
+                {feature.icon}
+              </span>
+              <h3 className="m-0 text-base font-bold text-slate-900 dark:text-slate-100">
+                {feature.title}
               </h3>
-              {isExternalLink(resource.href) ? (
-                <a
-                  href={resource.href}
-                  className="mt-3 inline-block font-semibold text-blue-700 no-underline hover:underline dark:text-blue-700"
-                >
-                  Open Resource
-                </a>
-              ) : (
-                <Link
-                  to={resource.href}
-                  className="mt-3 inline-block font-semibold text-blue-700 no-underline hover:underline dark:text-blue-700"
-                >
-                  Open Resource
-                </Link>
-              )}
+              <p className="m-0 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                {feature.description}
+              </p>
             </article>
           ))}
         </div>
@@ -421,44 +369,72 @@ function TryLiveSection() {
   const { siteConfig } = useDocusaurusContext();
   const demoUrl = resolveDemoUrl(siteConfig);
   return (
-    <section className="bg-slate-50 py-14 dark:bg-slate-50">
-      <div className="mx-auto max-w-6xl px-5">
-        <div className="grid gap-6 rounded-3xl border border-blue-300/60 bg-gradient-to-br from-white to-blue-50 p-7 shadow-lg dark:border-blue-300/60 dark:from-white dark:to-blue-50 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-          <div>
-            <p className="text-xs font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-700">
-              Experience
-            </p>
-            <h2 className="mt-2 text-3xl font-black tracking-tight text-slate-900 dark:text-slate-900">
-              Try It Live
-            </h2>
-            <p className="mt-3 max-w-2xl text-slate-600 dark:text-slate-600">
-              Open the live demo to test schema rendering, conditional behavior,
-              and response flow.
-            </p>
-            <a
-              className="mt-6 inline-flex items-center rounded-full bg-blue-700 px-7 py-3 text-base font-bold text-white no-underline shadow-[0_12px_28px_rgba(29,78,216,0.35)] transition hover:-translate-y-0.5 hover:bg-blue-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-              href={demoUrl}
-            >
-              Try Live Demo
-            </a>
-          </div>
+    <section className="bg-white py-16 dark:bg-[#1b1b1d]">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="overflow-hidden rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 to-slate-50 dark:border-blue-500/15 dark:from-blue-500/8 dark:to-transparent dark:bg-[#242526]">
+          <div className="grid gap-8 p-8 lg:grid-cols-[1fr_auto] lg:items-center lg:p-10">
+            <div>
+              <SectionLabel>Experience</SectionLabel>
+              <SectionHeading>Try It Live</SectionHeading>
+              <SectionSubtext>
+                Open the live demo to test schema rendering, conditional
+                behavior, and response flow without any setup.
+              </SectionSubtext>
 
-          <div className="grid gap-4">
-            <div className="min-h-[9rem] rounded-2xl border border-blue-300/60 bg-white/70 p-5 backdrop-blur dark:border-blue-300/60 dark:bg-white/70">
-              <strong className="text-base text-slate-900 dark:text-slate-900">
-                Build
-              </strong>
-              <p className="mt-2 text-sm text-slate-600 dark:text-slate-600">
-                Author visually, refine in code.
-              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-6 py-3 text-sm font-semibold text-white no-underline shadow-sm transition hover:-translate-y-px hover:bg-blue-700 hover:text-white dark:bg-blue-500 dark:hover:bg-blue-400"
+                  href={demoUrl}
+                >
+                  Open Live Demo{' '}
+                  <span aria-hidden="true" className="opacity-70">
+                    →
+                  </span>
+                </a>
+                <Link
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-blue-200 bg-white px-6 py-3 text-sm font-semibold text-blue-700 no-underline shadow-sm transition hover:-translate-y-px hover:border-blue-300 hover:text-blue-800 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-300 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
+                  to="/docs/intro"
+                >
+                  Read the Docs
+                </Link>
+              </div>
             </div>
-            <div className="min-h-[9rem] rounded-2xl border border-blue-300/60 bg-white/70 p-5 backdrop-blur dark:border-blue-300/60 dark:bg-white/70">
-              <strong className="text-base text-slate-900 dark:text-slate-900">
-                Render
-              </strong>
-              <p className="mt-2 text-sm text-slate-600 dark:text-slate-600">
-                Run conditional flows with response capture.
-              </p>
+
+            <div className="flex flex-col gap-3 lg:min-w-56">
+              {[
+                {
+                  step: '01',
+                  label: 'Author',
+                  desc: 'Build visually or in code',
+                },
+                {
+                  step: '02',
+                  label: 'Preview',
+                  desc: 'Test conditions live',
+                },
+                {
+                  step: '03',
+                  label: 'Collect',
+                  desc: 'Capture form responses',
+                },
+              ].map((item) => (
+                <div
+                  key={item.step}
+                  className="flex items-center gap-4 rounded-xl border border-slate-200 bg-white px-4 py-3 dark:border-white/10 dark:bg-[#2a2a2d]"
+                >
+                  <span className="text-xs font-bold tabular-nums text-blue-600 dark:text-blue-400">
+                    {item.step}
+                  </span>
+                  <div>
+                    <p className="m-0 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      {item.label}
+                    </p>
+                    <p className="m-0 text-xs text-slate-500 dark:text-slate-400">
+                      {item.desc}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -466,6 +442,191 @@ function TryLiveSection() {
     </section>
   );
 }
+
+function QuickStartSection() {
+  return (
+    <section className="bg-slate-50 py-16 dark:bg-[#242526]">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionLabel>Install</SectionLabel>
+        <SectionHeading>Quick Start</SectionHeading>
+        <SectionSubtext>
+          Start with builder and renderer first, then add runtime variants when
+          needed.
+        </SectionSubtext>
+
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          {quickStarts.map((entry, index) => (
+            <Link
+              key={entry.title}
+              to={entry.href}
+              className={`group flex flex-col gap-3 rounded-xl border p-5 no-underline transition hover:-translate-y-0.5 hover:shadow-md ${
+                index < 2
+                  ? 'border-blue-200 bg-white hover:border-blue-400 dark:border-blue-500/20 dark:bg-[#2a2a2d] dark:hover:border-blue-500/40'
+                  : 'border-slate-200 bg-white hover:border-slate-300 dark:border-white/10 dark:bg-[#2a2a2d] dark:hover:border-white/20'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className={`text-[10px] font-bold uppercase tracking-[0.12em] ${
+                    index < 2
+                      ? 'text-blue-600 dark:text-blue-400'
+                      : 'text-slate-400 dark:text-slate-500'
+                  }`}
+                >
+                  {entry.level}
+                </span>
+                <span className="text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-blue-600 dark:text-slate-600 dark:group-hover:text-blue-400">
+                  →
+                </span>
+              </div>
+
+              <h3 className="m-0 font-mono text-base font-bold text-slate-900 dark:text-slate-100">
+                {entry.title}
+              </h3>
+
+              <pre className="m-0 overflow-x-auto rounded-lg border border-slate-100 bg-slate-50 px-3 py-2.5 text-[12px] leading-none dark:border-white/8 dark:bg-[#1b1b1d]">
+                <code className="font-mono text-slate-600 dark:text-slate-300">
+                  {entry.install}
+                </code>
+              </pre>
+
+              <p className="m-0 text-sm leading-relaxed text-slate-500 dark:text-slate-400">
+                {entry.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PackagesSection() {
+  const typeColors = {
+    Foundation:
+      'text-violet-700 bg-violet-50 dark:text-violet-300 dark:bg-violet-500/10',
+    Authoring:
+      'text-blue-700 bg-blue-50 dark:text-blue-300 dark:bg-blue-500/10',
+    Runtime:
+      'text-emerald-700 bg-emerald-50 dark:text-emerald-300 dark:bg-emerald-500/10',
+    'Field Layer':
+      'text-amber-700 bg-amber-50 dark:text-amber-300 dark:bg-amber-500/10',
+  };
+
+  return (
+    <section id="docs-packages" className="bg-white py-16 dark:bg-[#1b1b1d]">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionLabel>Modules</SectionLabel>
+        <SectionHeading>NPM Packages</SectionHeading>
+        <SectionSubtext>
+          Each package is independently installable and serves a distinct role
+          in the ecosystem.
+        </SectionSubtext>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {packages.map((entry) => (
+            <a
+              key={entry.name}
+              href={entry.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 no-underline shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-white/10 dark:bg-[#2a2a2d] dark:hover:border-white/20"
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className={`rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
+                    typeColors[entry.type] ??
+                    'text-slate-600 bg-slate-100 dark:text-slate-400 dark:bg-white/10'
+                  }`}
+                >
+                  {entry.type}
+                </span>
+                <span className="text-[11px] font-semibold text-blue-600 opacity-0 transition group-hover:translate-x-0.5 group-hover:opacity-100 dark:text-blue-400">
+                  npm →
+                </span>
+              </div>
+
+              <h3 className="m-0 font-mono text-sm font-bold text-slate-900 dark:text-slate-100">
+                {entry.name}
+              </h3>
+
+              <p className="m-0 text-sm leading-relaxed text-slate-500 dark:text-slate-400">
+                {entry.summary}
+              </p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ResourcesSection() {
+  const typeColors = {
+    Community:
+      'text-blue-700 bg-blue-50 dark:text-blue-300 dark:bg-blue-500/10',
+    Docs: 'text-slate-700 bg-slate-100 dark:text-slate-300 dark:bg-white/8',
+  };
+
+  return (
+    <section className="bg-slate-50 py-16 dark:bg-[#242526]">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionLabel>Learn More</SectionLabel>
+        <SectionHeading>Resources</SectionHeading>
+        <SectionSubtext>
+          Documentation, community links, and quick references to get you
+          moving.
+        </SectionSubtext>
+
+        <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {resources.map((resource) => (
+            <article
+              key={resource.label}
+              className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-[#2a2a2d]"
+            >
+              <span
+                className={`w-fit rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
+                  typeColors[resource.type] ??
+                  'text-slate-600 bg-slate-100 dark:text-slate-400 dark:bg-white/10'
+                }`}
+              >
+                {resource.type}
+              </span>
+              <h3 className="m-0 text-sm font-bold text-slate-900 dark:text-slate-100">
+                {resource.label}
+              </h3>
+              {isExternalLink(resource.href) ? (
+                <a
+                  href={resource.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-blue-600 no-underline transition hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Open{' '}
+                  <span aria-hidden="true" className="text-xs opacity-60">
+                    ↗
+                  </span>
+                </a>
+              ) : (
+                <Link
+                  to={resource.href}
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-blue-600 no-underline transition hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Read{' '}
+                  <span aria-hidden="true" className="text-xs opacity-60">
+                    →
+                  </span>
+                </Link>
+              )}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -45,7 +45,7 @@ function App() {
 import { EsheetBuilder } from '@esheet/builder';
 
 const initialForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'patient-intake',
   title: 'Patient Intake',
   fields: [
     { id: 'name', fieldType: 'text', question: 'Full Name', required: true },

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -21,6 +21,8 @@ export {
   useUI,
   useInstanceId,
   type EsheetBuilderProps,
+  type BuilderTools,
+  type FieldSummary,
 } from './lib/EsheetBuilder.js';
 
 export {
@@ -33,7 +35,6 @@ export {
   registerCustomFieldTypes,
   getFieldComponent,
   getRegisteredComponentKeys,
-  resetComponentRegistry,
 } from '@esheet/fields';
 
 export {
@@ -59,3 +60,6 @@ export type {
   ToolDefinition,
   UseBuilderMcpToolHandlerOptions,
 } from './lib/mcp/index.js';
+
+// Re-export core schema types for consumer convenience
+export type { FormDefinition, FieldDefinition } from '@esheet/core';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,6 @@ export {
   fieldDefinitionSchema,
   formDefinitionSchema,
   formDefinitionJSONSchema,
-  normalizeFormDefinition,
 
   // Types
   type FieldType,
@@ -73,8 +72,8 @@ export {
   registerFieldType,
   getFieldTypeMeta,
   getRegisteredFieldTypes,
-  resetFieldTypeRegistry,
   registerFieldElements,
+  // NOTE: resetFieldTypeRegistry intentionally not exported - internal/test-only
 } from './lib/registry.js';
 
 export {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -64,5 +64,5 @@ export {
   getRegisteredComponentKeys,
   registerFieldComponents,
   registerCustomFieldTypes,
-  resetComponentRegistry,
+  // NOTE: resetComponentRegistry intentionally not exported - internal/test-only
 } from './lib/component-registry.js';

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -39,7 +39,7 @@ import { EsheetRenderer } from '@esheet/renderer';
 import type { FormDefinition } from '@esheet/core';
 
 const myForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'patient-intake',
   title: 'Patient Intake',
   fields: [
     {
@@ -105,7 +105,7 @@ function App() {
 
 ```tsx
 const yamlSchema = `
-schemaType: mieforms-v1.0
+id: simple-form
 title: Simple Form
 fields:
   - id: q1
@@ -164,7 +164,7 @@ EsheetRenderer is a thin wrapper that:
 
 ```tsx
 const conditionalForm: FormDefinition = {
-  schemaType: 'mieforms-v1.0',
+  id: 'conditional-form',
   title: 'Conditional Form',
   fields: [
     {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -7,8 +7,12 @@ export {
   type EsheetRendererHandle,
 } from './lib/EsheetRenderer.js';
 
-// Core types
-export type { ValidationError } from '@esheet/core';
+// Core types (re-exported for consumer convenience)
+export type {
+  FormDefinition,
+  FormResponseEnvelope,
+  ValidationError,
+} from '@esheet/core';
 
 // Components (for advanced use cases)
 export { RendererBody, FieldNode } from './lib/components/index.js';

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -55,7 +55,7 @@ export interface EsheetRendererHandle {
  * Renders a form in fill-out mode with conditional visibility logic.
  * Reuses all field components from @esheet/fields.
  *
- * @example
+* @example
  * ```tsx
  * const rendererRef = useRef<EsheetRendererHandle>(null);
  *

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -55,7 +55,7 @@ export interface EsheetRendererHandle {
  * Renders a form in fill-out mode with conditional visibility logic.
  * Reuses all field components from @esheet/fields.
  *
-* @example
+ * @example
  * ```tsx
  * const rendererRef = useRef<EsheetRendererHandle>(null);
  *


### PR DESCRIPTION
## PR Description

### Overview

This PR updates the documentation site to reflect the current public package APIs, adds dedicated documentation for the new `@esheet/adapters` package, and refreshes the docs landing page with a more complete product overview.

It also removes references to internal/test-only utilities from the public API docs and updates demo imports so consumers are guided toward package-level exports instead of importing shared types directly from `@esheet/core`.

### What Changed

* Added a new **Adapters** docs section with dedicated pages for:

  * `@esheet/adapters` overview
  * SurveyJS conversion
  * MCP elicitation conversion
* Updated API reference docs to remove internal exports:

  * `resetFieldTypeRegistry`
  * `resetComponentRegistry`
  * `normalizeFormDefinition`
  * `SCHEMA_TYPE`
* Documented newly exposed public types and APIs:

  * `InstanceIdContext`
  * `BuilderTools`
  * `FieldSummary`
  * `FormDefinition`
  * `FieldDefinition`
  * `FormResponseEnvelope`
* Updated demo app imports to use package-level exports from `@esheet/builder` and `@esheet/renderer`
* Expanded and refreshed docs across conditional logic, schema format, renderer responses, validation, intro, and getting started pages
* Redesigned the docs landing page with:

  * Modern hero section
  * Live schema-to-renderer preview
  * Dark mode support aligned with Docusaurus theme state
  * Updated package cards including `@esheet/adapters`
  * Improved typography, resource links, and install blocks
* Enabled system theme preference support in Docusaurus
* Added dark mode styling for the navbar logo and links

### How to Test

1. Start the docs site locally.

   ```bash
   npm run docs
   ```

2. Verify the new **Adapters** sidebar section appears and includes:

   * Overview
   * SurveyJS
   * MCP

3. Open the API reference page and confirm internal/test-only exports are no longer documented.

4. Check the docs landing page in both light and dark mode:

   * Hero section renders correctly
   * Navbar blends cleanly in dark mode
   * Logo inverts correctly
   * Package cards include `@esheet/adapters`

5. Validate the demo app still builds and uses public package-level type exports.

   ```bash
   npm run build
   ```

6. Review the updated renderer, schema, validation, and getting started docs for broken links or outdated package references.

### Breaking Changes

No runtime breaking changes.

This PR updates docs and public export guidance, but it also reflects public API cleanup where internal/test-only utilities are no longer exported from package entry points.
