### PR TITLE
feat(adapters): add FHIR adapter support

### DIFF
--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -6,7 +6,7 @@ import {
   RENDERER_TOOL_DEFINITIONS,
   RENDERER_SYSTEM_PROMPT,
   type FormDefinition,
-  type FormResponseEnvelope,
+  type ResponseFormat,
 } from '@esheet/renderer';
 import { Navbar } from '../components/Navbar';
 import {
@@ -33,7 +33,7 @@ interface SubmitResult {
   readonly message: string;
   readonly items?: readonly string[];
   readonly detail?: string;
-  readonly data?: FormResponseEnvelope;
+  readonly data?: unknown;
 }
 
 interface SchemaOption {
@@ -92,6 +92,8 @@ export function RendererView() {
 
   const [touchMode, setTouchMode] = useState(false);
   const [activeTab, setActiveTab] = useState<'form' | 'definition'>('form');
+  const [responseFormat, setResponseFormat] =
+    useState<ResponseFormat>('native');
 
   const resetFormKey = useCallback(() => {
     setFormKey((prev) => prev + 1);
@@ -147,17 +149,28 @@ export function RendererView() {
       return;
     }
 
-    const hydrated = renderer.getFormStore().getState().hydrateResponse();
+    // Get response in selected format
+    const response = renderer.getResponse({
+      format: responseFormat,
+      fhir:
+        responseFormat === 'fhir'
+          ? {
+              status: 'completed',
+            }
+          : undefined,
+    });
+
     console.log(
-      'Validated Form Response:',
-      JSON.stringify(result.response, null, 2)
+      `${responseFormat.toUpperCase()} Response:`,
+      JSON.stringify(response, null, 2)
     );
-    console.log('Hydrated Submit Payload:', JSON.stringify(hydrated, null, 2));
     setSubmitResult({
       kind: 'success',
-      title: 'Submit successful',
+      title: `Submit successful (${
+        responseFormat === 'fhir' ? 'FHIR QuestionnaireResponse' : 'Native'
+      })`,
       message: 'Validation passed. Form response data:',
-      data: hydrated,
+      data: response,
     });
   };
 
@@ -192,7 +205,7 @@ export function RendererView() {
               {submitResult.detail && (
                 <p className="mt-3 text-sm">{submitResult.detail}</p>
               )}
-              {submitResult.data && (
+              {submitResult.data != null && (
                 <pre className="mt-3 p-3 bg-background/50 rounded-lg text-xs overflow-auto max-h-96 border border-border">
                   {JSON.stringify(submitResult.data, null, 2)}
                 </pre>
@@ -254,6 +267,17 @@ export function RendererView() {
                   <span className="hidden sm:inline ml-1">Touch</span>
                 </Button>
                 <div className="ml-auto flex items-center gap-2">
+                  <Select
+                    value={responseFormat}
+                    onValueChange={(v: string) =>
+                      setResponseFormat(v as ResponseFormat)
+                    }
+                    options={[
+                      { value: 'native', label: 'Native' },
+                      { value: 'fhir', label: 'FHIR' },
+                    ]}
+                    className="w-28"
+                  />
                   <Button
                     variant="outline"
                     size="sm"

--- a/apps/docs/docs/adapters/fhir.md
+++ b/apps/docs/docs/adapters/fhir.md
@@ -1,0 +1,594 @@
+---
+sidebar_position: 4
+---
+
+# FHIR Adapter
+
+Convert between FHIR R4 Questionnaire/QuestionnaireResponse resources and eSheet `FormDefinition`. Supports bidirectional conversion with metadata preservation for round-trip fidelity, conditional logic (enableWhen), and DTR profile compatibility.
+
+## Functions
+
+| Function                      | Signature                                                                                                               | Description                                 |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `importFromFhir`              | `(questionnaire: FhirQuestionnaire, options?: FhirImportOptions) => FormDefinition`                                     | Import FHIR Questionnaire to eSheet         |
+| `exportToFhir`                | `(form: FormDefinition, options?: FhirExportOptions) => FhirQuestionnaire`                                              | Export eSheet to FHIR Questionnaire         |
+| `importResponseFromFhir`      | `(response: FhirQuestionnaireResponse, options?: ResponseImportOptions) => Record<string, unknown>`                     | Import QuestionnaireResponse to answers map |
+| `exportResponseToFhir`        | `(form: FormDefinition, answers: Record<string, unknown>, options: ResponseExportOptions) => FhirQuestionnaireResponse` | Export answers to QuestionnaireResponse     |
+| `isFhirQuestionnaire`         | `(value: unknown) => value is FhirQuestionnaire`                                                                        | Type guard for Questionnaire                |
+| `isFhirQuestionnaireResponse` | `(value: unknown) => value is FhirQuestionnaireResponse`                                                                | Type guard for QuestionnaireResponse        |
+
+## Import from FHIR
+
+```typescript
+import { importFromFhir } from '@esheet/adapters';
+
+const fhirQuestionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'patient-intake',
+  status: 'active',
+  title: 'Patient Intake Form',
+  item: [
+    {
+      linkId: 'name',
+      text: 'Full Name',
+      type: 'string',
+      required: true,
+    },
+    {
+      linkId: 'dob',
+      text: 'Date of Birth',
+      type: 'date',
+    },
+    {
+      linkId: 'conditions',
+      text: 'Pre-existing Conditions',
+      type: 'choice',
+      repeats: true,
+      answerOption: [
+        { valueCoding: { code: 'diabetes', display: 'Diabetes' } },
+        { valueCoding: { code: 'hypertension', display: 'Hypertension' } },
+      ],
+    },
+  ],
+};
+
+const formDefinition = importFromFhir(fhirQuestionnaire);
+// formDefinition.fields contains text, date, and checkbox fields
+```
+
+### Import Options
+
+```typescript
+interface FhirImportOptions {
+  formId?: string; // Override generated form ID
+  preserveExtensions?: boolean; // Keep extensions in _sourceData (default: true)
+  strictMode?: boolean; // Fail on unsupported features (default: false)
+}
+
+const form = importFromFhir(questionnaire, {
+  formId: 'custom-form-id',
+  preserveExtensions: true,
+});
+```
+
+## Export to FHIR
+
+```typescript
+import { exportToFhir } from '@esheet/adapters';
+
+const fhirQuestionnaire = exportToFhir(formDefinition, {
+  canonicalUrl: 'https://example.org/fhir',
+  publisher: 'My Organization',
+  status: 'active',
+});
+// Returns valid FHIR R4 Questionnaire resource
+```
+
+### Export Options
+
+```typescript
+interface FhirExportOptions {
+  resourceId?: string; // Override resource ID
+  canonicalUrl?: string; // Base URL for canonical references
+  status?: 'draft' | 'active' | 'retired' | 'unknown'; // Resource status (default: draft)
+  publisher?: string; // Publisher name
+  dtrCompliant?: boolean; // Apply DTR profile constraints
+}
+```
+
+## Type Guards
+
+Use type guards to detect FHIR resources when handling unknown input:
+
+```typescript
+import {
+  isFhirQuestionnaire,
+  isFhirQuestionnaireResponse,
+  importFromFhir,
+  importResponseFromFhir,
+} from '@esheet/adapters';
+
+function detectAndConvert(resource: unknown) {
+  if (isFhirQuestionnaire(resource)) {
+    return importFromFhir(resource);
+  }
+  if (isFhirQuestionnaireResponse(resource)) {
+    return importResponseFromFhir(resource);
+  }
+  return null;
+}
+```
+
+Returns `true` if value has `resourceType: 'Questionnaire'` or `resourceType: 'QuestionnaireResponse'`.
+
+## Response Conversion
+
+### Import QuestionnaireResponse
+
+Convert filled-out responses back to an eSheet answers map:
+
+```typescript
+import { importResponseFromFhir } from '@esheet/adapters';
+
+const fhirResponse = {
+  resourceType: 'QuestionnaireResponse',
+  questionnaire: 'Questionnaire/patient-intake',
+  status: 'completed',
+  item: [
+    {
+      linkId: 'name',
+      answer: [{ valueString: 'John Doe' }],
+    },
+    {
+      linkId: 'conditions',
+      answer: [
+        { valueCoding: { code: 'diabetes' } },
+        { valueCoding: { code: 'hypertension' } },
+      ],
+    },
+  ],
+};
+
+const answers = importResponseFromFhir(fhirResponse);
+// { name: 'John Doe', conditions: ['diabetes', 'hypertension'] }
+```
+
+### Export to QuestionnaireResponse
+
+Convert eSheet answers to a FHIR QuestionnaireResponse:
+
+```typescript
+import { exportResponseToFhir } from '@esheet/adapters';
+
+const answers = {
+  name: 'Jane Smith',
+  dob: '1990-05-15',
+  conditions: ['diabetes'],
+};
+
+const fhirResponse = exportResponseToFhir(formDefinition, answers, {
+  questionnaireUrl: 'https://example.org/fhir/Questionnaire/patient-intake',
+  subject: { reference: 'Patient/123' },
+  author: { reference: 'Practitioner/456' },
+  status: 'completed',
+});
+```
+
+### Response Export Options
+
+```typescript
+interface ResponseExportOptions {
+  questionnaireUrl: string; // Canonical reference to questionnaire (required)
+  subject?: FhirReference; // Patient/subject reference
+  author?: FhirReference; // Author reference
+  status?:
+    | 'in-progress'
+    | 'completed'
+    | 'amended'
+    | 'entered-in-error'
+    | 'stopped';
+  resourceId?: string; // Resource ID
+}
+```
+
+## Field Type Mapping
+
+### FHIR → eSheet
+
+| FHIR Item Type | itemControl Extension        | eSheet Field Type                  |
+| -------------- | ---------------------------- | ---------------------------------- |
+| `string`       | —                            | `text` (inputType: string)         |
+| `text`         | —                            | `longtext`                         |
+| `boolean`      | —                            | `boolean`                          |
+| `decimal`      | —                            | `text` (inputType: number)         |
+| `integer`      | —                            | `text` (inputType: number)         |
+| `integer`      | `slider`                     | `slider`                           |
+| `date`         | —                            | `text` (inputType: date)           |
+| `dateTime`     | —                            | `text` (inputType: datetime-local) |
+| `time`         | —                            | `text` (inputType: time)           |
+| `url`          | —                            | `text` (inputType: url)            |
+| `choice`       | `radio-button`               | `radio`                            |
+| `choice`       | `check-box`                  | `check`                            |
+| `choice`       | `drop-down` / `autocomplete` | `dropdown`                         |
+| `choice`       | — (with `repeats: true`)     | `check`                            |
+| `choice`       | — (without `repeats`)        | `radio`                            |
+| `open-choice`  | (same as `choice`)           | (same as `choice`)                 |
+| `group`        | —                            | `section`                          |
+| `display`      | —                            | `display`                          |
+| `attachment`   | — (with signatureRequired)   | `signature`                        |
+| `attachment`   | —                            | `diagram`                          |
+| `reference`    | —                            | `text` ⚠️                          |
+| `quantity`     | —                            | `text` ⚠️                          |
+
+⚠️ = Lossy conversion (see [Warning System](#warning-system))
+
+### eSheet → FHIR
+
+| eSheet Field Type       | FHIR Type    | itemControl Extension       |
+| ----------------------- | ------------ | --------------------------- |
+| `text`                  | (varies)     | —                           |
+| `text` (number)         | `decimal`    | —                           |
+| `text` (date)           | `date`       | —                           |
+| `text` (datetime-local) | `dateTime`   | —                           |
+| `text` (time)           | `time`       | —                           |
+| `text` (url)            | `url`        | —                           |
+| `longtext`              | `text`       | —                           |
+| `boolean`               | `boolean`    | —                           |
+| `radio`                 | `choice`     | `radio-button`              |
+| `check`                 | `choice`     | `check-box` (repeats: true) |
+| `dropdown`              | `choice`     | `drop-down`                 |
+| `multiselectdropdown`   | `choice`     | `drop-down` (repeats: true) |
+| `rating`                | `integer`    | `slider`                    |
+| `slider`                | `decimal`    | `slider`                    |
+| `section`               | `group`      | —                           |
+| `display`               | `display`    | —                           |
+| `signature`             | `attachment` | — (signatureRequired ext)   |
+| `diagram`               | `attachment` | —                           |
+
+## Extension Handling
+
+### itemControl Extension
+
+The `questionnaire-itemControl` extension determines how choice fields render:
+
+```typescript
+const item = {
+  linkId: 'priority',
+  type: 'choice',
+  extension: [
+    {
+      url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+      valueCodeableConcept: {
+        coding: [
+          {
+            system: 'http://hl7.org/fhir/questionnaire-item-control',
+            code: 'drop-down', // or 'radio-button', 'check-box', 'autocomplete'
+          },
+        ],
+      },
+    },
+  ],
+};
+```
+
+### Validation Extensions
+
+The adapter extracts and preserves these validation extensions:
+
+| Extension URL | Purpose                  | Stored in               |
+| ------------- | ------------------------ | ----------------------- |
+| `minValue`    | Minimum allowed value    | `_sourceData.minValue`  |
+| `maxValue`    | Maximum allowed value    | `_sourceData.maxValue`  |
+| `minLength`   | Minimum string length    | `_sourceData.minLength` |
+| `regex`       | Regex validation pattern | `_sourceData.regex`     |
+
+```typescript
+const form = importFromFhir(questionnaire);
+const field = form.fields[0];
+
+if (field._sourceData?.minValue !== undefined) {
+  // Apply validation: value >= minValue
+}
+```
+
+### Option Scoring (ordinalValue)
+
+Scores from `ordinalValue` extensions on answerOptions map to `FieldOption.score`:
+
+```typescript
+const item = {
+  linkId: 'pain-level',
+  type: 'choice',
+  answerOption: [
+    {
+      valueCoding: { code: 'mild', display: 'Mild' },
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+          valueDecimal: 1,
+        },
+      ],
+    },
+    {
+      valueCoding: { code: 'severe', display: 'Severe' },
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+          valueDecimal: 10,
+        },
+      ],
+    },
+  ],
+};
+
+// Converts to:
+// options: [{ id: 'mild', value: 'mild', text: 'Mild', score: 1 }, ...]
+```
+
+### Supported Extension URLs
+
+```typescript
+import { FHIR_EXT } from '@esheet/adapters';
+
+FHIR_EXT.ITEM_CONTROL; // questionnaire-itemControl
+FHIR_EXT.MIN_VALUE; // minValue
+FHIR_EXT.MAX_VALUE; // maxValue
+FHIR_EXT.MIN_LENGTH; // minLength
+FHIR_EXT.REGEX; // regex
+FHIR_EXT.ORDINAL_VALUE; // ordinalValue
+FHIR_EXT.HIDDEN; // questionnaire-hidden
+FHIR_EXT.SLIDER_STEP; // questionnaire-sliderStepValue
+FHIR_EXT.SIGNATURE_REQUIRED; // questionnaire-signatureRequired
+
+// SDC / DTR Extensions
+FHIR_EXT.INITIAL_EXPRESSION; // sdc-questionnaire-initialExpression
+FHIR_EXT.CALCULATED_EXPRESSION; // sdc-questionnaire-calculatedExpression
+FHIR_EXT.ENABLE_WHEN_EXPRESSION; // sdc-questionnaire-enableWhenExpression
+FHIR_EXT.VARIABLE; // variable
+```
+
+## Metadata Preservation
+
+### FhirFieldMeta
+
+Field-level FHIR metadata preserved in `_sourceData`:
+
+```typescript
+interface FhirFieldMeta {
+  definition?: string; // Element definition URL
+  code?: FhirCoding[]; // Semantic codes
+  prefix?: string; // Numbering prefix ("1.", "a)")
+  readOnly?: boolean; // Read-only flag
+  repeats?: boolean; // Repeating item flag
+  fhirItemType?: string; // Original FHIR type
+  fhirExtensions?: FhirExtension[]; // All preserved extensions
+
+  // Validation
+  minValue?: number | string;
+  maxValue?: number | string;
+  minLength?: number;
+  regex?: string;
+
+  // DTR expressions (preserved, not evaluated)
+  initialExpression?: FhirExpression;
+  calculatedExpression?: FhirExpression;
+  enableWhenExpression?: FhirExpression;
+}
+```
+
+### FhirFormMeta
+
+Form-level FHIR metadata preserved in `_sourceData`:
+
+```typescript
+interface FhirFormMeta {
+  url?: string; // Canonical URL
+  version?: string; // Semantic version
+  name?: string; // Computer-friendly name
+  status?: string; // Publication status
+  publisher?: string; // Publisher organization
+  date?: string; // Publication date
+  subjectType?: string[]; // Allowed subject types
+  derivedFrom?: string[]; // Parent questionnaires
+  code?: FhirCoding[]; // Form-level codes
+  fhirExtensions?: FhirExtension[]; // Form-level extensions
+  _conversionWarnings?: ImportWarning[]; // Conversion warnings
+}
+```
+
+## Warning System
+
+The adapter tracks potentially lossy conversions via warnings:
+
+```typescript
+const form = importFromFhir(questionnaire);
+const meta = form._sourceData as FhirFormMeta;
+
+if (meta._conversionWarnings) {
+  for (const warning of meta._conversionWarnings) {
+    console.warn(`${warning.code} at ${warning.path}: ${warning.message}`);
+  }
+}
+```
+
+### Warning Codes
+
+| Code                       | Description                                             |
+| -------------------------- | ------------------------------------------------------- |
+| `UNSUPPORTED_TYPE`         | FHIR type converted to text field (reference, quantity) |
+| `VALUESET_NOT_EXPANDED`    | `answerValueSet` reference not expanded — options empty |
+| `EXPRESSION_PRESERVED`     | FHIRPath/CQL expression preserved but not evaluated     |
+| `NESTED_ANSWERS_FLATTENED` | Nested answer structure flattened                       |
+| `EXTENSION_PRESERVED`      | Unknown extension preserved in `_sourceData`            |
+| `REPEAT_NOT_SUPPORTED`     | `repeats` on non-choice field ignored                   |
+
+## Conditional Logic (enableWhen)
+
+### Import: enableWhen → rules
+
+FHIR `enableWhen` conditions convert to eSheet visibility rules:
+
+```typescript
+// FHIR enableWhen
+const item = {
+  linkId: 'pregnancy-details',
+  type: 'text',
+  enableWhen: [
+    { question: 'is-pregnant', operator: '=', answerBoolean: true },
+  ],
+};
+
+// Converts to eSheet rule:
+{
+  effect: 'visible',
+  logic: 'AND',
+  conditions: [{
+    conditionType: 'field',
+    targetId: 'is-pregnant',
+    operator: 'equals',
+    expected: 'true',
+  }],
+}
+```
+
+### Operator Mapping
+
+| FHIR Operator    | eSheet Operator      |
+| ---------------- | -------------------- |
+| `=`              | `equals`             |
+| `!=`             | `notEquals`          |
+| `>`              | `greaterThan`        |
+| `>=`             | `greaterThanOrEqual` |
+| `<`              | `lessThan`           |
+| `<=`             | `lessThanOrEqual`    |
+| `exists` (true)  | `notEmpty`           |
+| `exists` (false) | `empty`              |
+
+### enableBehavior
+
+| FHIR enableBehavior | eSheet logic |
+| ------------------- | ------------ |
+| `all` (default)     | `AND`        |
+| `any`               | `OR`         |
+
+### Export: rules → enableWhen
+
+Only `visible` effect rules export back to enableWhen. Other effects (`enable`, `required`) are not supported in standard FHIR and are preserved in `_sourceData`.
+
+## DTR Profile Support
+
+For Da Vinci DTR (Documentation Templates and Rules) compliance:
+
+```typescript
+const fhirQuestionnaire = exportToFhir(formDefinition, {
+  dtrCompliant: true,
+  canonicalUrl: 'https://example.org/fhir',
+});
+// Sets subjectType: ['Patient'] and applies DTR constraints
+```
+
+### DTR Extensions Preserved
+
+The adapter preserves these SDC/DTR extensions in `_sourceData` without evaluation:
+
+- `initialExpression` — FHIRPath expression for initial value
+- `calculatedExpression` — FHIRPath expression for calculated value
+- `enableWhenExpression` — FHIRPath expression for visibility
+- `variable` — Named FHIRPath expressions
+
+These expressions require a FHIRPath evaluation engine to execute at runtime.
+
+## Round-Trip Fidelity
+
+Original FHIR metadata is preserved in `_sourceData` for lossless round-trips:
+
+```typescript
+// Import
+const form = importFromFhir(originalQuestionnaire);
+
+// Modify
+form.title = 'Updated Title';
+
+// Export — original extensions, codes, definitions restored
+const exported = exportToFhir(form);
+```
+
+### What Gets Preserved
+
+- ✅ All standard FHIR properties (url, version, status, publisher, etc.)
+- ✅ All extensions (itemControl, validation, scoring, custom)
+- ✅ Semantic codes and definitions
+- ✅ Nested item structure
+- ✅ enableWhen/enableBehavior
+- ✅ repeats flag
+- ✅ readOnly flag
+
+### What Requires Re-mapping
+
+- ⚠️ `answerValueSet` — Must be expanded before import
+- ⚠️ Complex expressions — FHIRPath/CQL evaluated externally
+- ⚠️ Nested answers in QuestionnaireResponse — Flattened to simple map
+
+## Utility Functions
+
+For advanced use cases, low-level utilities are exported:
+
+```typescript
+import {
+  mapFhirTypeToEsheet,
+  mapEsheetTypeToFhir,
+  convertAnswerOptionToFieldOption,
+  convertOptionToFhirAnswerOption,
+  mapFhirOperatorToEsheet,
+  mapEsheetOperatorToFhir,
+  getExtensionValue,
+  createItemControlExtension,
+  FHIR_EXT,
+  ITEM_CONTROL_SYSTEM,
+} from '@esheet/adapters';
+```
+
+## Types
+
+```typescript
+import type {
+  // Primitives
+  FhirCoding,
+  FhirCodeableConcept,
+  FhirReference,
+  FhirIdentifier,
+  FhirPeriod,
+  FhirAttachment,
+  FhirQuantity,
+  FhirExpression,
+  FhirExtension,
+
+  // Questionnaire
+  FhirQuestionnaire,
+  FhirQuestionnaireItem,
+  FhirQuestionnaireStatus,
+  FhirQuestionnaireItemType,
+  FhirAnswerOption,
+  FhirEnableWhen,
+  FhirEnableWhenOperator,
+  FhirEnableBehavior,
+
+  // Response
+  FhirQuestionnaireResponse,
+  FhirQuestionnaireResponseItem,
+  FhirResponseAnswer,
+  FhirResponseStatus,
+
+  // Options
+  FhirImportOptions,
+  FhirExportOptions,
+  ResponseImportOptions,
+  ResponseExportOptions,
+  ImportWarning,
+  ImportWarningCode,
+
+  // Metadata
+  FhirFieldMeta,
+  FhirFormMeta,
+} from '@esheet/adapters';
+```

--- a/apps/docs/docs/adapters/overview.md
+++ b/apps/docs/docs/adapters/overview.md
@@ -34,6 +34,26 @@ const formDefinition = importFromSurveyJS(surveyJSSchema);
 const surveyJSSchema = exportToSurveyJS(formDefinition);
 ```
 
+## Built-in Auto-Detection (Components)
+
+You rarely need to call adapter functions directly. Both `EsheetRenderer` and `EsheetBuilder` automatically detect and convert foreign schemas at input — just pass the schema straight through:
+
+```tsx
+// All of these work without any manual adapter calls
+<EsheetRenderer formDataInput={fhirQuestionnaire} />
+<EsheetRenderer formDataInput={surveyJSSchema} />
+<EsheetRenderer formDataInput={mcpElicitationEnvelope} />
+
+<EsheetBuilder definition={fhirQuestionnaire} />
+<EsheetBuilder definition={surveyJSSchema} />
+```
+
+The detection order is: **FHIR → MCP → SurveyJS → native eSheet**.
+
+> **Renderer only:** Pass `strict={true}` to disable auto-detection and require a native `FormDefinition`. The Builder always auto-detects with no bypass option.
+
+Call the adapter functions directly only when you need to transform schemas outside of these components (e.g. in a server-side pipeline or before persisting to a database).
+
 ## Auto-Detection
 
 Use type guards to detect the schema format when handling unknown input:

--- a/apps/docs/docs/adapters/overview.md
+++ b/apps/docs/docs/adapters/overview.md
@@ -18,6 +18,7 @@ npm install @esheet/adapters
 | -------- | -------------------- | ------------------ | ------------------------- | ---------------------------------------- |
 | SurveyJS | `importFromSurveyJS` | `exportToSurveyJS` | `isSurveyJSSchema`        | Convert to/from SurveyJS form schemas    |
 | MCP      | `importFromMcp`      | `exportToMcp`      | `isMcpElicitationRequest` | Convert to/from MCP elicitation requests |
+| FHIR     | `importFromFhir`     | `exportToFhir`     | `isFhirQuestionnaire`     | Convert to/from FHIR R4 Questionnaires   |
 
 ## Common Pattern
 
@@ -41,8 +42,10 @@ Use type guards to detect the schema format when handling unknown input:
 import {
   isSurveyJSSchema,
   isMcpElicitationRequest,
+  isFhirQuestionnaire,
   importFromSurveyJS,
   importFromMcp,
+  importFromFhir,
 } from '@esheet/adapters';
 import type { FormDefinition } from '@esheet/core';
 
@@ -52,6 +55,9 @@ function detectAndConvert(unknownSchema: unknown): FormDefinition | null {
   }
   if (isMcpElicitationRequest(unknownSchema)) {
     return importFromMcp(unknownSchema.params.requestedSchema);
+  }
+  if (isFhirQuestionnaire(unknownSchema)) {
+    return importFromFhir(unknownSchema);
   }
   return null;
 }
@@ -86,6 +92,17 @@ import {
   exportToMcp,
   isMcpElicitationRequest,
 
+  // FHIR Adapter
+  importFromFhir,
+  exportToFhir,
+  importResponseFromFhir,
+  exportResponseToFhir,
+  isFhirQuestionnaire,
+  isFhirQuestionnaireResponse,
+  mapFhirTypeToEsheet,
+  mapEsheetTypeToFhir,
+  FHIR_EXT,
+
   // Types
   type SurveyJSDetectionSchema,
   type McpElicitationSchema,
@@ -96,7 +113,13 @@ import {
   type McpBooleanProp,
   type McpArrayProp,
   type McpConstOption,
+  type FhirQuestionnaire,
+  type FhirQuestionnaireResponse,
+  type FhirImportOptions,
+  type FhirExportOptions,
+  type FhirFieldMeta,
+  type FhirFormMeta,
 } from '@esheet/adapters';
 ```
 
-See the [SurveyJS Adapter](./surveyjs.md) and [MCP Adapter](./mcp.md) pages for detailed documentation.
+See the [SurveyJS Adapter](./surveyjs.md), [MCP Adapter](./mcp.md), and [FHIR Adapter](./fhir.md) pages for detailed documentation.

--- a/apps/docs/docs/builder/overview.md
+++ b/apps/docs/docs/builder/overview.md
@@ -58,15 +58,15 @@ import { EsheetBuilder } from '@esheet/builder';
 
 ### Props Reference
 
-| Prop                | Type                            | Default     | Description                                                                      |
-| ------------------- | ------------------------------- | ----------- | -------------------------------------------------------------------------------- |
-| `definition`        | `FormDefinition`                | `undefined` | Initial form definition to load                                                  |
-| `onChange`          | `(def: FormDefinition) => void` | --          | Called when the form definition changes (any edit, reorder, add, remove)         |
-| `dragEnabled`       | `boolean`                       | `true`      | Whether drag-and-drop is enabled. Disable for better performance on slow devices |
-| `className`         | `string`                        | `''`        | Additional CSS class for the root container                                      |
-| `touchMode`         | `boolean \| 'auto'`             | --          | Touch mode for preview: `true`, `false`, `'auto'`, or omit for CSS-only          |
-| `onTouchModeChange` | `(enabled: boolean) => void`    | --          | Callback when touch mode changes                                                 |
-| `children`          | `ReactNode`                     | --          | Content rendered between the header and the editor layout                        |
+| Prop                | Type                            | Default     | Description                                                                                                                                                             |
+| ------------------- | ------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `definition`        | `FormDefinition`                | `undefined` | Initial form definition — accepts eSheet `FormDefinition`, FHIR R4 Questionnaire, SurveyJS schema, or MCP elicitation envelope. Auto-detected and converted internally. |
+| `onChange`          | `(def: FormDefinition) => void` | --          | Called when the form definition changes (any edit, reorder, add, remove)                                                                                                |
+| `dragEnabled`       | `boolean`                       | `true`      | Whether drag-and-drop reordering is enabled. When `false`, field reordering is disabled entirely — there is no fallback UI (e.g. arrow buttons).                        |
+| `className`         | `string`                        | `''`        | Additional CSS class for the root container                                                                                                                             |
+| `touchMode`         | `boolean \| 'auto'`             | --          | Touch mode for preview: `true`, `false`, `'auto'`, or omit for CSS-only                                                                                                 |
+| `onTouchModeChange` | `(enabled: boolean) => void`    | --          | Callback when touch mode changes                                                                                                                                        |
+| `children`          | `ReactNode`                     | --          | Content rendered between the header and the editor layout                                                                                                               |
 
 See [Touch Mode](./touch-mode) for details on mobile-friendly form preview.
 

--- a/apps/docs/docs/renderer/overview.md
+++ b/apps/docs/docs/renderer/overview.md
@@ -51,26 +51,28 @@ function SurveyPage() {
 
 ## Props Reference
 
-| Prop                | Type                         | Default    | Description                                                         |
-| ------------------- | ---------------------------- | ---------- | ------------------------------------------------------------------- |
-| `formDataInput`     | `FormDefinition \| string`   | _required_ | Form definition as a JavaScript object, JSON string, or YAML string |
-| `className`         | `string`                     | `''`       | Additional CSS class for the root container                         |
-| `initialResponses`  | `FormResponse`               | --         | Pre-fill the form with existing response data                       |
-| `touchMode`         | `boolean \| 'auto'`          | --         | Touch mode: `true`, `false`, `'auto'`, or omit for CSS-only         |
-| `onTouchModeChange` | `(enabled: boolean) => void` | --         | Callback when touch mode changes                                    |
-| `ref`               | `Ref<EsheetRendererHandle>`  | --         | Imperative handle for accessing responses and stores                |
+| Prop                | Type                         | Default    | Description                                                                                                                                                                                |
+| ------------------- | ---------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `formDataInput`     | `FormDefinition \| string`   | _required_ | Form definition — accepts eSheet `FormDefinition`, FHIR R4 Questionnaire, SurveyJS schema, MCP elicitation envelope, or any as a JSON/YAML string. Auto-detected and converted internally. |
+| `className`         | `string`                     | `''`       | Additional CSS class for the root container                                                                                                                                                |
+| `initialResponses`  | `FormResponse`               | --         | Pre-fill the form with existing response data                                                                                                                                              |
+| `strict`            | `boolean`                    | `false`    | Disable auto-detection — requires a native eSheet `FormDefinition`. Fires `onValidationError` if the input does not conform.                                                               |
+| `touchMode`         | `boolean \| 'auto'`          | --         | Touch mode: `true`, `false`, `'auto'`, or omit for CSS-only                                                                                                                                |
+| `onTouchModeChange` | `(enabled: boolean) => void` | --         | Callback when touch mode changes                                                                                                                                                           |
+| `ref`               | `Ref<EsheetRendererHandle>`  | --         | Imperative handle for accessing responses and stores                                                                                                                                       |
 
 ## Ref API (`EsheetRendererHandle`)
 
-| Method                  | Returns                                                         | Description                                       |
-| ----------------------- | --------------------------------------------------------------- | ------------------------------------------------- |
-| `getRawResponse()`      | `FormResponse`                                                  | Get current response values for all fields        |
-| `getValidResponse()`    | `{ response: FormResponse \| null, errors: ValidationError[] }` | Validate + get responses                          |
-| `getFormStore()`        | `FormStore`                                                     | Get the underlying form state store (advanced)    |
-| `getUIStore()`          | `UIStore`                                                       | Get the underlying UI state store (advanced)      |
-| `isTouchModeEnabled()`  | `boolean`                                                       | Check if touch mode is currently enabled          |
-| `setTouchMode(enabled)` | `void`                                                          | Manually enable/disable touch mode                |
-| `resetTouchMode()`      | `void`                                                          | Reset to auto-detection (when `touchMode="auto"`) |
+| Method                  | Returns                                                         | Description                                                                                                                            |
+| ----------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `getRawResponse()`      | `FormResponse`                                                  | Get current response values for all fields                                                                                             |
+| `getResponse(options?)` | `FormResponse \| FhirQuestionnaireResponse`                     | Get responses in native or FHIR format. Pass `{ format: 'fhir' }` to get a FHIR `QuestionnaireResponse`. See [Responses](./responses). |
+| `getValidResponse()`    | `{ response: FormResponse \| null, errors: ValidationError[] }` | Validate + get responses                                                                                                               |
+| `getFormStore()`        | `FormStore`                                                     | Get the underlying form state store (advanced)                                                                                         |
+| `getUIStore()`          | `UIStore`                                                       | Get the underlying UI state store (advanced)                                                                                           |
+| `isTouchModeEnabled()`  | `boolean`                                                       | Check if touch mode is currently enabled                                                                                               |
+| `setTouchMode(enabled)` | `void`                                                          | Manually enable/disable touch mode                                                                                                     |
+| `resetTouchMode()`      | `void`                                                          | Reset to auto-detection (when `touchMode="auto"`)                                                                                      |
 
 ## Features
 

--- a/apps/docs/docs/renderer/responses.md
+++ b/apps/docs/docs/renderer/responses.md
@@ -88,6 +88,61 @@ function MyForm() {
 }
 ```
 
+## Response Format Options
+
+The renderer supports multiple output formats via the `getResponse()` method:
+
+### Native Format (Default)
+
+Returns the raw `FieldResponseMap` — structured response objects keyed by field ID:
+
+```tsx
+const response = ref.current?.getResponse();
+// or explicitly:
+const response = ref.current?.getResponse({ format: 'native' });
+```
+
+### FHIR QuestionnaireResponse
+
+Export responses directly as a FHIR R4 QuestionnaireResponse resource:
+
+```tsx
+const fhirResponse = ref.current?.getResponse({
+  format: 'fhir',
+  fhir: {
+    questionnaireUrl: 'http://example.org/Questionnaire/my-form',
+    status: 'completed',
+    subject: { reference: 'Patient/123' },
+    author: { reference: 'Practitioner/456' },
+  },
+});
+
+// Returns:
+// {
+//   resourceType: 'QuestionnaireResponse',
+//   questionnaire: 'http://example.org/Questionnaire/my-form',
+//   status: 'completed',
+//   subject: { reference: 'Patient/123' },
+//   author: { reference: 'Practitioner/456' },
+//   authored: '2024-01-15T10:30:00Z',
+//   item: [...]
+// }
+```
+
+**FHIR Options:**
+
+| Option             | Type            | Description                                                                        |
+| ------------------ | --------------- | ---------------------------------------------------------------------------------- |
+| `questionnaireUrl` | `string`        | Canonical URL of the questionnaire (auto-detected if imported from FHIR)           |
+| `status`           | `string`        | Response status: `'in-progress'`, `'completed'`, `'amended'`, `'entered-in-error'` |
+| `subject`          | `FhirReference` | Patient/subject reference (e.g., `{ reference: 'Patient/123' }`)                   |
+| `author`           | `FhirReference` | Author reference                                                                   |
+| `resourceId`       | `string`        | Resource ID for the QuestionnaireResponse                                          |
+
+:::tip
+If the form was imported from a FHIR Questionnaire, the `questionnaireUrl` is automatically detected from the original resource metadata.
+:::
+
 ## Pre-filling Responses
 
 Pass `initialResponses` to populate the form with existing data:

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -44,7 +44,12 @@ const sidebars = {
     {
       type: 'category',
       label: 'Adapters',
-      items: ['adapters/overview', 'adapters/surveyjs', 'adapters/mcp'],
+      items: [
+        'adapters/overview',
+        'adapters/surveyjs',
+        'adapters/mcp',
+        'adapters/fhir',
+      ],
     },
     {
       type: 'category',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,10 +58,6 @@ export default [
               onlyDependOnLibsWithTags: ['scope:core'],
             },
             {
-              sourceTag: 'scope:ai-gateway',
-              onlyDependOnLibsWithTags: ['scope:core'],
-            },
-            {
               sourceTag: 'scope:adapters',
               onlyDependOnLibsWithTags: ['scope:core'],
             },
@@ -73,7 +69,7 @@ export default [
                 'scope:fields',
                 'scope:builder',
                 'scope:renderer',
-                'scope:ai-gateway',
+                'scope:adapters',
               ],
             },
           ],

--- a/packages/adapters/src/fhir/fhir-adapter.spec.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.spec.ts
@@ -413,6 +413,32 @@ describe('importFromFhir', () => {
     }
   });
 
+  it('imports display fields with content (not question)', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'intro',
+          type: 'display',
+          text: 'Over the last 2 weeks, how often have you been bothered?',
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const field = form.fields[0];
+
+    expect(field.id).toBe('intro');
+    expect(field.fieldType).toBe('display');
+    expect('question' in field).toBe(false);
+    if (field.fieldType === 'display') {
+      expect(field.content).toBe(
+        'Over the last 2 weeks, how often have you been bothered?'
+      );
+    }
+  });
+
   it('imports choice fields with options', () => {
     const fhir: FhirQuestionnaire = {
       resourceType: 'Questionnaire',

--- a/packages/adapters/src/fhir/fhir-adapter.spec.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.spec.ts
@@ -1,0 +1,1160 @@
+// ---------------------------------------------------------------------------
+// FHIR Adapter Tests
+// ---------------------------------------------------------------------------
+
+import type {
+  FhirQuestionnaire,
+  FhirQuestionnaireResponse,
+  FhirQuestionnaireItem,
+} from './types.js';
+
+import {
+  isFhirQuestionnaire,
+  isFhirQuestionnaireResponse,
+  mapFhirTypeToEsheet,
+  mapEsheetTypeToFhir,
+  convertAnswerOptionToFieldOption,
+  mapFhirOperatorToEsheet,
+  FHIR_EXT,
+} from './utils.js';
+
+import {
+  importFromFhir,
+  exportToFhir,
+  importResponseFromFhir,
+  exportResponseToFhir,
+} from './fhir-adapter.js';
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+describe('isFhirQuestionnaire', () => {
+  it('returns true for valid Questionnaire resource', () => {
+    const q = { resourceType: 'Questionnaire', status: 'draft' };
+    expect(isFhirQuestionnaire(q)).toBe(true);
+  });
+
+  it('returns false for QuestionnaireResponse', () => {
+    const r = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'test',
+      status: 'completed',
+    };
+    expect(isFhirQuestionnaire(r)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isFhirQuestionnaire(null)).toBe(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isFhirQuestionnaire('string')).toBe(false);
+  });
+});
+
+describe('isFhirQuestionnaireResponse', () => {
+  it('returns true for valid QuestionnaireResponse', () => {
+    const r = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'test',
+      status: 'completed',
+    };
+    expect(isFhirQuestionnaireResponse(r)).toBe(true);
+  });
+
+  it('returns false for Questionnaire', () => {
+    const q = { resourceType: 'Questionnaire', status: 'draft' };
+    expect(isFhirQuestionnaireResponse(q)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type Mapping
+// ---------------------------------------------------------------------------
+
+describe('mapFhirTypeToEsheet', () => {
+  const makeItem = (
+    type: FhirQuestionnaireItem['type'],
+    opts?: Partial<FhirQuestionnaireItem>
+  ): FhirQuestionnaireItem => ({
+    linkId: 'test',
+    type,
+    ...opts,
+  });
+
+  it('maps string to text', () => {
+    const result = mapFhirTypeToEsheet('string', makeItem('string'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('string');
+  });
+
+  it('maps text to longtext', () => {
+    const result = mapFhirTypeToEsheet('text', makeItem('text'));
+    expect(result.fieldType).toBe('longtext');
+  });
+
+  it('maps boolean to boolean', () => {
+    const result = mapFhirTypeToEsheet('boolean', makeItem('boolean'));
+    expect(result.fieldType).toBe('boolean');
+  });
+
+  it('maps date to text with date inputType', () => {
+    const result = mapFhirTypeToEsheet('date', makeItem('date'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('date');
+  });
+
+  it('maps dateTime to text with datetime-local inputType', () => {
+    const result = mapFhirTypeToEsheet('dateTime', makeItem('dateTime'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('datetime-local');
+  });
+
+  it('maps time to text with time inputType', () => {
+    const result = mapFhirTypeToEsheet('time', makeItem('time'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('time');
+  });
+
+  it('maps url to text with url inputType', () => {
+    const result = mapFhirTypeToEsheet('url', makeItem('url'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('url');
+  });
+
+  it('maps decimal to text with number inputType', () => {
+    const result = mapFhirTypeToEsheet('decimal', makeItem('decimal'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('number');
+  });
+
+  it('maps integer to text with number inputType', () => {
+    const result = mapFhirTypeToEsheet('integer', makeItem('integer'));
+    expect(result.fieldType).toBe('text');
+    expect(result.inputType).toBe('number');
+  });
+
+  it('maps integer with slider itemControl to slider', () => {
+    const result = mapFhirTypeToEsheet(
+      'integer',
+      makeItem('integer', {
+        extension: [
+          {
+            url: FHIR_EXT.ITEM_CONTROL,
+            valueCodeableConcept: {
+              coding: [{ code: 'slider' }],
+            },
+          },
+        ],
+      })
+    );
+    expect(result.fieldType).toBe('slider');
+  });
+
+  it('maps choice to radio by default', () => {
+    const result = mapFhirTypeToEsheet('choice', makeItem('choice'));
+    expect(result.fieldType).toBe('radio');
+  });
+
+  it('maps choice with repeats to check', () => {
+    const result = mapFhirTypeToEsheet(
+      'choice',
+      makeItem('choice', { repeats: true })
+    );
+    expect(result.fieldType).toBe('check');
+  });
+
+  it('maps choice with drop-down itemControl to dropdown', () => {
+    const result = mapFhirTypeToEsheet(
+      'choice',
+      makeItem('choice', {
+        extension: [
+          {
+            url: FHIR_EXT.ITEM_CONTROL,
+            valueCodeableConcept: {
+              coding: [{ code: 'drop-down' }],
+            },
+          },
+        ],
+      })
+    );
+    expect(result.fieldType).toBe('dropdown');
+  });
+
+  it('maps group to section', () => {
+    const result = mapFhirTypeToEsheet('group', makeItem('group'));
+    expect(result.fieldType).toBe('section');
+  });
+
+  it('maps display to display', () => {
+    const result = mapFhirTypeToEsheet('display', makeItem('display'));
+    expect(result.fieldType).toBe('display');
+  });
+
+  it('maps attachment to diagram by default', () => {
+    const result = mapFhirTypeToEsheet('attachment', makeItem('attachment'));
+    expect(result.fieldType).toBe('diagram');
+  });
+
+  it('maps attachment with signatureRequired to signature', () => {
+    const result = mapFhirTypeToEsheet(
+      'attachment',
+      makeItem('attachment', {
+        extension: [
+          {
+            url: FHIR_EXT.SIGNATURE_REQUIRED,
+            valueBoolean: true,
+          },
+        ],
+      })
+    );
+    expect(result.fieldType).toBe('signature');
+  });
+});
+
+describe('mapEsheetTypeToFhir', () => {
+  it('maps text to string', () => {
+    const result = mapEsheetTypeToFhir('text');
+    expect(result.type).toBe('string');
+  });
+
+  it('maps text with number inputType to decimal', () => {
+    const result = mapEsheetTypeToFhir('text', 'number');
+    expect(result.type).toBe('decimal');
+  });
+
+  it('maps text with date inputType to date', () => {
+    const result = mapEsheetTypeToFhir('text', 'date');
+    expect(result.type).toBe('date');
+  });
+
+  it('maps longtext to text', () => {
+    const result = mapEsheetTypeToFhir('longtext');
+    expect(result.type).toBe('text');
+  });
+
+  it('maps boolean to boolean', () => {
+    const result = mapEsheetTypeToFhir('boolean');
+    expect(result.type).toBe('boolean');
+  });
+
+  it('maps radio to choice with radio-button itemControl', () => {
+    const result = mapEsheetTypeToFhir('radio');
+    expect(result.type).toBe('choice');
+    expect(result.itemControl).toBe('radio-button');
+  });
+
+  it('maps check to choice with check-box and repeats', () => {
+    const result = mapEsheetTypeToFhir('check');
+    expect(result.type).toBe('choice');
+    expect(result.itemControl).toBe('check-box');
+    expect(result.repeats).toBe(true);
+  });
+
+  it('maps dropdown to choice with drop-down itemControl', () => {
+    const result = mapEsheetTypeToFhir('dropdown');
+    expect(result.type).toBe('choice');
+    expect(result.itemControl).toBe('drop-down');
+  });
+
+  it('maps section to group', () => {
+    const result = mapEsheetTypeToFhir('section');
+    expect(result.type).toBe('group');
+  });
+
+  it('maps signature to attachment', () => {
+    const result = mapEsheetTypeToFhir('signature');
+    expect(result.type).toBe('attachment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operator Mapping
+// ---------------------------------------------------------------------------
+
+describe('mapFhirOperatorToEsheet', () => {
+  it('maps = to equals', () => {
+    expect(mapFhirOperatorToEsheet('=')).toBe('equals');
+  });
+
+  it('maps != to notEquals', () => {
+    expect(mapFhirOperatorToEsheet('!=')).toBe('notEquals');
+  });
+
+  it('maps > to greaterThan', () => {
+    expect(mapFhirOperatorToEsheet('>')).toBe('greaterThan');
+  });
+
+  it('maps >= to greaterThanOrEqual', () => {
+    expect(mapFhirOperatorToEsheet('>=')).toBe('greaterThanOrEqual');
+  });
+
+  it('maps < to lessThan', () => {
+    expect(mapFhirOperatorToEsheet('<')).toBe('lessThan');
+  });
+
+  it('maps <= to lessThanOrEqual', () => {
+    expect(mapFhirOperatorToEsheet('<=')).toBe('lessThanOrEqual');
+  });
+
+  it('maps exists with answerBoolean=true to notEmpty', () => {
+    expect(mapFhirOperatorToEsheet('exists', true)).toBe('notEmpty');
+  });
+
+  it('maps exists with answerBoolean=false to empty', () => {
+    expect(mapFhirOperatorToEsheet('exists', false)).toBe('empty');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option Conversion
+// ---------------------------------------------------------------------------
+
+describe('convertAnswerOptionToFieldOption', () => {
+  it('converts valueCoding option', () => {
+    const existingIds = new Set<string>();
+    const option = {
+      valueCoding: {
+        code: 'yes',
+        display: 'Yes, I agree',
+      },
+    };
+
+    const result = convertAnswerOptionToFieldOption(option, existingIds, 0);
+
+    expect(result.id).toBe('yes');
+    expect(result.value).toBe('yes');
+    expect(result.text).toBe('Yes, I agree');
+  });
+
+  it('converts valueString option', () => {
+    const existingIds = new Set<string>();
+    const option = { valueString: 'Hello World' };
+
+    const result = convertAnswerOptionToFieldOption(option, existingIds, 0);
+
+    expect(result.id).toBe('hello-world');
+    expect(result.value).toBe('Hello World');
+  });
+
+  it('converts valueInteger option', () => {
+    const existingIds = new Set<string>();
+    const option = { valueInteger: 42 };
+
+    const result = convertAnswerOptionToFieldOption(option, existingIds, 0);
+
+    expect(result.id).toBe('42');
+    expect(result.value).toBe('42');
+  });
+
+  it('extracts ordinalValue score', () => {
+    const existingIds = new Set<string>();
+    const option = {
+      valueCoding: { code: 'opt1', display: 'Option 1' },
+      extension: [
+        {
+          url: FHIR_EXT.ORDINAL_VALUE,
+          valueDecimal: 3,
+        },
+      ],
+    };
+
+    const result = convertAnswerOptionToFieldOption(option, existingIds, 0);
+
+    expect(result.score).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import: Basic Questionnaire
+// ---------------------------------------------------------------------------
+
+describe('importFromFhir', () => {
+  it('imports a simple questionnaire', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'test-form',
+      status: 'draft',
+      title: 'Test Form',
+      description: 'A test form',
+      item: [
+        {
+          linkId: 'q1',
+          text: 'What is your name?',
+          type: 'string',
+          required: true,
+        },
+        {
+          linkId: 'q2',
+          text: 'How old are you?',
+          type: 'integer',
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+
+    expect(form.id).toBe('test-form');
+    expect(form.title).toBe('Test Form');
+    expect(form.description).toBe('A test form');
+    expect(form.fields).toHaveLength(2);
+
+    const [q1, q2] = form.fields;
+    expect(q1.id).toBe('q1');
+    expect(q1.fieldType).toBe('text');
+    expect(q1.question).toBe('What is your name?');
+    expect(q1.required).toBe(true);
+
+    expect(q2.id).toBe('q2');
+    expect(q2.fieldType).toBe('text');
+    if (q2.fieldType === 'text') {
+      expect(q2.inputType).toBe('number');
+    }
+  });
+
+  it('imports choice fields with options', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'gender',
+          text: 'What is your gender?',
+          type: 'choice',
+          answerOption: [
+            { valueCoding: { code: 'male', display: 'Male' } },
+            { valueCoding: { code: 'female', display: 'Female' } },
+            { valueCoding: { code: 'other', display: 'Other' } },
+          ],
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const field = form.fields[0];
+
+    expect(field.fieldType).toBe('radio');
+    if (field.fieldType === 'radio') {
+      expect(field.options).toHaveLength(3);
+      expect(field.options?.[0].value).toBe('male');
+      expect(field.options?.[0].text).toBe('Male');
+    }
+  });
+
+  it('imports nested groups as sections', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'section1',
+          text: 'Personal Info',
+          type: 'group',
+          item: [
+            {
+              linkId: 'name',
+              text: 'Name',
+              type: 'string',
+            },
+            {
+              linkId: 'dob',
+              text: 'Date of Birth',
+              type: 'date',
+            },
+          ],
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const section = form.fields[0];
+
+    expect(section.fieldType).toBe('section');
+    if (section.fieldType === 'section') {
+      expect(section.title).toBe('Personal Info');
+      expect(section.fields).toHaveLength(2);
+      expect(section.fields?.[0].id).toBe('name');
+      expect(section.fields?.[1].id).toBe('dob');
+      if (section.fields?.[1].fieldType === 'text') {
+        expect(section.fields[1].inputType).toBe('date');
+      }
+    }
+  });
+
+  it('imports enableWhen conditions', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'has-condition',
+          text: 'Do you have a condition?',
+          type: 'boolean',
+        },
+        {
+          linkId: 'condition-details',
+          text: 'Please describe',
+          type: 'text',
+          enableWhen: [
+            {
+              question: 'has-condition',
+              operator: '=',
+              answerBoolean: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const conditionalField = form.fields[1];
+
+    expect(conditionalField.rules).toHaveLength(1);
+    expect(conditionalField.rules?.[0].effect).toBe('visible');
+    expect(conditionalField.rules?.[0].conditions[0].targetId).toBe(
+      'has-condition'
+    );
+    expect(conditionalField.rules?.[0].conditions[0].operator).toBe('equals');
+    expect(conditionalField.rules?.[0].conditions[0].expected).toBe('true');
+  });
+
+  it('preserves form metadata in _sourceData', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'test',
+      url: 'http://example.com/Questionnaire/test',
+      version: '1.0.0',
+      status: 'active',
+      publisher: 'Test Publisher',
+      item: [],
+    };
+
+    const form = importFromFhir(fhir);
+    const meta = form._sourceData as Record<string, unknown>;
+
+    expect(meta.url).toBe('http://example.com/Questionnaire/test');
+    expect(meta.version).toBe('1.0.0');
+    expect(meta.status).toBe('active');
+    expect(meta.publisher).toBe('Test Publisher');
+  });
+
+  it('allows overriding form ID via options', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'original-id',
+      status: 'draft',
+      item: [],
+    };
+
+    const form = importFromFhir(fhir, { formId: 'custom-id' });
+
+    expect(form.id).toBe('custom-id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export: FormDefinition → FHIR
+// ---------------------------------------------------------------------------
+
+describe('exportToFhir', () => {
+  it('exports a simple form to FHIR', () => {
+    const form = {
+      id: 'test-form',
+      title: 'Test Form',
+      fields: [
+        {
+          id: 'q1',
+          fieldType: 'text' as const,
+          question: 'What is your name?',
+          required: true,
+        },
+        {
+          id: 'q2',
+          fieldType: 'boolean' as const,
+          question: 'Do you agree?',
+        },
+      ],
+    };
+
+    const fhir = exportToFhir(form);
+
+    expect(fhir.resourceType).toBe('Questionnaire');
+    expect(fhir.id).toBe('test-form');
+    expect(fhir.title).toBe('Test Form');
+    expect(fhir.status).toBe('draft');
+    expect(fhir.item).toHaveLength(2);
+
+    expect(fhir.item?.[0].linkId).toBe('q1');
+    expect(fhir.item?.[0].type).toBe('string');
+    expect(fhir.item?.[0].required).toBe(true);
+
+    expect(fhir.item?.[1].linkId).toBe('q2');
+    expect(fhir.item?.[1].type).toBe('boolean');
+  });
+
+  it('exports choice fields with options', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        {
+          id: 'gender',
+          fieldType: 'radio' as const,
+          question: 'Gender',
+          options: [
+            { id: 'male', value: 'male', text: 'Male' },
+            { id: 'female', value: 'female', text: 'Female' },
+          ],
+        },
+      ],
+    };
+
+    const fhir = exportToFhir(form);
+    const item = fhir.item?.[0];
+
+    expect(item?.type).toBe('choice');
+    expect(item?.answerOption).toHaveLength(2);
+    expect(item?.answerOption?.[0].valueCoding?.code).toBe('male');
+    expect(item?.answerOption?.[0].valueCoding?.display).toBe('Male');
+  });
+
+  it('exports sections as groups', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        {
+          id: 'section1',
+          fieldType: 'section' as const,
+          title: 'Section 1',
+          fields: [
+            {
+              id: 'nested-q',
+              fieldType: 'text' as const,
+              question: 'Nested Question',
+            },
+          ],
+        },
+      ],
+    };
+
+    const fhir = exportToFhir(form);
+    const section = fhir.item?.[0];
+
+    expect(section?.type).toBe('group');
+    expect(section?.text).toBe('Section 1');
+    expect(section?.item).toHaveLength(1);
+    expect(section?.item?.[0].linkId).toBe('nested-q');
+  });
+
+  it('exports visibility rules as enableWhen', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        {
+          id: 'q1',
+          fieldType: 'boolean' as const,
+          question: 'Show more?',
+        },
+        {
+          id: 'q2',
+          fieldType: 'text' as const,
+          question: 'Details',
+          rules: [
+            {
+              effect: 'visible' as const,
+              logic: 'AND' as const,
+              conditions: [
+                {
+                  conditionType: 'field' as const,
+                  targetId: 'q1',
+                  operator: 'equals' as const,
+                  expected: 'true',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const fhir = exportToFhir(form);
+    const q2 = fhir.item?.[1];
+
+    expect(q2?.enableWhen).toHaveLength(1);
+    expect(q2?.enableWhen?.[0].question).toBe('q1');
+    expect(q2?.enableWhen?.[0].operator).toBe('=');
+    expect(q2?.enableWhen?.[0].answerBoolean).toBe(true);
+  });
+
+  it('applies export options', () => {
+    const form = {
+      id: 'test',
+      fields: [],
+    };
+
+    const fhir = exportToFhir(form, {
+      resourceId: 'custom-id',
+      canonicalUrl: 'http://example.com/fhir',
+      status: 'active',
+      publisher: 'Test Publisher',
+      dtrCompliant: true,
+    });
+
+    expect(fhir.id).toBe('custom-id');
+    expect(fhir.url).toBe('http://example.com/fhir/Questionnaire/test');
+    expect(fhir.status).toBe('active');
+    expect(fhir.publisher).toBe('Test Publisher');
+    expect(fhir.subjectType).toContain('Patient');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-Trip
+// ---------------------------------------------------------------------------
+
+describe('round-trip', () => {
+  it('preserves basic structure through import → export', () => {
+    const original: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      id: 'round-trip-test',
+      status: 'active',
+      title: 'Round Trip Test',
+      item: [
+        {
+          linkId: 'name',
+          text: 'Name',
+          type: 'string',
+          required: true,
+        },
+        {
+          linkId: 'age',
+          text: 'Age',
+          type: 'integer',
+        },
+        {
+          linkId: 'active',
+          text: 'Is Active?',
+          type: 'boolean',
+        },
+      ],
+    };
+
+    const form = importFromFhir(original);
+    const exported = exportToFhir(form);
+
+    expect(exported.id).toBe('round-trip-test');
+    expect(exported.title).toBe('Round Trip Test');
+    expect(exported.item).toHaveLength(3);
+
+    expect(exported.item?.[0].linkId).toBe('name');
+    expect(exported.item?.[0].type).toBe('string');
+    expect(exported.item?.[0].required).toBe(true);
+
+    expect(exported.item?.[1].linkId).toBe('age');
+    // Note: integer becomes decimal unless we preserve original type
+    expect(['decimal', 'integer']).toContain(exported.item?.[1].type);
+
+    expect(exported.item?.[2].linkId).toBe('active');
+    expect(exported.item?.[2].type).toBe('boolean');
+  });
+
+  it('preserves choice options through round-trip', () => {
+    const original: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'color',
+          text: 'Favorite Color',
+          type: 'choice',
+          answerOption: [
+            { valueCoding: { code: 'red', display: 'Red' } },
+            { valueCoding: { code: 'blue', display: 'Blue' } },
+            { valueCoding: { code: 'green', display: 'Green' } },
+          ],
+        },
+      ],
+    };
+
+    const form = importFromFhir(original);
+    const exported = exportToFhir(form);
+
+    expect(exported.item?.[0].answerOption).toHaveLength(3);
+    expect(exported.item?.[0].answerOption?.[0].valueCoding?.code).toBe('red');
+    expect(exported.item?.[0].answerOption?.[1].valueCoding?.code).toBe('blue');
+    expect(exported.item?.[0].answerOption?.[2].valueCoding?.code).toBe(
+      'green'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response Import
+// ---------------------------------------------------------------------------
+
+describe('importResponseFromFhir', () => {
+  it('imports simple response answers', () => {
+    const response: FhirQuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'http://example.com/Questionnaire/test',
+      status: 'completed',
+      item: [
+        {
+          linkId: 'name',
+          answer: [{ valueString: 'John Doe' }],
+        },
+        {
+          linkId: 'age',
+          answer: [{ valueInteger: 30 }],
+        },
+        {
+          linkId: 'active',
+          answer: [{ valueBoolean: true }],
+        },
+      ],
+    };
+
+    const answers = importResponseFromFhir(response);
+
+    expect(answers.name).toBe('John Doe');
+    expect(answers.age).toBe(30);
+    expect(answers.active).toBe(true);
+  });
+
+  it('imports coding answers as code values', () => {
+    const response: FhirQuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'test',
+      status: 'completed',
+      item: [
+        {
+          linkId: 'gender',
+          answer: [{ valueCoding: { code: 'male', display: 'Male' } }],
+        },
+      ],
+    };
+
+    const answers = importResponseFromFhir(response);
+
+    expect(answers.gender).toBe('male');
+  });
+
+  it('imports multiple answers as array', () => {
+    const response: FhirQuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'test',
+      status: 'completed',
+      item: [
+        {
+          linkId: 'colors',
+          answer: [
+            { valueCoding: { code: 'red' } },
+            { valueCoding: { code: 'blue' } },
+          ],
+        },
+      ],
+    };
+
+    const answers = importResponseFromFhir(response);
+
+    expect(answers.colors).toEqual(['red', 'blue']);
+  });
+
+  it('imports nested response items', () => {
+    const response: FhirQuestionnaireResponse = {
+      resourceType: 'QuestionnaireResponse',
+      questionnaire: 'test',
+      status: 'completed',
+      item: [
+        {
+          linkId: 'section1',
+          item: [
+            {
+              linkId: 'nested-q',
+              answer: [{ valueString: 'nested answer' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const answers = importResponseFromFhir(response);
+
+    expect(answers['nested-q']).toBe('nested answer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response Export
+// ---------------------------------------------------------------------------
+
+describe('exportResponseToFhir', () => {
+  it('exports simple answers to response', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        { id: 'name', fieldType: 'text' as const, question: 'Name' },
+        { id: 'age', fieldType: 'text' as const, inputType: 'number' as const },
+        { id: 'active', fieldType: 'boolean' as const },
+      ],
+    };
+
+    const answers = {
+      name: 'John Doe',
+      age: 30,
+      active: true,
+    };
+
+    const response = exportResponseToFhir(form, answers, {
+      questionnaireUrl: 'http://example.com/Questionnaire/test',
+    });
+
+    expect(response.resourceType).toBe('QuestionnaireResponse');
+    expect(response.questionnaire).toBe(
+      'http://example.com/Questionnaire/test'
+    );
+    expect(response.status).toBe('completed');
+    expect(response.item).toHaveLength(3);
+
+    expect(response.item?.[0].answer?.[0].valueString).toBe('John Doe');
+    expect(response.item?.[1].answer?.[0].valueDecimal).toBe(30);
+    expect(response.item?.[2].answer?.[0].valueBoolean).toBe(true);
+  });
+
+  it('exports choice answers with valueCoding', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        {
+          id: 'gender',
+          fieldType: 'radio' as const,
+          options: [
+            { id: 'male', value: 'male', text: 'Male' },
+            { id: 'female', value: 'female', text: 'Female' },
+          ],
+        },
+      ],
+    };
+
+    const answers = { gender: 'male' };
+
+    const response = exportResponseToFhir(form, answers, {
+      questionnaireUrl: 'test',
+    });
+
+    expect(response.item?.[0].answer?.[0].valueCoding?.code).toBe('male');
+    expect(response.item?.[0].answer?.[0].valueCoding?.display).toBe('Male');
+  });
+
+  it('exports multiple selections as multiple answers', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        {
+          id: 'colors',
+          fieldType: 'check' as const,
+          options: [
+            { id: 'red', value: 'red', text: 'Red' },
+            { id: 'blue', value: 'blue', text: 'Blue' },
+            { id: 'green', value: 'green', text: 'Green' },
+          ],
+        },
+      ],
+    };
+
+    const answers = { colors: ['red', 'blue'] };
+
+    const response = exportResponseToFhir(form, answers, {
+      questionnaireUrl: 'test',
+    });
+
+    expect(response.item?.[0].answer).toHaveLength(2);
+    expect(response.item?.[0].answer?.[0].valueCoding?.code).toBe('red');
+    expect(response.item?.[0].answer?.[1].valueCoding?.code).toBe('blue');
+  });
+
+  it('skips fields with no answer', () => {
+    const form = {
+      id: 'test',
+      fields: [
+        { id: 'q1', fieldType: 'text' as const },
+        { id: 'q2', fieldType: 'text' as const },
+      ],
+    };
+
+    const answers = { q1: 'answer1' };
+
+    const response = exportResponseToFhir(form, answers, {
+      questionnaireUrl: 'test',
+    });
+
+    expect(response.item).toHaveLength(1);
+    expect(response.item?.[0].linkId).toBe('q1');
+  });
+
+  it('applies response options', () => {
+    const form = { id: 'test', fields: [] };
+
+    const response = exportResponseToFhir(
+      form,
+      {},
+      {
+        questionnaireUrl: 'http://example.com/Q/test',
+        resourceId: 'response-123',
+        status: 'in-progress',
+        subject: { reference: 'Patient/123' },
+        author: { reference: 'Practitioner/456' },
+      }
+    );
+
+    expect(response.id).toBe('response-123');
+    expect(response.status).toBe('in-progress');
+    expect(response.subject?.reference).toBe('Patient/123');
+    expect(response.author?.reference).toBe('Practitioner/456');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge Cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  it('handles empty questionnaire', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+    };
+
+    const form = importFromFhir(fhir);
+
+    expect(form.fields).toHaveLength(0);
+    expect(form.id).toBeTruthy(); // Should generate an ID
+  });
+
+  it('handles questionnaire with no item array', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: undefined,
+    };
+
+    const form = importFromFhir(fhir);
+
+    expect(form.fields).toHaveLength(0);
+  });
+
+  it('handles deeply nested sections', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'level1',
+          type: 'group',
+          text: 'Level 1',
+          item: [
+            {
+              linkId: 'level2',
+              type: 'group',
+              text: 'Level 2',
+              item: [
+                {
+                  linkId: 'level3',
+                  type: 'string',
+                  text: 'Deep Question',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const level1 = form.fields[0];
+
+    expect(level1.fieldType).toBe('section');
+    if (level1.fieldType === 'section') {
+      const level2 = level1.fields?.[0];
+      expect(level2?.fieldType).toBe('section');
+      if (level2?.fieldType === 'section') {
+        expect(level2.fields?.[0].id).toBe('level3');
+      }
+    }
+  });
+
+  it('adds warning for answerValueSet reference and preserves URL', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        {
+          linkId: 'q1',
+          type: 'choice',
+          answerValueSet: 'http://example.com/ValueSet/test',
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const meta = form._sourceData as { _conversionWarnings?: unknown[] };
+
+    expect(meta._conversionWarnings).toBeDefined();
+    expect(meta._conversionWarnings).toHaveLength(1);
+
+    // Verify answerValueSet URL is preserved in field's _sourceData
+    const fieldMeta = form.fields[0]._sourceData as { answerValueSet?: string };
+    expect(fieldMeta.answerValueSet).toBe('http://example.com/ValueSet/test');
+  });
+
+  it('handles enableWhen with multiple conditions', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        { linkId: 'q1', type: 'boolean' },
+        { linkId: 'q2', type: 'integer' },
+        {
+          linkId: 'q3',
+          type: 'string',
+          enableWhen: [
+            { question: 'q1', operator: '=', answerBoolean: true },
+            { question: 'q2', operator: '>', answerInteger: 10 },
+          ],
+          enableBehavior: 'all',
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const q3 = form.fields[2];
+
+    expect(q3.rules?.[0].conditions).toHaveLength(2);
+    expect(q3.rules?.[0].logic).toBe('AND');
+  });
+
+  it('handles enableWhen with any behavior', () => {
+    const fhir: FhirQuestionnaire = {
+      resourceType: 'Questionnaire',
+      status: 'draft',
+      item: [
+        { linkId: 'q1', type: 'boolean' },
+        { linkId: 'q2', type: 'boolean' },
+        {
+          linkId: 'q3',
+          type: 'string',
+          enableWhen: [
+            { question: 'q1', operator: '=', answerBoolean: true },
+            { question: 'q2', operator: '=', answerBoolean: true },
+          ],
+          enableBehavior: 'any',
+        },
+      ],
+    };
+
+    const form = importFromFhir(fhir);
+    const q3 = form.fields[2];
+
+    expect(q3.rules?.[0].logic).toBe('OR');
+  });
+});

--- a/packages/adapters/src/fhir/fhir-adapter.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.ts
@@ -188,8 +188,17 @@ function convertItemToField(
         ...(typeResult.inputType ? { inputType: typeResult.inputType } : {}),
       };
 
-    case 'boolean':
     case 'display':
+      // Display fields have no question — FHIR item.text maps to content (the displayed text)
+      return {
+        id: base.id,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: 'display',
+        content: item.text,
+      };
+
+    case 'boolean':
     case 'signature':
     case 'diagram':
       return {

--- a/packages/adapters/src/fhir/fhir-adapter.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.ts
@@ -1,0 +1,763 @@
+// ---------------------------------------------------------------------------
+// FHIR R4 Adapter - Bidirectional conversion
+// ---------------------------------------------------------------------------
+
+import type {
+  FormDefinition,
+  FieldDefinition,
+  FieldOption,
+  ConditionalRule,
+  Condition,
+  TextInputType,
+  SectionFieldDefinition,
+} from '@esheet/core';
+
+import type {
+  FhirQuestionnaire,
+  FhirQuestionnaireItem,
+  FhirQuestionnaireResponse,
+  FhirQuestionnaireResponseItem,
+  FhirResponseAnswer,
+  FhirAnswerOption,
+  FhirEnableWhen,
+  FhirExtension,
+  FhirImportOptions,
+  FhirExportOptions,
+  ResponseImportOptions,
+  ResponseExportOptions,
+  ImportWarning,
+  FhirFieldMeta,
+  FhirFormMeta,
+  FhirCoding,
+} from './types.js';
+
+import {
+  isFhirQuestionnaire,
+  isFhirQuestionnaireResponse,
+  mapFhirTypeToEsheet,
+  mapEsheetTypeToFhir,
+  convertAnswerOptionToFieldOption,
+  convertOptionToFhirAnswerOption,
+  mapFhirOperatorToEsheet,
+  mapEsheetOperatorToFhir,
+  mapEnableBehaviorToLogic,
+  extractEnableWhenAnswer,
+  getExtensionValue,
+  createItemControlExtension,
+  createSignatureRequiredExtension,
+  generateUUID,
+  FHIR_EXT,
+} from './utils.js';
+
+// Re-export type guards
+export { isFhirQuestionnaire, isFhirQuestionnaireResponse };
+
+// ---------------------------------------------------------------------------
+// Import: FHIR Questionnaire → FormDefinition
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a FHIR R4 Questionnaire to an eSheet FormDefinition.
+ */
+export function importFromFhir(
+  questionnaire: FhirQuestionnaire,
+  options?: FhirImportOptions
+): FormDefinition {
+  const warnings: ImportWarning[] = [];
+  const formId =
+    options?.formId ?? questionnaire.id ?? questionnaire.name ?? generateUUID();
+
+  const form: FormDefinition = {
+    id: formId,
+    title: questionnaire.title,
+    description: questionnaire.description,
+    fields: [],
+    _sourceData: extractFormMetadata(questionnaire, options),
+  };
+
+  if (questionnaire.item) {
+    form.fields = questionnaire.item.map((item, index) =>
+      convertItemToField(item, `item[${index}]`, warnings, options)
+    );
+  }
+
+  if (warnings.length > 0) {
+    const meta = form._sourceData as FhirFormMeta;
+    (meta as { _conversionWarnings: ImportWarning[] })._conversionWarnings =
+      warnings;
+  }
+
+  return form;
+}
+
+function extractFormMetadata(
+  q: FhirQuestionnaire,
+  options?: FhirImportOptions
+): FhirFormMeta {
+  const meta: FhirFormMeta = {};
+  const preserve = options?.preserveExtensions !== false;
+
+  if (q.url) (meta as { url: string }).url = q.url;
+  if (q.version) (meta as { version: string }).version = q.version;
+  if (q.name) (meta as { name: string }).name = q.name;
+  if (q.status) (meta as { status: string }).status = q.status;
+  if (q.publisher) (meta as { publisher: string }).publisher = q.publisher;
+  if (q.date) (meta as { date: string }).date = q.date;
+  if (q.subjectType)
+    (meta as { subjectType: readonly string[] }).subjectType = q.subjectType;
+  if (q.derivedFrom)
+    (meta as { derivedFrom: readonly string[] }).derivedFrom = q.derivedFrom;
+  if (q.code) (meta as { code: readonly FhirCoding[] }).code = q.code;
+
+  if (preserve && q.extension) {
+    (meta as { fhirExtensions: readonly FhirExtension[] }).fhirExtensions =
+      q.extension;
+  }
+
+  return meta;
+}
+
+function convertItemToField(
+  item: FhirQuestionnaireItem,
+  path: string,
+  warnings: ImportWarning[],
+  options?: FhirImportOptions
+): FieldDefinition {
+  const typeResult = mapFhirTypeToEsheet(item.type, item);
+  const existingIds = new Set<string>();
+
+  // Build base field
+  const base = {
+    id: item.linkId,
+    question: item.text,
+    required: item.required,
+  };
+
+  // Build _sourceData for round-trip
+  const fieldMeta: FhirFieldMeta = buildFieldMeta(item, typeResult, options);
+  const hasFieldMeta = Object.keys(fieldMeta).length > 0;
+
+  // Convert enableWhen to rules
+  const rules = convertEnableWhenToRules(item.enableWhen, item.enableBehavior);
+  const rulesSpread = rules.length > 0 ? { rules } : {};
+
+  // Handle warnings for lossy conversions
+  addConversionWarnings(item, path, typeResult, warnings);
+
+  // Build field based on type
+  switch (typeResult.fieldType) {
+    case 'section':
+      return buildSectionField(
+        base,
+        item,
+        path,
+        warnings,
+        options,
+        hasFieldMeta ? fieldMeta : undefined
+      );
+
+    case 'radio':
+    case 'check':
+    case 'dropdown':
+    case 'multiselectdropdown':
+      return {
+        ...base,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: typeResult.fieldType,
+        options: convertAnswerOptions(item.answerOption, existingIds),
+      };
+
+    case 'rating':
+    case 'slider':
+      return {
+        ...base,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: typeResult.fieldType,
+        options: convertAnswerOptions(item.answerOption, existingIds),
+      };
+
+    case 'text':
+    case 'longtext':
+      return {
+        ...base,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: typeResult.fieldType,
+        ...(typeResult.inputType ? { inputType: typeResult.inputType } : {}),
+      };
+
+    case 'boolean':
+    case 'display':
+    case 'signature':
+    case 'diagram':
+      return {
+        ...base,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: typeResult.fieldType,
+      };
+
+    default:
+      return {
+        ...base,
+        ...(hasFieldMeta ? { _sourceData: fieldMeta } : {}),
+        ...rulesSpread,
+        fieldType: 'text',
+      };
+  }
+}
+
+function buildSectionField(
+  base: { id: string; question?: string; required?: boolean },
+  item: FhirQuestionnaireItem,
+  path: string,
+  warnings: ImportWarning[],
+  options?: FhirImportOptions,
+  fieldMeta?: FhirFieldMeta
+): SectionFieldDefinition {
+  const nestedFields = item.item
+    ? item.item.map((child, i) =>
+        convertItemToField(child, `${path}.item[${i}]`, warnings, options)
+      )
+    : [];
+
+  return {
+    ...base,
+    ...(fieldMeta ? { _sourceData: fieldMeta } : {}),
+    fieldType: 'section',
+    title: item.text,
+    fields: nestedFields,
+  };
+}
+
+function buildFieldMeta(
+  item: FhirQuestionnaireItem,
+  typeResult: {
+    fieldType: string;
+    inputType?: TextInputType;
+    subType?: string;
+  },
+  options?: FhirImportOptions
+): FhirFieldMeta {
+  const meta: FhirFieldMeta = {};
+  const preserve = options?.preserveExtensions !== false;
+
+  if (item.definition)
+    (meta as { definition: string }).definition = item.definition;
+  if (item.code) (meta as { code: readonly FhirCoding[] }).code = item.code;
+  if (item.prefix) (meta as { prefix: string }).prefix = item.prefix;
+  if (item.readOnly) (meta as { readOnly: boolean }).readOnly = item.readOnly;
+  if (item.repeats) (meta as { repeats: boolean }).repeats = item.repeats;
+
+  // Store original FHIR type for export
+  (meta as { fhirItemType: string }).fhirItemType = item.type;
+
+  // Extract validation extensions
+  const minVal = getExtensionValue<number | string>(
+    item.extension,
+    FHIR_EXT.MIN_VALUE
+  );
+  const maxVal = getExtensionValue<number | string>(
+    item.extension,
+    FHIR_EXT.MAX_VALUE
+  );
+  const minLen = getExtensionValue<number>(item.extension, FHIR_EXT.MIN_LENGTH);
+  const regex = getExtensionValue<string>(item.extension, FHIR_EXT.REGEX);
+
+  if (minVal !== undefined)
+    (meta as { minValue: number | string }).minValue = minVal;
+  if (maxVal !== undefined)
+    (meta as { maxValue: number | string }).maxValue = maxVal;
+  if (minLen !== undefined) (meta as { minLength: number }).minLength = minLen;
+  if (regex !== undefined) (meta as { regex: string }).regex = regex;
+
+  // Preserve unknown extensions
+  if (preserve && item.extension) {
+    (meta as { fhirExtensions: readonly FhirExtension[] }).fhirExtensions =
+      item.extension;
+  }
+
+  // Preserve answerValueSet URL for client-side resolution
+  if (item.answerValueSet) {
+    (meta as { answerValueSet: string }).answerValueSet = item.answerValueSet;
+  }
+
+  return meta;
+}
+
+function convertAnswerOptions(
+  answerOptions: readonly FhirAnswerOption[] | undefined,
+  existingIds: Set<string>
+): FieldOption[] {
+  if (!answerOptions) return [];
+
+  return answerOptions.map((opt, index) =>
+    convertAnswerOptionToFieldOption(opt, existingIds, index)
+  );
+}
+
+function convertEnableWhenToRules(
+  enableWhen: readonly FhirEnableWhen[] | undefined,
+  enableBehavior: 'all' | 'any' | undefined
+): ConditionalRule[] {
+  if (!enableWhen || enableWhen.length === 0) return [];
+
+  const conditions: Condition[] = [];
+
+  for (const ew of enableWhen) {
+    const operator = mapFhirOperatorToEsheet(ew.operator, ew.answerBoolean);
+    if (!operator) continue;
+
+    conditions.push({
+      conditionType: 'field',
+      targetId: ew.question,
+      operator,
+      expected: extractEnableWhenAnswer(ew),
+    });
+  }
+
+  if (conditions.length === 0) return [];
+
+  return [
+    {
+      effect: 'visible',
+      logic: mapEnableBehaviorToLogic(enableBehavior),
+      conditions,
+    },
+  ];
+}
+
+function addConversionWarnings(
+  item: FhirQuestionnaireItem,
+  path: string,
+  typeResult: { fieldType: string; subType?: string },
+  warnings: ImportWarning[]
+): void {
+  // Reference type warning
+  if (typeResult.subType === 'reference') {
+    warnings.push({
+      path,
+      code: 'UNSUPPORTED_TYPE',
+      message: `FHIR reference type converted to text field. Type safety lost.`,
+    });
+  }
+
+  // Quantity type warning
+  if (typeResult.subType === 'quantity') {
+    warnings.push({
+      path,
+      code: 'UNSUPPORTED_TYPE',
+      message: `FHIR quantity type converted to number field. Unit choices lost.`,
+    });
+  }
+
+  // ValueSet reference (informational)
+  if (item.answerValueSet) {
+    warnings.push({
+      path,
+      code: 'VALUESET_NOT_EXPANDED',
+      severity: 'info',
+      message: `ValueSet "${item.answerValueSet}" requires expansion. URL preserved in _sourceData.answerValueSet for client-side $expand.`,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Export: FormDefinition → FHIR Questionnaire
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an eSheet FormDefinition to a FHIR R4 Questionnaire.
+ */
+export function exportToFhir(
+  form: FormDefinition,
+  options?: FhirExportOptions
+): FhirQuestionnaire {
+  const sourceMeta = form._sourceData as FhirFormMeta | undefined;
+
+  const questionnaire: FhirQuestionnaire = {
+    resourceType: 'Questionnaire',
+    id: options?.resourceId ?? form.id,
+    url: options?.canonicalUrl
+      ? `${options.canonicalUrl}/Questionnaire/${form.id}`
+      : sourceMeta?.url ?? `urn:uuid:${generateUUID()}`,
+    status: options?.status ?? sourceMeta?.status ?? 'draft',
+    title: form.title,
+    description: form.description,
+    ...(sourceMeta?.version ? { version: sourceMeta.version } : {}),
+    ...(options?.publisher ?? sourceMeta?.publisher
+      ? { publisher: options?.publisher ?? sourceMeta?.publisher }
+      : {}),
+    ...(sourceMeta?.date ? { date: sourceMeta.date } : {}),
+    item: form.fields.map(convertFieldToItem),
+  };
+
+  // DTR compliance
+  if (options?.dtrCompliant) {
+    (questionnaire as unknown as { subjectType: string[] }).subjectType = [
+      'Patient',
+    ];
+  }
+
+  // Restore preserved extensions
+  if (sourceMeta?.fhirExtensions) {
+    (
+      questionnaire as unknown as { extension: readonly FhirExtension[] }
+    ).extension = sourceMeta.fhirExtensions;
+  }
+
+  return questionnaire;
+}
+
+function convertFieldToItem(field: FieldDefinition): FhirQuestionnaireItem {
+  const fieldMeta = field._sourceData as FhirFieldMeta | undefined;
+  const inputType =
+    'inputType' in field ? (field.inputType as TextInputType) : undefined;
+  const typeResult = mapEsheetTypeToFhir(field.fieldType, inputType);
+
+  // For sections, use title if question is not set
+  const text =
+    field.question ??
+    (field.fieldType === 'section' && 'title' in field
+      ? field.title
+      : undefined);
+
+  const item: FhirQuestionnaireItem = {
+    linkId: field.id,
+    text,
+    type: typeResult.type,
+    ...(field.required ? { required: true } : {}),
+    ...(typeResult.repeats ? { repeats: true } : {}),
+    ...(fieldMeta?.readOnly ? { readOnly: true } : {}),
+  };
+
+  // Build extensions array
+  const extensions: FhirExtension[] = [];
+
+  // Add itemControl extension
+  if (typeResult.itemControl) {
+    extensions.push(createItemControlExtension(typeResult.itemControl));
+  }
+
+  // Add signature extension for signature fields
+  if (field.fieldType === 'signature') {
+    extensions.push(createSignatureRequiredExtension());
+  }
+
+  // Add preserved extensions
+  if (fieldMeta?.fhirExtensions) {
+    // Filter out extensions we're generating ourselves
+    const preserved = fieldMeta.fhirExtensions.filter(
+      (e) =>
+        e.url !== FHIR_EXT.ITEM_CONTROL && e.url !== FHIR_EXT.SIGNATURE_REQUIRED
+    );
+    extensions.push(...preserved);
+  }
+
+  if (extensions.length > 0) {
+    (item as unknown as { extension: FhirExtension[] }).extension = extensions;
+  }
+
+  // Add answer options
+  if ('options' in field && field.options && field.options.length > 0) {
+    (item as unknown as { answerOption: FhirAnswerOption[] }).answerOption =
+      field.options.map(convertOptionToFhirAnswerOption);
+  }
+
+  // Add enableWhen for visibility rules
+  const enableWhen = convertRulesToEnableWhen(field.rules);
+  if (enableWhen.length > 0) {
+    (item as unknown as { enableWhen: FhirEnableWhen[] }).enableWhen =
+      enableWhen;
+    if (enableWhen.length > 1) {
+      // Check original logic mode
+      const visibleRule = field.rules?.find((r) => r.effect === 'visible');
+      (item as unknown as { enableBehavior: 'all' | 'any' }).enableBehavior =
+        visibleRule?.logic === 'OR' ? 'any' : 'all';
+    }
+  }
+
+  // Handle nested fields for sections
+  if (field.fieldType === 'section' && 'fields' in field && field.fields) {
+    (item as unknown as { item: FhirQuestionnaireItem[] }).item =
+      field.fields.map(convertFieldToItem);
+  }
+
+  // Restore definition, code, prefix from metadata
+  if (fieldMeta?.definition)
+    (item as { definition: string }).definition = fieldMeta.definition;
+  if (fieldMeta?.code)
+    (item as { code: readonly FhirCoding[] }).code = fieldMeta.code;
+  if (fieldMeta?.prefix) (item as { prefix: string }).prefix = fieldMeta.prefix;
+
+  return item;
+}
+
+function convertRulesToEnableWhen(
+  rules: ConditionalRule[] | undefined
+): FhirEnableWhen[] {
+  if (!rules) return [];
+
+  // Only convert 'visible' rules to enableWhen
+  const visibleRule = rules.find((r) => r.effect === 'visible');
+  if (!visibleRule) return [];
+
+  return visibleRule.conditions
+    .map((cond) => {
+      if (cond.conditionType === 'expression') return null;
+      if (!cond.targetId || !cond.operator) return null;
+
+      const fhirOp = mapEsheetOperatorToFhir(cond.operator);
+      if (!fhirOp) return null;
+
+      const ew: FhirEnableWhen = {
+        question: cond.targetId,
+        operator: fhirOp.operator,
+      };
+
+      // Set the answer value
+      if (fhirOp.answerBoolean !== undefined) {
+        (ew as { answerBoolean: boolean }).answerBoolean = fhirOp.answerBoolean;
+      } else if (cond.expected !== undefined) {
+        // Determine answer type based on expected value
+        if (cond.expected === 'true' || cond.expected === 'false') {
+          (ew as { answerBoolean: boolean }).answerBoolean =
+            cond.expected === 'true';
+        } else if (!isNaN(Number(cond.expected))) {
+          (ew as { answerDecimal: number }).answerDecimal = Number(
+            cond.expected
+          );
+        } else {
+          (ew as { answerString: string }).answerString = cond.expected;
+        }
+      }
+
+      return ew;
+    })
+    .filter((ew): ew is FhirEnableWhen => ew !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Import: FHIR QuestionnaireResponse → Answers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a FHIR QuestionnaireResponse to an eSheet answer map.
+ */
+export function importResponseFromFhir(
+  response: FhirQuestionnaireResponse,
+  options?: ResponseImportOptions
+): Record<string, unknown> {
+  const answers: Record<string, unknown> = {};
+
+  if (response.item) {
+    collectResponseAnswers(response.item, answers);
+  }
+
+  return answers;
+}
+
+function collectResponseAnswers(
+  items: readonly FhirQuestionnaireResponseItem[],
+  answers: Record<string, unknown>
+): void {
+  for (const item of items) {
+    if (item.answer && item.answer.length > 0) {
+      answers[item.linkId] = extractAnswerValue(item.answer);
+    }
+
+    // Recurse into nested items
+    if (item.item) {
+      collectResponseAnswers(item.item, answers);
+    }
+
+    // Also recurse into answer-nested items
+    for (const ans of item.answer ?? []) {
+      if (ans.item) {
+        collectResponseAnswers(ans.item, answers);
+      }
+    }
+  }
+}
+
+function extractAnswerValue(answers: readonly FhirResponseAnswer[]): unknown {
+  // Multiple answers → array (for repeating items)
+  if (answers.length > 1) {
+    return answers.map(extractSingleAnswerValue);
+  }
+
+  return extractSingleAnswerValue(answers[0]);
+}
+
+function extractSingleAnswerValue(answer: FhirResponseAnswer): unknown {
+  if (answer.valueBoolean !== undefined) return answer.valueBoolean;
+  if (answer.valueDecimal !== undefined) return answer.valueDecimal;
+  if (answer.valueInteger !== undefined) return answer.valueInteger;
+  if (answer.valueDate !== undefined) return answer.valueDate;
+  if (answer.valueDateTime !== undefined) return answer.valueDateTime;
+  if (answer.valueTime !== undefined) return answer.valueTime;
+  if (answer.valueString !== undefined) return answer.valueString;
+  if (answer.valueUri !== undefined) return answer.valueUri;
+  if (answer.valueCoding) return answer.valueCoding.code;
+  if (answer.valueQuantity) return answer.valueQuantity.value;
+  if (answer.valueAttachment) return answer.valueAttachment.data;
+  if (answer.valueReference) return answer.valueReference.reference;
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Export: Answers → FHIR QuestionnaireResponse
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert eSheet answers to a FHIR QuestionnaireResponse.
+ */
+export function exportResponseToFhir(
+  form: FormDefinition,
+  answers: Record<string, unknown>,
+  options: ResponseExportOptions
+): FhirQuestionnaireResponse {
+  const response: FhirQuestionnaireResponse = {
+    resourceType: 'QuestionnaireResponse',
+    ...(options.resourceId ? { id: options.resourceId } : {}),
+    questionnaire: options.questionnaireUrl,
+    status: options.status ?? 'completed',
+    ...(options.subject ? { subject: options.subject } : {}),
+    ...(options.author ? { author: options.author } : {}),
+    authored: new Date().toISOString(),
+    item: convertFieldsToResponseItems(form.fields, answers),
+  };
+
+  return response;
+}
+
+function convertFieldsToResponseItems(
+  fields: readonly FieldDefinition[],
+  answers: Record<string, unknown>
+): FhirQuestionnaireResponseItem[] {
+  const items: FhirQuestionnaireResponseItem[] = [];
+
+  for (const field of fields) {
+    const item = convertFieldToResponseItem(field, answers);
+    if (item) {
+      items.push(item);
+    }
+  }
+
+  return items;
+}
+
+function convertFieldToResponseItem(
+  field: FieldDefinition,
+  answers: Record<string, unknown>
+): FhirQuestionnaireResponseItem | null {
+  const value = answers[field.id];
+
+  // Handle sections recursively
+  if (field.fieldType === 'section' && 'fields' in field && field.fields) {
+    const nestedItems = convertFieldsToResponseItems(field.fields, answers);
+    if (nestedItems.length === 0) return null;
+
+    return {
+      linkId: field.id,
+      text: field.question,
+      item: nestedItems,
+    };
+  }
+
+  // Skip fields with no answer
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const item: FhirQuestionnaireResponseItem = {
+    linkId: field.id,
+    text: field.question,
+    answer: convertValueToAnswers(field, value),
+  };
+
+  return item;
+}
+
+function convertValueToAnswers(
+  field: FieldDefinition,
+  value: unknown
+): FhirResponseAnswer[] {
+  const inputType =
+    'inputType' in field ? (field.inputType as TextInputType) : undefined;
+
+  switch (field.fieldType) {
+    case 'text':
+    case 'longtext':
+      return [convertTextAnswer(value, inputType)];
+
+    case 'boolean':
+      return [{ valueBoolean: Boolean(value) }];
+
+    case 'radio':
+    case 'dropdown':
+      return [createCodingAnswer(field, value as string)];
+
+    case 'check':
+    case 'multiselectdropdown': {
+      const selected = Array.isArray(value) ? value : [value];
+      return selected.map((v) => createCodingAnswer(field, v as string));
+    }
+
+    case 'rating':
+    case 'slider':
+      return [{ valueInteger: Number(value) }];
+
+    case 'signature':
+    case 'diagram':
+      return [
+        {
+          valueAttachment: {
+            contentType: 'image/png',
+            data: value as string,
+          },
+        },
+      ];
+
+    default:
+      return [{ valueString: String(value) }];
+  }
+}
+
+function convertTextAnswer(
+  value: unknown,
+  inputType?: TextInputType
+): FhirResponseAnswer {
+  switch (inputType) {
+    case 'number':
+      return { valueDecimal: Number(value) };
+    case 'date':
+      return { valueDate: value as string };
+    case 'datetime-local':
+      return { valueDateTime: value as string };
+    case 'time':
+      return { valueTime: value as string };
+    case 'url':
+      return { valueUri: value as string };
+    default:
+      return { valueString: String(value) };
+  }
+}
+
+function createCodingAnswer(
+  field: FieldDefinition,
+  selectedId: string
+): FhirResponseAnswer {
+  const options = 'options' in field ? field.options : undefined;
+  const option = options?.find((o: FieldOption) => o.id === selectedId);
+
+  return {
+    valueCoding: {
+      code: option?.value ?? selectedId,
+      display: option?.text,
+    },
+  };
+}

--- a/packages/adapters/src/fhir/index.ts
+++ b/packages/adapters/src/fhir/index.ts
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------
+// FHIR Adapter - Public API
+// ---------------------------------------------------------------------------
+
+// Types
+export type {
+  // Primitives
+  FhirCoding,
+  FhirCodeableConcept,
+  FhirReference,
+  FhirIdentifier,
+  FhirPeriod,
+  FhirAttachment,
+  FhirQuantity,
+  FhirExpression,
+  FhirExpressionLanguage,
+  FhirExtension,
+  FhirMeta,
+  FhirContactDetail,
+  FhirContactPoint,
+  FhirUsageContext,
+  FhirRange,
+  // Questionnaire
+  FhirQuestionnaireStatus,
+  FhirQuestionnaireItemType,
+  FhirEnableWhenOperator,
+  FhirEnableBehavior,
+  FhirEnableWhen,
+  FhirAnswerOption,
+  FhirInitialValue,
+  FhirQuestionnaireItem,
+  FhirQuestionnaire,
+  // Response
+  FhirResponseStatus,
+  FhirResponseAnswer,
+  FhirQuestionnaireResponseItem,
+  FhirQuestionnaireResponse,
+  // Options & Warnings
+  FhirImportOptions,
+  FhirExportOptions,
+  ResponseImportOptions,
+  ResponseExportOptions,
+  ImportWarning,
+  ImportWarningCode,
+  ImportWarningSeverity,
+  // Metadata
+  FhirFieldMeta,
+  FhirFormMeta,
+} from './types.js';
+
+// Type guards
+export { isFhirQuestionnaire, isFhirQuestionnaireResponse } from './utils.js';
+
+// Adapter functions
+export {
+  importFromFhir,
+  exportToFhir,
+  importResponseFromFhir,
+  exportResponseToFhir,
+} from './fhir-adapter.js';
+
+// Utility functions (for advanced users)
+export {
+  mapFhirTypeToEsheet,
+  mapEsheetTypeToFhir,
+  convertAnswerOptionToFieldOption,
+  convertOptionToFhirAnswerOption,
+  mapFhirOperatorToEsheet,
+  mapEsheetOperatorToFhir,
+  getExtensionValue,
+  createItemControlExtension,
+  FHIR_EXT,
+  ITEM_CONTROL_SYSTEM,
+} from './utils.js';

--- a/packages/adapters/src/fhir/types.ts
+++ b/packages/adapters/src/fhir/types.ts
@@ -1,0 +1,430 @@
+// ---------------------------------------------------------------------------
+// FHIR R4 Type Definitions for Questionnaire/QuestionnaireResponse
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Primitive Types
+// ---------------------------------------------------------------------------
+
+export interface FhirCoding {
+  readonly system?: string;
+  readonly version?: string;
+  readonly code?: string;
+  readonly display?: string;
+  readonly userSelected?: boolean;
+}
+
+export interface FhirCodeableConcept {
+  readonly coding?: readonly FhirCoding[];
+  readonly text?: string;
+}
+
+export interface FhirReference {
+  readonly reference?: string;
+  readonly type?: string;
+  readonly identifier?: FhirIdentifier;
+  readonly display?: string;
+}
+
+export interface FhirIdentifier {
+  readonly use?: 'usual' | 'official' | 'temp' | 'secondary' | 'old';
+  readonly type?: FhirCodeableConcept;
+  readonly system?: string;
+  readonly value?: string;
+  readonly period?: FhirPeriod;
+}
+
+export interface FhirPeriod {
+  readonly start?: string;
+  readonly end?: string;
+}
+
+export interface FhirAttachment {
+  readonly contentType?: string;
+  readonly language?: string;
+  readonly data?: string; // Base64
+  readonly url?: string;
+  readonly size?: number;
+  readonly hash?: string;
+  readonly title?: string;
+  readonly creation?: string;
+}
+
+export interface FhirQuantity {
+  readonly value?: number;
+  readonly comparator?: '<' | '<=' | '>=' | '>';
+  readonly unit?: string;
+  readonly system?: string;
+  readonly code?: string;
+}
+
+export type FhirExpressionLanguage =
+  | 'text/cql'
+  | 'text/fhirpath'
+  | 'application/x-fhir-query';
+
+export interface FhirExpression {
+  readonly description?: string;
+  readonly name?: string;
+  readonly language: FhirExpressionLanguage;
+  readonly expression?: string;
+  readonly reference?: string;
+}
+
+export interface FhirExtension {
+  readonly url: string;
+  readonly valueBoolean?: boolean;
+  readonly valueInteger?: number;
+  readonly valueDecimal?: number;
+  readonly valueString?: string;
+  readonly valueUri?: string;
+  readonly valueCode?: string;
+  readonly valueCoding?: FhirCoding;
+  readonly valueCodeableConcept?: FhirCodeableConcept;
+  readonly valueExpression?: FhirExpression;
+  readonly valueQuantity?: FhirQuantity;
+  readonly valueAttachment?: FhirAttachment;
+  readonly valueReference?: FhirReference;
+  readonly extension?: readonly FhirExtension[]; // Nested extensions
+}
+
+export interface FhirMeta {
+  readonly versionId?: string;
+  readonly lastUpdated?: string;
+  readonly source?: string;
+  readonly profile?: readonly string[];
+  readonly security?: readonly FhirCoding[];
+  readonly tag?: readonly FhirCoding[];
+}
+
+export interface FhirContactDetail {
+  readonly name?: string;
+  readonly telecom?: readonly FhirContactPoint[];
+}
+
+export interface FhirContactPoint {
+  readonly system?:
+    | 'phone'
+    | 'fax'
+    | 'email'
+    | 'pager'
+    | 'url'
+    | 'sms'
+    | 'other';
+  readonly value?: string;
+  readonly use?: 'home' | 'work' | 'temp' | 'old' | 'mobile';
+  readonly rank?: number;
+  readonly period?: FhirPeriod;
+}
+
+export interface FhirUsageContext {
+  readonly code: FhirCoding;
+  readonly valueCodeableConcept?: FhirCodeableConcept;
+  readonly valueQuantity?: FhirQuantity;
+  readonly valueRange?: FhirRange;
+  readonly valueReference?: FhirReference;
+}
+
+export interface FhirRange {
+  readonly low?: FhirQuantity;
+  readonly high?: FhirQuantity;
+}
+
+// ---------------------------------------------------------------------------
+// Questionnaire Types
+// ---------------------------------------------------------------------------
+
+export type FhirQuestionnaireStatus =
+  | 'draft'
+  | 'active'
+  | 'retired'
+  | 'unknown';
+
+export type FhirQuestionnaireItemType =
+  | 'group'
+  | 'display'
+  | 'boolean'
+  | 'decimal'
+  | 'integer'
+  | 'date'
+  | 'dateTime'
+  | 'time'
+  | 'string'
+  | 'text'
+  | 'url'
+  | 'choice'
+  | 'open-choice'
+  | 'attachment'
+  | 'reference'
+  | 'quantity';
+
+export type FhirEnableWhenOperator =
+  | 'exists'
+  | '='
+  | '!='
+  | '>'
+  | '<'
+  | '>='
+  | '<=';
+
+export type FhirEnableBehavior = 'all' | 'any';
+
+export interface FhirEnableWhen {
+  readonly question: string;
+  readonly operator: FhirEnableWhenOperator;
+  // answer[x] - polymorphic
+  readonly answerBoolean?: boolean;
+  readonly answerDecimal?: number;
+  readonly answerInteger?: number;
+  readonly answerDate?: string;
+  readonly answerDateTime?: string;
+  readonly answerTime?: string;
+  readonly answerString?: string;
+  readonly answerCoding?: FhirCoding;
+  readonly answerQuantity?: FhirQuantity;
+  readonly answerReference?: FhirReference;
+}
+
+export interface FhirAnswerOption {
+  // value[x] - polymorphic
+  readonly valueInteger?: number;
+  readonly valueDate?: string;
+  readonly valueTime?: string;
+  readonly valueString?: string;
+  readonly valueCoding?: FhirCoding;
+  readonly valueReference?: FhirReference;
+  readonly initialSelected?: boolean;
+  readonly extension?: readonly FhirExtension[];
+}
+
+export interface FhirInitialValue {
+  // value[x] - polymorphic
+  readonly valueBoolean?: boolean;
+  readonly valueDecimal?: number;
+  readonly valueInteger?: number;
+  readonly valueDate?: string;
+  readonly valueDateTime?: string;
+  readonly valueTime?: string;
+  readonly valueString?: string;
+  readonly valueUri?: string;
+  readonly valueAttachment?: FhirAttachment;
+  readonly valueCoding?: FhirCoding;
+  readonly valueQuantity?: FhirQuantity;
+  readonly valueReference?: FhirReference;
+}
+
+export interface FhirQuestionnaireItem {
+  readonly linkId: string;
+  readonly definition?: string;
+  readonly code?: readonly FhirCoding[];
+  readonly prefix?: string;
+  readonly text?: string;
+  readonly type: FhirQuestionnaireItemType;
+  readonly enableWhen?: readonly FhirEnableWhen[];
+  readonly enableBehavior?: FhirEnableBehavior;
+  readonly required?: boolean;
+  readonly repeats?: boolean;
+  readonly readOnly?: boolean;
+  readonly maxLength?: number;
+  readonly answerValueSet?: string;
+  readonly answerOption?: readonly FhirAnswerOption[];
+  readonly initial?: readonly FhirInitialValue[];
+  readonly item?: readonly FhirQuestionnaireItem[]; // Nested items (recursive)
+  readonly extension?: readonly FhirExtension[];
+}
+
+export interface FhirQuestionnaire {
+  readonly resourceType: 'Questionnaire';
+  readonly id?: string;
+  readonly meta?: FhirMeta;
+  readonly url?: string;
+  readonly identifier?: readonly FhirIdentifier[];
+  readonly version?: string;
+  readonly name?: string;
+  readonly title?: string;
+  readonly derivedFrom?: readonly string[];
+  readonly status: FhirQuestionnaireStatus;
+  readonly experimental?: boolean;
+  readonly subjectType?: readonly string[];
+  readonly date?: string;
+  readonly publisher?: string;
+  readonly contact?: readonly FhirContactDetail[];
+  readonly description?: string;
+  readonly useContext?: readonly FhirUsageContext[];
+  readonly jurisdiction?: readonly FhirCodeableConcept[];
+  readonly purpose?: string;
+  readonly copyright?: string;
+  readonly approvalDate?: string;
+  readonly lastReviewDate?: string;
+  readonly effectivePeriod?: FhirPeriod;
+  readonly code?: readonly FhirCoding[];
+  readonly item?: readonly FhirQuestionnaireItem[];
+  readonly extension?: readonly FhirExtension[];
+}
+
+// ---------------------------------------------------------------------------
+// QuestionnaireResponse Types
+// ---------------------------------------------------------------------------
+
+export type FhirResponseStatus =
+  | 'in-progress'
+  | 'completed'
+  | 'amended'
+  | 'entered-in-error'
+  | 'stopped';
+
+export interface FhirResponseAnswer {
+  // value[x] - polymorphic
+  readonly valueBoolean?: boolean;
+  readonly valueDecimal?: number;
+  readonly valueInteger?: number;
+  readonly valueDate?: string;
+  readonly valueDateTime?: string;
+  readonly valueTime?: string;
+  readonly valueString?: string;
+  readonly valueUri?: string;
+  readonly valueAttachment?: FhirAttachment;
+  readonly valueCoding?: FhirCoding;
+  readonly valueQuantity?: FhirQuantity;
+  readonly valueReference?: FhirReference;
+  readonly item?: readonly FhirQuestionnaireResponseItem[]; // Nested items
+}
+
+export interface FhirQuestionnaireResponseItem {
+  readonly linkId: string;
+  readonly definition?: string;
+  readonly text?: string;
+  readonly answer?: readonly FhirResponseAnswer[];
+  readonly item?: readonly FhirQuestionnaireResponseItem[];
+}
+
+export interface FhirQuestionnaireResponse {
+  readonly resourceType: 'QuestionnaireResponse';
+  readonly id?: string;
+  readonly meta?: FhirMeta;
+  readonly identifier?: FhirIdentifier;
+  readonly basedOn?: readonly FhirReference[];
+  readonly partOf?: readonly FhirReference[];
+  readonly questionnaire: string; // Canonical reference
+  readonly status: FhirResponseStatus;
+  readonly subject?: FhirReference;
+  readonly encounter?: FhirReference;
+  readonly authored?: string;
+  readonly author?: FhirReference;
+  readonly source?: FhirReference;
+  readonly item?: readonly FhirQuestionnaireResponseItem[];
+  readonly extension?: readonly FhirExtension[];
+}
+
+// ---------------------------------------------------------------------------
+// Adapter Options & Warnings
+// ---------------------------------------------------------------------------
+
+export interface FhirImportOptions {
+  /** Override generated form ID. */
+  readonly formId?: string;
+  /** Keep all extensions in _sourceData (default: true). */
+  readonly preserveExtensions?: boolean;
+  /** Fail on unsupported features (default: false). */
+  readonly strictMode?: boolean;
+}
+
+export interface FhirExportOptions {
+  /** Override resource ID. */
+  readonly resourceId?: string;
+  /** Base URL for canonical references. */
+  readonly canonicalUrl?: string;
+  /** Resource status (default: draft). */
+  readonly status?: FhirQuestionnaireStatus;
+  /** Publisher name. */
+  readonly publisher?: string;
+  /** Apply DTR profile constraints. */
+  readonly dtrCompliant?: boolean;
+}
+
+export interface ResponseImportOptions {
+  /** Form schema for type hints. */
+  readonly schema?: unknown;
+  /** Include display text in output. */
+  readonly extractText?: boolean;
+}
+
+export interface ResponseExportOptions {
+  /** Canonical reference to the questionnaire (required). */
+  readonly questionnaireUrl: string;
+  /** Patient/subject reference. */
+  readonly subject?: FhirReference;
+  /** Author reference. */
+  readonly author?: FhirReference;
+  /** Response status (default: completed). */
+  readonly status?: FhirResponseStatus;
+  /** Resource ID. */
+  readonly resourceId?: string;
+}
+
+export type ImportWarningCode =
+  | 'UNSUPPORTED_TYPE'
+  | 'EXPRESSION_PRESERVED'
+  | 'VALUESET_NOT_EXPANDED'
+  | 'NESTED_ANSWERS_FLATTENED'
+  | 'EXTENSION_PRESERVED'
+  | 'REPEAT_NOT_SUPPORTED';
+
+export type ImportWarningSeverity = 'info' | 'warning' | 'error';
+
+export interface ImportWarning {
+  readonly path: string; // JSON path (e.g., "item[0].item[2]")
+  readonly code: ImportWarningCode;
+  readonly message: string;
+  /** Severity level. Defaults to 'warning' if omitted. */
+  readonly severity?: ImportWarningSeverity;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter Metadata (stored in _sourceData)
+// ---------------------------------------------------------------------------
+
+export interface FhirFieldMeta {
+  // Standard FHIR properties not in eSheet schema
+  readonly definition?: string;
+  readonly code?: readonly FhirCoding[];
+  readonly prefix?: string;
+  readonly readOnly?: boolean;
+
+  // Extensions preserved verbatim for round-trip
+  readonly fhirExtensions?: readonly FhirExtension[];
+
+  // DTR-specific expressions (preserved, not evaluated)
+  readonly initialExpression?: FhirExpression;
+  readonly calculatedExpression?: FhirExpression;
+  readonly enableWhenExpression?: FhirExpression;
+
+  // Validation extensions
+  readonly minValue?: number | string;
+  readonly maxValue?: number | string;
+  readonly minLength?: number;
+  readonly regex?: string;
+
+  // Original item type (for ambiguous mappings)
+  readonly fhirItemType?: FhirQuestionnaireItemType;
+
+  // Repeats flag for export
+  readonly repeats?: boolean;
+
+  // ValueSet URL for client-side resolution
+  readonly answerValueSet?: string;
+}
+
+export interface FhirFormMeta {
+  readonly url?: string;
+  readonly version?: string;
+  readonly name?: string;
+  readonly status?: FhirQuestionnaireStatus;
+  readonly publisher?: string;
+  readonly date?: string;
+  readonly subjectType?: readonly string[];
+  readonly derivedFrom?: readonly string[];
+  readonly code?: readonly FhirCoding[];
+  readonly fhirExtensions?: readonly FhirExtension[];
+  readonly _conversionWarnings?: readonly ImportWarning[];
+}

--- a/packages/adapters/src/fhir/utils.ts
+++ b/packages/adapters/src/fhir/utils.ts
@@ -1,0 +1,598 @@
+// ---------------------------------------------------------------------------
+// FHIR Adapter Utilities
+// ---------------------------------------------------------------------------
+
+import type {
+  FieldOption,
+  ConditionOperator,
+  TextInputType,
+} from '@esheet/core';
+import { generateOptionId } from '@esheet/core';
+
+import type {
+  FhirQuestionnaire,
+  FhirQuestionnaireResponse,
+  FhirQuestionnaireItemType,
+  FhirQuestionnaireItem,
+  FhirCoding,
+  FhirAnswerOption,
+  FhirEnableWhen,
+  FhirEnableBehavior,
+  FhirEnableWhenOperator,
+  FhirExtension,
+  FhirCodeableConcept,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Extension URLs (Constants)
+// ---------------------------------------------------------------------------
+
+export const FHIR_EXT = {
+  // Questionnaire item control
+  ITEM_CONTROL:
+    'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+
+  // Validation
+  MIN_VALUE: 'http://hl7.org/fhir/StructureDefinition/minValue',
+  MAX_VALUE: 'http://hl7.org/fhir/StructureDefinition/maxValue',
+  MIN_LENGTH: 'http://hl7.org/fhir/StructureDefinition/minLength',
+  REGEX: 'http://hl7.org/fhir/StructureDefinition/regex',
+
+  // Option scoring
+  ORDINAL_VALUE: 'http://hl7.org/fhir/StructureDefinition/ordinalValue',
+
+  // Display
+  HIDDEN: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
+  ITEM_MEDIA: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemMedia',
+
+  // Slider
+  SLIDER_STEP:
+    'http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue',
+
+  // Signature
+  SIGNATURE_REQUIRED:
+    'http://hl7.org/fhir/StructureDefinition/questionnaire-signatureRequired',
+
+  // SDC / DTR
+  INITIAL_EXPRESSION:
+    'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression',
+  CALCULATED_EXPRESSION:
+    'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression',
+  ENABLE_WHEN_EXPRESSION:
+    'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-enableWhenExpression',
+  VARIABLE: 'http://hl7.org/fhir/StructureDefinition/variable',
+} as const;
+
+export const ITEM_CONTROL_SYSTEM =
+  'http://hl7.org/fhir/questionnaire-item-control';
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Type guard to check if a value is a FHIR Questionnaire resource.
+ */
+export function isFhirQuestionnaire(
+  value: unknown
+): value is FhirQuestionnaire {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v['resourceType'] === 'Questionnaire';
+}
+
+/**
+ * Type guard to check if a value is a FHIR QuestionnaireResponse resource.
+ */
+export function isFhirQuestionnaireResponse(
+  value: unknown
+): value is FhirQuestionnaireResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v['resourceType'] === 'QuestionnaireResponse';
+}
+
+// ---------------------------------------------------------------------------
+// Type Mapping: FHIR → eSheet
+// ---------------------------------------------------------------------------
+
+export interface EsheetFieldTypeResult {
+  readonly fieldType: string;
+  readonly inputType?: TextInputType;
+  readonly subType?: string;
+}
+
+/**
+ * Map a FHIR item type to eSheet field type.
+ */
+export function mapFhirTypeToEsheet(
+  fhirType: FhirQuestionnaireItemType,
+  item: FhirQuestionnaireItem
+): EsheetFieldTypeResult {
+  const itemControl = getItemControlCode(item.extension);
+
+  switch (fhirType) {
+    case 'string':
+      return { fieldType: 'text', inputType: 'string' };
+
+    case 'text':
+      return { fieldType: 'longtext' };
+
+    case 'boolean':
+      return { fieldType: 'boolean' };
+
+    case 'decimal':
+      return { fieldType: 'text', inputType: 'number' };
+
+    case 'integer':
+      if (itemControl === 'slider') {
+        return { fieldType: 'slider' };
+      }
+      return { fieldType: 'text', inputType: 'number' };
+
+    case 'date':
+      return { fieldType: 'text', inputType: 'date' };
+
+    case 'dateTime':
+      return { fieldType: 'text', inputType: 'datetime-local' };
+
+    case 'time':
+      return { fieldType: 'text', inputType: 'time' };
+
+    case 'url':
+      return { fieldType: 'text', inputType: 'url' };
+
+    case 'choice':
+    case 'open-choice':
+      return mapChoiceType(item, itemControl);
+
+    case 'group':
+      return { fieldType: 'section' };
+
+    case 'display':
+      return { fieldType: 'display' };
+
+    case 'attachment':
+      if (hasSignatureRequired(item.extension)) {
+        return { fieldType: 'signature' };
+      }
+      return { fieldType: 'diagram' };
+
+    case 'reference':
+      return { fieldType: 'text', subType: 'reference' };
+
+    case 'quantity':
+      return { fieldType: 'text', inputType: 'number', subType: 'quantity' };
+
+    default:
+      return { fieldType: 'text' };
+  }
+}
+
+function mapChoiceType(
+  item: FhirQuestionnaireItem,
+  itemControl: string | undefined
+): EsheetFieldTypeResult {
+  const repeats = item.repeats ?? false;
+
+  if (itemControl === 'drop-down' || itemControl === 'autocomplete') {
+    return repeats
+      ? { fieldType: 'multiselectdropdown' }
+      : { fieldType: 'dropdown' };
+  }
+
+  if (itemControl === 'check-box') {
+    return { fieldType: 'check' };
+  }
+
+  if (itemControl === 'radio-button') {
+    return { fieldType: 'radio' };
+  }
+
+  // Default based on repeats
+  return repeats ? { fieldType: 'check' } : { fieldType: 'radio' };
+}
+
+// ---------------------------------------------------------------------------
+// Type Mapping: eSheet → FHIR
+// ---------------------------------------------------------------------------
+
+export interface FhirFieldTypeResult {
+  readonly type: FhirQuestionnaireItemType;
+  readonly itemControl?: string;
+  readonly repeats?: boolean;
+}
+
+/**
+ * Map an eSheet field type to FHIR item type.
+ */
+export function mapEsheetTypeToFhir(
+  esheetType: string,
+  inputType?: TextInputType,
+  subType?: string
+): FhirFieldTypeResult {
+  switch (esheetType) {
+    case 'text':
+      return mapTextTypeToFhir(inputType);
+
+    case 'longtext':
+      return { type: 'text' };
+
+    case 'boolean':
+      return { type: 'boolean' };
+
+    case 'radio':
+      return { type: 'choice', itemControl: 'radio-button' };
+
+    case 'check':
+      return { type: 'choice', itemControl: 'check-box', repeats: true };
+
+    case 'dropdown':
+      return { type: 'choice', itemControl: 'drop-down' };
+
+    case 'multiselectdropdown':
+      return { type: 'choice', itemControl: 'drop-down', repeats: true };
+
+    case 'rating':
+      return { type: 'integer', itemControl: 'slider' };
+
+    case 'slider':
+      return { type: 'decimal', itemControl: 'slider' };
+
+    case 'section':
+      return { type: 'group' };
+
+    case 'display':
+      return { type: 'display' };
+
+    case 'signature':
+      return { type: 'attachment' };
+
+    case 'diagram':
+      return { type: 'attachment' };
+
+    case 'singlematrix':
+    case 'multimatrix':
+      return { type: 'group' };
+
+    case 'image':
+    case 'html':
+      return { type: 'display' };
+
+    default:
+      return { type: 'string' };
+  }
+}
+
+function mapTextTypeToFhir(inputType?: TextInputType): FhirFieldTypeResult {
+  switch (inputType) {
+    case 'number':
+      return { type: 'decimal' };
+    case 'date':
+      return { type: 'date' };
+    case 'datetime-local':
+      return { type: 'dateTime' };
+    case 'time':
+      return { type: 'time' };
+    case 'url':
+      return { type: 'url' };
+    default:
+      return { type: 'string' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options Conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a FHIR Coding to an eSheet FieldOption.
+ */
+export function convertFhirCodingToOption(
+  coding: FhirCoding,
+  existingIds: Set<string>,
+  fallbackIndex: number
+): FieldOption {
+  const id =
+    coding.code ?? generateOptionId(existingIds, `opt-${fallbackIndex}`);
+  existingIds.add(id);
+
+  return {
+    id,
+    value: coding.code ?? '',
+    ...(coding.display ? { text: coding.display } : {}),
+  };
+}
+
+/**
+ * Convert a FHIR answerOption to an eSheet FieldOption.
+ */
+export function convertAnswerOptionToFieldOption(
+  option: FhirAnswerOption,
+  existingIds: Set<string>,
+  index: number
+): FieldOption {
+  const opt: FieldOption = {
+    id: '',
+    value: '',
+  };
+
+  if (option.valueCoding) {
+    opt.id =
+      option.valueCoding.code ?? generateOptionId(existingIds, `opt-${index}`);
+    opt.value = option.valueCoding.code ?? '';
+    if (option.valueCoding.display) {
+      opt.text = option.valueCoding.display;
+    }
+  } else if (option.valueString !== undefined) {
+    opt.id = toKebabCase(option.valueString) || `opt-${index}`;
+    opt.value = option.valueString;
+  } else if (option.valueInteger !== undefined) {
+    opt.id = String(option.valueInteger);
+    opt.value = String(option.valueInteger);
+  } else if (option.valueDate !== undefined) {
+    opt.id = `date-${index}`;
+    opt.value = option.valueDate;
+  } else if (option.valueTime !== undefined) {
+    opt.id = `time-${index}`;
+    opt.value = option.valueTime;
+  } else {
+    opt.id = generateOptionId(existingIds, `opt-${index}`);
+  }
+
+  existingIds.add(opt.id);
+
+  // Extract ordinalValue score from extension
+  const ordinalExt = option.extension?.find(
+    (e) => e.url === FHIR_EXT.ORDINAL_VALUE
+  );
+  if (ordinalExt?.valueDecimal !== undefined) {
+    opt.score = ordinalExt.valueDecimal;
+  } else if (ordinalExt?.valueInteger !== undefined) {
+    opt.score = ordinalExt.valueInteger;
+  }
+
+  return opt;
+}
+
+/**
+ * Convert an eSheet FieldOption to a FHIR answerOption.
+ */
+export function convertOptionToFhirAnswerOption(
+  option: FieldOption
+): FhirAnswerOption {
+  const result: FhirAnswerOption = {};
+
+  // Prefer valueCoding for rich options (with display text or score)
+  if (option.text || option.score !== undefined) {
+    (result as { valueCoding: FhirCoding }).valueCoding = {
+      code: option.value,
+      display: option.text ?? option.value,
+      system: 'urn:esheet:options',
+    };
+
+    if (option.score !== undefined) {
+      (result as { extension: FhirExtension[] }).extension = [
+        {
+          url: FHIR_EXT.ORDINAL_VALUE,
+          valueDecimal: option.score,
+        },
+      ];
+    }
+  } else {
+    (result as { valueString: string }).valueString = option.value;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Condition/EnableWhen Conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a FHIR enableWhen operator to an eSheet condition operator.
+ */
+export function mapFhirOperatorToEsheet(
+  operator: FhirEnableWhenOperator,
+  answerBoolean?: boolean
+): ConditionOperator | null {
+  switch (operator) {
+    case '=':
+      return 'equals';
+    case '!=':
+      return 'notEquals';
+    case '>':
+      return 'greaterThan';
+    case '>=':
+      return 'greaterThanOrEqual';
+    case '<':
+      return 'lessThan';
+    case '<=':
+      return 'lessThanOrEqual';
+    case 'exists':
+      return answerBoolean === true ? 'notEmpty' : 'empty';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map an eSheet condition operator to a FHIR enableWhen operator.
+ */
+export function mapEsheetOperatorToFhir(
+  operator: ConditionOperator
+): { operator: FhirEnableWhenOperator; answerBoolean?: boolean } | null {
+  switch (operator) {
+    case 'equals':
+      return { operator: '=' };
+    case 'notEquals':
+      return { operator: '!=' };
+    case 'greaterThan':
+      return { operator: '>' };
+    case 'greaterThanOrEqual':
+      return { operator: '>=' };
+    case 'lessThan':
+      return { operator: '<' };
+    case 'lessThanOrEqual':
+      return { operator: '<=' };
+    case 'empty':
+      return { operator: 'exists', answerBoolean: false };
+    case 'notEmpty':
+      return { operator: 'exists', answerBoolean: true };
+    case 'contains':
+    case 'includes':
+      // These require FHIRPath expressions, not supported in basic enableWhen
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map FHIR enableBehavior to eSheet logic mode.
+ */
+export function mapEnableBehaviorToLogic(
+  behavior: FhirEnableBehavior | undefined
+): 'AND' | 'OR' {
+  return behavior === 'any' ? 'OR' : 'AND';
+}
+
+/**
+ * Extract the answer value from a FHIR enableWhen condition.
+ */
+export function extractEnableWhenAnswer(
+  enableWhen: FhirEnableWhen
+): string | undefined {
+  if (enableWhen.answerBoolean !== undefined) {
+    return String(enableWhen.answerBoolean);
+  }
+  if (enableWhen.answerDecimal !== undefined) {
+    return String(enableWhen.answerDecimal);
+  }
+  if (enableWhen.answerInteger !== undefined) {
+    return String(enableWhen.answerInteger);
+  }
+  if (enableWhen.answerDate !== undefined) {
+    return enableWhen.answerDate;
+  }
+  if (enableWhen.answerDateTime !== undefined) {
+    return enableWhen.answerDateTime;
+  }
+  if (enableWhen.answerTime !== undefined) {
+    return enableWhen.answerTime;
+  }
+  if (enableWhen.answerString !== undefined) {
+    return enableWhen.answerString;
+  }
+  if (enableWhen.answerCoding?.code !== undefined) {
+    return enableWhen.answerCoding.code;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Extension Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the value of an extension by URL.
+ */
+export function getExtensionValue<T = unknown>(
+  extensions: readonly FhirExtension[] | undefined,
+  url: string
+): T | undefined {
+  if (!extensions) return undefined;
+
+  const ext = extensions.find((e) => e.url === url);
+  if (!ext) return undefined;
+
+  // Return the first non-url value property
+  for (const key of Object.keys(ext)) {
+    if (key.startsWith('value')) {
+      return ext[key as keyof FhirExtension] as T;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get the itemControl code from extensions.
+ */
+export function getItemControlCode(
+  extensions: readonly FhirExtension[] | undefined
+): string | undefined {
+  if (!extensions) return undefined;
+
+  const ext = extensions.find((e) => e.url === FHIR_EXT.ITEM_CONTROL);
+  if (!ext) return undefined;
+
+  // itemControl uses valueCodeableConcept
+  const coding = ext.valueCodeableConcept?.coding?.[0];
+  return coding?.code;
+}
+
+/**
+ * Check if the signatureRequired extension is present and true.
+ */
+export function hasSignatureRequired(
+  extensions: readonly FhirExtension[] | undefined
+): boolean {
+  if (!extensions) return false;
+
+  const ext = extensions.find((e) => e.url === FHIR_EXT.SIGNATURE_REQUIRED);
+  return ext?.valueBoolean === true;
+}
+
+/**
+ * Create an itemControl extension.
+ */
+export function createItemControlExtension(controlType: string): FhirExtension {
+  return {
+    url: FHIR_EXT.ITEM_CONTROL,
+    valueCodeableConcept: {
+      coding: [
+        {
+          system: ITEM_CONTROL_SYSTEM,
+          code: controlType,
+        },
+      ],
+    } as FhirCodeableConcept,
+  };
+}
+
+/**
+ * Create a signatureRequired extension.
+ */
+export function createSignatureRequiredExtension(): FhirExtension {
+  return {
+    url: FHIR_EXT.SIGNATURE_REQUIRED,
+    valueBoolean: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// String Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a string to kebab-case for use as an ID.
+ */
+export function toKebabCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Generate a simple UUID v4.
+ */
+export function generateUUID(): string {
+  // Simple UUID v4 implementation
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -24,3 +24,4 @@ export {
   type McpArrayProp,
   type McpConstOption,
 } from './lib/mcp.js';
+export * from './fhir/index.js';

--- a/packages/adapters/vitest.config.mts
+++ b/packages/adapters/vitest.config.mts
@@ -2,9 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => ({
   root: __dirname,
-  cacheDir: '../../node_modules/.vite/packages/ai-gateway',
+  cacheDir: '../../node_modules/.vite/packages/adapters',
   test: {
-    name: '@esheet/ai-gateway',
+    name: '@esheet/adapters',
     watch: false,
     globals: true,
     environment: 'node',

--- a/packages/builder/src/lib/EsheetBuilder.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.tsx
@@ -69,7 +69,7 @@ export interface EsheetBuilderProps {
    * everything a developer needs is available through the builder's own UI and props.
    */
   onBuilderToolsReady?: (tools: BuilderTools) => void;
-  /** Whether drag-and-drop reordering is enabled (default: true). Disable for better performance on slow devices. */
+  /** Whether drag-and-drop reordering is enabled (default: true). When false, field reordering is disabled entirely — no fallback UI (e.g. arrow buttons) is shown. */
   dragEnabled?: boolean;
   /** Additional CSS class name. */
   className?: string;

--- a/packages/builder/src/lib/EsheetBuilder.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.tsx
@@ -18,8 +18,11 @@ import {
   isSurveyJSSchema,
   importFromMcp,
   isMcpElicitationRequest,
+  importFromFhir,
+  isFhirQuestionnaire,
   type McpElicitationRequest,
   type McpElicitationSchema,
+  type FhirQuestionnaire,
 } from '@esheet/adapters';
 import { Canvas } from './components/Canvas.js';
 import { ToolPanel } from './components/ToolPanel.js';
@@ -56,7 +59,7 @@ export type { BuilderTools, FieldSummary };
 // ---------------------------------------------------------------------------
 
 export interface EsheetBuilderProps {
-  /** Initial form definition to load. Also accepts SurveyJS or MCP elicitation schemas, which are auto-converted. */
+  /** Initial form definition to load. Also accepts SurveyJS, MCP elicitation, or FHIR Questionnaire schemas, which are auto-converted. */
   definition?: FormDefinition | Record<string, unknown>;
   /** Callback fired when the form definition changes. */
   onChange?: (definition: FormDefinition) => void;
@@ -120,7 +123,9 @@ export const EsheetBuilder = React.forwardRef<
 
   if (!formRef.current) {
     let resolved: FormDefinition | undefined;
-    if (isSurveyJSSchema(definition)) {
+    if (isFhirQuestionnaire(definition)) {
+      resolved = importFromFhir(definition as FhirQuestionnaire);
+    } else if (isSurveyJSSchema(definition)) {
       resolved = convertSurveyJS(
         definition as Parameters<typeof convertSurveyJS>[0]
       );

--- a/packages/builder/src/lib/components/BuilderHeader.tsx
+++ b/packages/builder/src/lib/components/BuilderHeader.tsx
@@ -18,8 +18,12 @@ import {
   convertSurveyJS,
   isSurveyJSSchema,
   isMcpElicitationRequest,
+  importFromFhir,
+  exportToFhir,
+  isFhirQuestionnaire,
   type McpElicitationRequest,
   type McpElicitationSchema,
+  type FhirQuestionnaire,
 } from '@esheet/adapters';
 import {
   VEditorIcon,
@@ -220,9 +224,9 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
   const [exportIdModalOpen, setExportIdModalOpen] = React.useState(false);
   const [exportIdInput, setExportIdInput] = React.useState('');
   const [exportIdError, setExportIdError] = React.useState('');
-  const [exportFormat, setExportFormat] = React.useState<'esheet' | 'mcp'>(
-    'esheet'
-  );
+  const [exportFormat, setExportFormat] = React.useState<
+    'esheet' | 'mcp' | 'fhir'
+  >('esheet');
   const [feedback, setFeedback] = React.useState<FeedbackState>({
     open: false,
     title: '',
@@ -307,6 +311,23 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
       const schema = exportToMcp(definition);
       const filename = (definition.id || 'form') + '-mcp-schema.json';
       const blob = new Blob([JSON.stringify(schema, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      setExportIdModalOpen(false);
+      return;
+    }
+
+    if (exportFormat === 'fhir') {
+      const definition = form.getState().hydrateDefinition();
+      const fhirQuestionnaire = exportToFhir(definition);
+      const filename = (definition.id || 'form') + '-fhir-questionnaire.json';
+      const blob = new Blob([JSON.stringify(fhirQuestionnaire, null, 2)], {
         type: 'application/json',
       });
       const url = URL.createObjectURL(blob);
@@ -409,6 +430,53 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
             );
             return;
           }
+        }
+
+        if (!isYaml && isFhirQuestionnaire(parsed)) {
+          const formDef = importFromFhir(parsed as FhirQuestionnaire);
+          form.getState().loadDefinition(formDef);
+          // Check for conversion warnings in _sourceData
+          type ConversionWarning = {
+            code: string;
+            itemLinkId?: string;
+            message: string;
+            severity?: 'info' | 'warning' | 'error';
+          };
+          const meta = formDef._sourceData as
+            | { _conversionWarnings?: ConversionWarning[] }
+            | undefined;
+          const allWarnings = meta?._conversionWarnings ?? [];
+          // Split by severity: info vs warning/error
+          const infoItems = allWarnings.filter((w) => w.severity === 'info');
+          const warnItems = allWarnings.filter((w) => w.severity !== 'info');
+          const hasActualWarnings = warnItems.length > 0;
+
+          if (allWarnings.length > 0) {
+            const items = hasActualWarnings ? warnItems : infoItems;
+            const prefix = hasActualWarnings ? '⚠️' : 'ℹ️';
+            showFeedback(
+              hasActualWarnings ? 'warning' : 'success',
+              hasActualWarnings
+                ? 'Import Successful (with warnings)'
+                : 'Import Successful',
+              `Loaded ${formDef.fields.length} field(s) from FHIR Questionnaire.`,
+              undefined,
+              items.map(
+                (w) =>
+                  `${prefix} [${w.code}] ${w.itemLinkId ?? 'form'}: ${
+                    w.message
+                  }`
+              ),
+              hasActualWarnings ? 'Import Warnings' : 'Import Notes'
+            );
+          } else {
+            showFeedback(
+              'success',
+              'Import Successful',
+              `Loaded ${formDef.fields.length} field(s) from FHIR Questionnaire.`
+            );
+          }
+          return;
         }
 
         if (!isYaml && isSurveyJSSchema(parsed)) {
@@ -522,7 +590,7 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
         open={exportIdModalOpen}
         title="Export Form"
         message={
-          exportFormat === 'mcp'
+          exportFormat === 'mcp' || exportFormat === 'fhir'
             ? 'Choose a format to export your form.'
             : `Do you want to use '${
                 sanitizeFormId(exportIdInput) || exportIdInput
@@ -550,6 +618,16 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
                   onChange={() => setExportFormat('mcp')}
                 />
                 MCP Elicitation Schema
+              </label>
+              <label className="ms:flex ms:items-center ms:gap-2 ms:text-sm ms:text-mstext ms:cursor-pointer">
+                <input
+                  type="radio"
+                  name="export-format"
+                  value="fhir"
+                  checked={exportFormat === 'fhir'}
+                  onChange={() => setExportFormat('fhir')}
+                />
+                FHIR R4 Questionnaire
               </label>
             </div>
             {exportFormat === 'esheet' && (
@@ -588,11 +666,25 @@ export function BuilderHeader(_props: BuilderHeaderProps) {
                 omitted.
               </p>
             )}
+            {exportFormat === 'fhir' && (
+              <p className="ms:text-sm ms:text-mstextmuted">
+                Exports as a FHIR R4{' '}
+                <code className="ms:font-mono ms:text-xs ms:bg-msbackground ms:px-1 ms:py-0.5 ms:rounded">
+                  Questionnaire
+                </code>{' '}
+                resource. Supports standard item types, enableWhen logic, and
+                common extensions. DTR profiles are applied when applicable.
+              </p>
+            )}
           </div>
         }
         variant="info"
         confirmLabel={
-          exportFormat === 'mcp' ? 'Export MCP Schema' : 'Use This ID & Export'
+          exportFormat === 'mcp'
+            ? 'Export MCP Schema'
+            : exportFormat === 'fhir'
+            ? 'Export FHIR Questionnaire'
+            : 'Use This ID & Export'
         }
         cancelLabel="Cancel"
         showCancel

--- a/packages/builder/src/lib/components/FeedbackModal.tsx
+++ b/packages/builder/src/lib/components/FeedbackModal.tsx
@@ -82,6 +82,15 @@ export function FeedbackModal({
             issues={issues}
             hint={issuesHint ?? 'Please resolve these issues and try again.'}
             className="ms:mb-3 ms:p-4"
+            variant={
+              variant === 'error'
+                ? 'error'
+                : variant === 'warning'
+                ? 'warning'
+                : variant === 'success'
+                ? 'success'
+                : 'info'
+            }
           />
         )}
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,11 @@ export {
 export { hydrateResponse } from './lib/functions/hydrate-response.js';
 
 export {
+  normalizeResponses,
+  extractResponseValue,
+} from './lib/functions/normalize-responses.js';
+
+export {
   evaluateCondition,
   evaluateRule,
   isExpressionValid,

--- a/packages/core/src/lib/functions/normalize-responses.spec.ts
+++ b/packages/core/src/lib/functions/normalize-responses.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeResponses,
+  extractResponseValue,
+} from './normalize-responses.js';
+import type { FieldResponse, FieldResponseMap } from '../types.js';
+
+describe('extractResponseValue', () => {
+  it('returns undefined for empty response', () => {
+    expect(extractResponseValue(undefined)).toBe(undefined);
+    expect(extractResponseValue({})).toBe(undefined);
+  });
+
+  it('extracts text answer', () => {
+    const response: FieldResponse = { answer: 'Hello' };
+    expect(extractResponseValue(response)).toBe('Hello');
+  });
+
+  it('extracts empty string answer', () => {
+    const response: FieldResponse = { answer: '' };
+    expect(extractResponseValue(response)).toBe('');
+  });
+
+  it('extracts single selection', () => {
+    const response: FieldResponse = {
+      selected: { id: 'opt1', value: 'Yes' },
+    };
+    expect(extractResponseValue(response)).toEqual({
+      id: 'opt1',
+      value: 'Yes',
+    });
+  });
+
+  it('extracts multiple selections', () => {
+    const response: FieldResponse = {
+      selected: [
+        { id: 'opt1', value: 'A' },
+        { id: 'opt2', value: 'B' },
+      ],
+    };
+    expect(extractResponseValue(response)).toEqual([
+      { id: 'opt1', value: 'A' },
+      { id: 'opt2', value: 'B' },
+    ]);
+  });
+
+  it('extracts multitext answers', () => {
+    const response: FieldResponse = {
+      multitextAnswers: { opt1: 'text1', opt2: 'text2' },
+    };
+    expect(extractResponseValue(response)).toEqual({
+      opt1: 'text1',
+      opt2: 'text2',
+    });
+  });
+
+  it('extracts signature data', () => {
+    const response: FieldResponse = {
+      signatureData: 'stroke-data',
+      signatureImage: 'data:image/png;base64,...',
+    };
+    expect(extractResponseValue(response)).toEqual({
+      type: 'signature',
+      data: 'stroke-data',
+      image: 'data:image/png;base64,...',
+    });
+  });
+
+  it('extracts diagram data', () => {
+    const response: FieldResponse = {
+      markupData: 'markup-stroke-data',
+      markupImage: 'data:image/png;base64,...',
+    };
+    expect(extractResponseValue(response)).toEqual({
+      type: 'diagram',
+      data: 'markup-stroke-data',
+      image: 'data:image/png;base64,...',
+    });
+  });
+
+  it('prefers answer over selected', () => {
+    const response: FieldResponse = {
+      answer: 'text',
+      selected: { id: 'opt1', value: 'Yes' },
+    };
+    expect(extractResponseValue(response)).toBe('text');
+  });
+});
+
+describe('normalizeResponses', () => {
+  it('returns empty object for empty responses', () => {
+    expect(normalizeResponses({})).toEqual({});
+  });
+
+  it('normalizes multiple field responses', () => {
+    const responses: FieldResponseMap = {
+      field1: { answer: 'Hello' },
+      field2: { selected: { id: 'opt1', value: 'Yes' } },
+      field3: { answer: '' },
+    };
+    expect(normalizeResponses(responses)).toEqual({
+      field1: 'Hello',
+      field2: { id: 'opt1', value: 'Yes' },
+      field3: '',
+    });
+  });
+
+  it('skips fields with undefined values', () => {
+    const responses: FieldResponseMap = {
+      field1: { answer: 'Hello' },
+      field2: {}, // No value
+    };
+    expect(normalizeResponses(responses)).toEqual({
+      field1: 'Hello',
+    });
+  });
+});

--- a/packages/core/src/lib/functions/normalize-responses.ts
+++ b/packages/core/src/lib/functions/normalize-responses.ts
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// Normalize Responses — extract raw values from FieldResponseMap
+// ---------------------------------------------------------------------------
+
+import type { FieldResponse, FieldResponseMap } from '../types.js';
+
+/**
+ * Extract the primary value from a FieldResponse.
+ *
+ * This converts structured `FieldResponse` objects into simple values
+ * suitable for adapters that expect `Record<string, unknown>`.
+ *
+ * Priority:
+ * 1. `answer` — text/longtext fields
+ * 2. `selected` — choice fields (radio, check, dropdown, etc.)
+ * 3. `multitextAnswers` — multitext fields
+ * 4. `signatureData` — signature fields (prefer raw stroke data)
+ * 5. `markupData` — diagram fields (prefer raw stroke data)
+ *
+ * @param response - A single field's response object.
+ * @returns The primary value, or undefined if empty.
+ */
+export function extractResponseValue(
+  response: FieldResponse | undefined
+): unknown {
+  if (!response) return undefined;
+
+  // Text answer takes precedence
+  if (response.answer !== undefined) {
+    return response.answer;
+  }
+
+  // Selection (single or multiple options)
+  if (response.selected !== undefined) {
+    return response.selected;
+  }
+
+  // Multitext answers (Record<optionId, string>)
+  if (
+    response.multitextAnswers !== undefined &&
+    Object.keys(response.multitextAnswers).length > 0
+  ) {
+    return response.multitextAnswers;
+  }
+
+  // Signature: prefer stroke data, fall back to image
+  if (response.signatureData !== undefined) {
+    return {
+      type: 'signature',
+      data: response.signatureData,
+      image: response.signatureImage,
+    };
+  }
+
+  // Diagram: prefer stroke data, fall back to image
+  if (response.markupData !== undefined) {
+    return {
+      type: 'diagram',
+      data: response.markupData,
+      image: response.markupImage,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Normalize a FieldResponseMap into a simple `Record<string, unknown>`.
+ *
+ * Converts structured `FieldResponse` objects into their primary values,
+ * stripping metadata like `_ai`. Useful for adapters (FHIR, SurveyJS) that
+ * expect flat key-value maps.
+ *
+ * @param responses - The full response map from the form store.
+ * @returns A normalized map of field ID → value.
+ *
+ * @example
+ * ```ts
+ * const raw = normalizeResponses(formStore.getState().responses);
+ * // { field1: "text answer", field2: { id: "opt1", value: "Yes" }, ... }
+ * ```
+ */
+export function normalizeResponses(
+  responses: FieldResponseMap
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [fieldId, response] of Object.entries(responses)) {
+    const value = extractResponseValue(response);
+    if (value !== undefined) {
+      result[fieldId] = value;
+    }
+  }
+
+  return result;
+}

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -59,6 +59,7 @@ export {
 export {
   ZodIssuesPanel,
   type ZodIssuesPanelProps,
+  type ZodIssuesPanelVariant,
 } from './lib/ZodIssuesPanel.js';
 
 // Field component registry

--- a/packages/fields/src/lib/ZodIssuesPanel.tsx
+++ b/packages/fields/src/lib/ZodIssuesPanel.tsx
@@ -1,8 +1,37 @@
+export type ZodIssuesPanelVariant = 'error' | 'warning' | 'info' | 'success';
+
+const PANEL_VARIANT_STYLES: Record<
+  ZodIssuesPanelVariant,
+  { border: string; icon: string; number: string }
+> = {
+  error: {
+    border: 'ms:border-l-msdanger',
+    icon: 'ms:text-msdanger',
+    number: 'ms:text-msdanger',
+  },
+  warning: {
+    border: 'ms:border-l-mswarning',
+    icon: 'ms:text-mswarning',
+    number: 'ms:text-mswarning',
+  },
+  info: {
+    border: 'ms:border-l-msprimary',
+    icon: 'ms:text-msprimary',
+    number: 'ms:text-msprimary',
+  },
+  success: {
+    border: 'ms:border-l-msaccent',
+    icon: 'ms:text-msaccent',
+    number: 'ms:text-msaccent',
+  },
+};
+
 export interface ZodIssuesPanelProps {
   title?: string;
   issues: readonly string[];
   hint?: string;
   className?: string;
+  variant?: ZodIssuesPanelVariant;
 }
 
 /**
@@ -13,11 +42,14 @@ export function ZodIssuesPanel({
   issues,
   hint = 'Please check your form definition for the above issues.',
   className = '',
+  variant = 'error',
 }: ZodIssuesPanelProps) {
   if (issues.length === 0) return null;
 
+  const styles = PANEL_VARIANT_STYLES[variant];
+
   const rootClassName = [
-    'zod-issues-panel ms:mb-2 ms:p-6 ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:border-l-2 ms:border-l-msdanger',
+    `zod-issues-panel ms:mb-2 ms:p-6 ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:border-l-2 ${styles.border}`,
     className,
   ]
     .filter(Boolean)
@@ -26,7 +58,9 @@ export function ZodIssuesPanel({
   return (
     <div className={rootClassName} role="alert" aria-live="polite">
       <div className="ms:flex ms:items-start ms:gap-3">
-        <div className="ms:text-msdanger ms:text-base ms:flex-shrink-0 ms:mt-0.5">
+        <div
+          className={`${styles.icon} ms:text-base ms:flex-shrink-0 ms:mt-0.5`}
+        >
           ⚠
         </div>
         <div className="ms:flex-1">
@@ -39,7 +73,9 @@ export function ZodIssuesPanel({
                 key={`${idx}-${issue}`}
                 className="ms:flex ms:gap-2 ms:py-1.5"
               >
-                <div className="ms:flex-shrink-0 ms:text-msdanger ms:text-xs ms:font-medium ms:min-w-5">
+                <div
+                  className={`ms:flex-shrink-0 ${styles.number} ms:text-xs ms:font-medium ms:min-w-5`}
+                >
                   {idx + 1}.
                 </div>
                 <div className="ms:flex-1 ms:text-sm ms:text-mstext ms:break-words">

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -5,6 +5,9 @@ export {
   EsheetRenderer,
   type EsheetRendererProps,
   type EsheetRendererHandle,
+  type GetResponseOptions,
+  type GetResponseResult,
+  type ResponseFormat,
 } from './lib/EsheetRenderer.js';
 
 // Core types (re-exported for consumer convenience)

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -2,12 +2,20 @@ import React from 'react';
 import {
   createFormStore,
   createUIStore,
+  normalizeResponses,
+  hydrateDefinition,
   validateForm,
   type FormResponse,
   type FormStore,
   type UIStore,
   type ValidationError,
 } from '@esheet/core';
+import {
+  exportResponseToFhir,
+  type FhirFormMeta,
+  type FhirQuestionnaireResponse,
+  type ResponseExportOptions,
+} from '@esheet/adapters';
 import { createRendererTools, type RendererTools } from './renderer-tools.js';
 import {
   FormStoreContext,
@@ -53,9 +61,55 @@ export interface EsheetRendererProps {
   onTouchModeChange?: (enabled: boolean) => void;
 }
 
+// ---------------------------------------------------------------------------
+// Response Format Options
+// ---------------------------------------------------------------------------
+
+/** Response format options for getResponse() */
+export type ResponseFormat = 'native' | 'fhir';
+
+/** Options for getResponse() */
+export interface GetResponseOptions {
+  /** Output format: 'native' (default) or 'fhir' (FHIR QuestionnaireResponse) */
+  format?: ResponseFormat;
+  /** FHIR export options (required when format is 'fhir') */
+  fhir?: Omit<ResponseExportOptions, 'questionnaireUrl'> & {
+    /** Canonical URL of the questionnaire. Falls back to form._sourceData metadata if available. */
+    questionnaireUrl?: string;
+  };
+}
+
+/** Return type for getResponse() — varies by format */
+export type GetResponseResult<T extends ResponseFormat = 'native'> =
+  T extends 'fhir' ? FhirQuestionnaireResponse : FormResponse;
+
 export interface EsheetRendererHandle {
   /** Get current form responses */
   getRawResponse: () => FormResponse;
+  /**
+   * Get form responses in the specified format.
+   *
+   * @param options - Format and export options
+   * @returns Native FormResponse or FHIR QuestionnaireResponse
+   *
+   * @example
+   * ```ts
+   * // Native format (default)
+   * const native = ref.current.getResponse();
+   *
+   * // FHIR QuestionnaireResponse
+   * const fhir = ref.current.getResponse({
+   *   format: 'fhir',
+   *   fhir: {
+   *     questionnaireUrl: 'http://example.org/Questionnaire/my-form',
+   *     status: 'completed',
+   *   }
+   * });
+   * ```
+   */
+  getResponse: <T extends ResponseFormat = 'native'>(
+    options?: GetResponseOptions & { format?: T }
+  ) => GetResponseResult<T>;
   /** Get form store instance */
   getFormStore: () => FormStore;
   /** Get UI store instance */
@@ -171,6 +225,48 @@ const EsheetRendererInner = React.forwardRef<
     ref,
     () => ({
       getRawResponse: () => formStore.getState().responses,
+      getResponse: <T extends ResponseFormat = 'native'>(
+        options?: GetResponseOptions & { format?: T }
+      ): GetResponseResult<T> => {
+        const state = formStore.getState();
+        const responses = state.responses;
+
+        if (options?.format === 'fhir') {
+          // Build FHIR QuestionnaireResponse
+          const normalizedAnswers = normalizeResponses(responses);
+
+          // Try to get questionnaire URL from options or formSourceData
+          const fhirMeta = state.formSourceData as FhirFormMeta | undefined;
+          const questionnaireUrl =
+            options.fhir?.questionnaireUrl ??
+            fhirMeta?.url ??
+            `urn:uuid:${state.formId}`;
+
+          const exportOptions: ResponseExportOptions = {
+            questionnaireUrl,
+            status: options.fhir?.status ?? 'completed',
+            subject: options.fhir?.subject,
+            author: options.fhir?.author,
+            resourceId: options.fhir?.resourceId,
+          };
+
+          // Rebuild form definition from normalized state
+          const formDefinition = {
+            id: state.formId,
+            fields: hydrateDefinition(state.normalized),
+            _sourceData: state.formSourceData,
+          };
+
+          return exportResponseToFhir(
+            formDefinition,
+            normalizedAnswers,
+            exportOptions
+          ) as GetResponseResult<T>;
+        }
+
+        // Native format (default)
+        return responses as GetResponseResult<T>;
+      },
       getFormStore: () => formStore,
       getUIStore: () => uiStore,
       getValidResponse: () => {

--- a/packages/renderer/src/lib/hooks/useRendererInit.ts
+++ b/packages/renderer/src/lib/hooks/useRendererInit.ts
@@ -12,7 +12,10 @@ import {
   convertSurveyJS,
   isSurveyJSSchema,
   isMcpElicitationRequest,
+  importFromFhir,
+  isFhirQuestionnaire,
   type McpElicitationRequest,
+  type FhirQuestionnaire,
 } from '@esheet/adapters';
 
 /**
@@ -20,6 +23,7 @@ import {
  *
  * Auto-detects and converts the following input formats:
  * - eSheet FormDefinition (object or JSON/YAML string)
+ * - FHIR R4 Questionnaire resource
  * - MCP elicitation/create envelope
  * - SurveyJS schema (has top-level `pages` or `elements` array)
  */
@@ -49,8 +53,10 @@ export function useRendererInit(
         parsed = formData;
       }
 
-      // Auto-detect and convert MCP or SurveyJS input (skipped in strict mode)
-      if (!strict && isMcpElicitationRequest(parsed)) {
+      // Auto-detect and convert FHIR, MCP or SurveyJS input (skipped in strict mode)
+      if (!strict && isFhirQuestionnaire(parsed)) {
+        parsed = importFromFhir(parsed as FhirQuestionnaire);
+      } else if (!strict && isMcpElicitationRequest(parsed)) {
         const mcpReq = parsed as McpElicitationRequest;
         if (mcpReq.params.mode !== 'url') {
           parsed = importFromMcp(


### PR DESCRIPTION
Adds FHIR R4 adapter support to `@esheet/adapters`, allowing eSheet forms to be imported from and exported to FHIR `Questionnaire` resources.

This also extends the renderer public API with a new `getResponse()` method that can return either the native eSheet `FormResponse` format or a FHIR `QuestionnaireResponse`, giving consumers a direct path for FHIR-compatible response output.

## What Changed

* Added a new FHIR adapter module under `packages/adapters/src/fhir`

  * FHIR R4 type definitions
  * Questionnaire import/export support
  * QuestionnaireResponse import/export support
  * FHIR utility helpers, extension constants, and type guards
  * Adapter test coverage
* Added core response normalization utilities:

  * `normalizeResponses()`
  * `extractResponseValue()`
* Exported response normalization helpers from `@esheet/core`
* Re-exported the FHIR adapter from the top-level `@esheet/adapters` package
* Added renderer `getResponse()` support for:

  * Native `FormResponse`
  * FHIR `QuestionnaireResponse`
* Added renderer response format types:

  * `ResponseFormat`
  * `GetResponseOptions`
  * `GetResponseResult<T>`
* Updated the demo renderer view to exercise FHIR response output
* Updated builder UI areas related to header controls, feedback modal behavior, and validation display
* Enhanced `ZodIssuesPanel` validation issue display
* Added documentation for:

  * FHIR adapter usage
  * Renderer response formats
  * Updated adapter overview

## How to Test

1. Run the full CI checks:

   ```bash
   npm run lint
   npm run test
   npm run build
   npm run typecheck
   ```

2. Validate FHIR adapter tests:

   ```bash
   npx nx test adapters
   ```

3. Import a FHIR `Questionnaire` through the adapter and verify it converts into a valid eSheet form definition.

4. Export an eSheet form definition to FHIR and verify the result is a valid FHIR R4 `Questionnaire`.

5. Render a form in the demo app and call:

   ```ts
   ref.current.getResponse()
   ```

   Confirm it returns the native eSheet `FormResponse`.

6. Call:

   ```ts
   ref.current.getResponse({
     format: 'fhir',
     fhir: {
       questionnaireUrl: 'http://example.org/questionnaire',
       status: 'completed',
     },
   })
   ```

   Confirm it returns a FHIR `QuestionnaireResponse`.

7. Review the new FHIR and response format documentation pages to confirm the public API is documented.

## Breaking Changes

No breaking changes.
