### PR TITLE
fix(repo): preserve falsey setValue results and improve form accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ graphify-out*
 # Adaptive Codegraph index artifacts
 .adaptive-codegraph/
 .fastembed_cache/
+
+.vscode/

--- a/packages/adapters/src/fhir/fhir-adapter.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.ts
@@ -134,7 +134,6 @@ function convertItemToField(
     id: item.linkId,
     question: item.text,
     required: item.required,
-    ...(item.readOnly ? { readOnly: item.readOnly } : {}),
   };
 
   // Build _sourceData for round-trip

--- a/packages/adapters/src/lib/surveyjs-converter.ts
+++ b/packages/adapters/src/lib/surveyjs-converter.ts
@@ -456,7 +456,6 @@ function convertElement(
     id,
     question: element.title ?? element.name,
     required: element.isRequired ?? false,
-    ...(element.readOnly ? { readOnly: element.readOnly } : {}),
     rules,
     _sourceData,
   };

--- a/packages/core/src/lib/logic/comprehensive-conditions.spec.ts
+++ b/packages/core/src/lib/logic/comprehensive-conditions.spec.ts
@@ -2242,11 +2242,13 @@ describe('comprehensive conditions integration', () => {
       ).toBe(false);
     });
 
-    it('equals — matches __other__ when user types custom text', () => {
+    it('equals — matches other-option id when user selects the other option', () => {
       const { normalized, field } = setup(openChoiceDef);
-      field.rules = [fieldRule('visible', 'other-1', 'equals', '__other__')];
+      field.rules = [
+        fieldRule('visible', 'other-1', 'equals', 'other-1-other'),
+      ];
       const resp: FieldResponse = {
-        selected: { id: '__other__', value: 'custom text' },
+        selected: { id: 'other-1-other', value: 'custom text' },
       };
       expect(
         resolveEffect('visible', field, normalized, { 'other-1': resp })
@@ -2292,7 +2294,7 @@ describe('comprehensive conditions integration', () => {
       };
       const normalized = normalizeDefinition([driver, target]);
       const resp: FieldResponse = {
-        selected: { id: '__other__', value: 'custom text' },
+        selected: { id: 'other-5-other', value: 'custom text' },
       };
       expect(
         resolveEffect('visible', target, normalized, { 'other-5': resp })

--- a/packages/core/src/lib/logic/resolve.ts
+++ b/packages/core/src/lib/logic/resolve.ts
@@ -77,18 +77,43 @@ export function resolveSetValue(
   const rules = field.rules?.filter((r) => r.effect === 'setValue') ?? [];
 
   for (const rule of rules) {
-    if (evaluateRule(rule, normalized, responses, dangerouslyAllowJS)) {
-      // Rule matched; now extract and evaluate the expression condition to get the value.
-      // Typically, a setValue rule will have ONE expression condition that produces the value.
-      const expressionCondition = rule.conditions.find(
-        (c) => c.conditionType === 'expression'
+    // Determine if this is a pure expression rule (all conditions are expression type,
+    // no field-ref guard conditions with targetId/operator).
+    // Pure expression rules from FHIR calculatedExpression/initialExpression should be
+    // evaluated unconditionally — the expression IS the value, not a guard condition.
+    // Gating behind evaluateRule would treat the expression as boolean and discard
+    // falsey results like 0, false, or "".
+    const isExpressionOnly =
+      rule.conditions.length > 0 &&
+      rule.conditions.every(
+        (c) => c.conditionType === 'expression' && !c.targetId && !c.operator
       );
 
-      if (
-        expressionCondition &&
-        expressionCondition.conditionType === 'expression' &&
-        expressionCondition.expression
-      ) {
+    const expressionCondition = rule.conditions.find(
+      (c) => c.conditionType === 'expression' && c.expression
+    );
+
+    if (isExpressionOnly && expressionCondition?.expression) {
+      // Evaluate expression unconditionally to preserve falsey values.
+      try {
+        const result = evaluateExpression(
+          expressionCondition.expression,
+          normalized,
+          responses
+        );
+        if (result === null || result === undefined) return null;
+        if (typeof result === 'string' || typeof result === 'number') {
+          return result;
+        }
+        return String(result);
+      } catch {
+        continue;
+      }
+    }
+
+    if (evaluateRule(rule, normalized, responses, dangerouslyAllowJS)) {
+      // Rule matched; now extract and evaluate the expression condition to get the value.
+      if (expressionCondition?.expression) {
         try {
           // Evaluate the expression in context of current responses
           // Uses the proper AST-based evaluator from conditions.ts, not string substitution

--- a/packages/fields/src/fields/rich/FileField.tsx
+++ b/packages/fields/src/fields/rich/FileField.tsx
@@ -376,10 +376,14 @@ export const FileField = React.memo(function FileField({
       </div>
 
       <div>
-        <label className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-2">
+        <label
+          htmlFor={`${instanceId}-editor-accepted-types-${def.id}`}
+          className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-2"
+        >
           Accepted types
         </label>
         <input
+          id={`${instanceId}-editor-accepted-types-${def.id}`}
           type="text"
           placeholder="Search file types..."
           value={typeSearch}
@@ -418,11 +422,15 @@ export const FileField = React.memo(function FileField({
       </div>
 
       <div>
-        <label className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1">
+        <label
+          htmlFor={`${instanceId}-editor-max-file-size-${def.id}`}
+          className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+        >
           Max file size
         </label>
         <div className="ms:flex ms:gap-2">
           <input
+            id={`${instanceId}-editor-max-file-size-${def.id}`}
             type="number"
             value={
               def.maxFileSize
@@ -441,6 +449,8 @@ export const FileField = React.memo(function FileField({
             className="ms:px-3 ms:py-2 ms:h-10 ms:flex-1 ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
           />
           <select
+            id={`${instanceId}-editor-size-unit-${def.id}`}
+            aria-label="File size unit"
             value={sizeUnit}
             onChange={(e) => {
               const newUnit = e.target.value as SizeUnit;
@@ -456,10 +466,14 @@ export const FileField = React.memo(function FileField({
       </div>
 
       <div>
-        <label className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1">
+        <label
+          htmlFor={`${instanceId}-editor-max-files-${def.id}`}
+          className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+        >
           Max files allowed
         </label>
         <input
+          id={`${instanceId}-editor-max-files-${def.id}`}
           type="number"
           min="1"
           value={def.maxFiles ?? ''}

--- a/packages/fields/src/fields/selection/OpenChoiceField.tsx
+++ b/packages/fields/src/fields/selection/OpenChoiceField.tsx
@@ -121,6 +121,7 @@ export const OpenChoiceField = React.memo(function OpenChoiceField({
           <div className="ms:mt-2">
             <input
               id={`${instanceId}-openchoice-other-${def.id}`}
+              aria-label={otherLabel}
               type="text"
               value={otherText}
               onChange={(e) => {


### PR DESCRIPTION
**Summary**
This branch tightens conditional value resolution and cleans up a few form/adaptor edge cases:

- `packages/core/src/lib/logic/resolve.ts` now evaluates pure expression-only `setValue` rules unconditionally, which preserves valid falsey results like `0`, `false`, and `""` instead of treating them like failed conditions.
- `packages/core/src/lib/logic/comprehensive-conditions.spec.ts` updates coverage for the revised open-choice “other” behavior.
- `packages/fields/src/fields/rich/FileField.tsx` and `packages/fields/src/fields/selection/OpenChoiceField.tsx` add missing `id` / `htmlFor` / `aria-label` wiring to improve accessibility.
- `packages/adapters/src/fhir/fhir-adapter.ts` and `packages/adapters/src/lib/surveyjs-converter.ts` stop copying `readOnly` through in the generated field definitions.
- `.gitignore` now excludes `.vscode/`.

If you want, I can also turn this into a more formal GitHub PR description with “What changed / Why / Testing” sections.