### PR TITLE
feat(builder): add collapsible option to sections

### DIFF
--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -384,7 +384,9 @@ function SectionEditContent({
         </label>
         <select
           id={`${instanceId}-editor-collapse-${fieldId}`}
-          value={(def as { sectionCollapse?: string }).sectionCollapse ?? 'disabled'}
+          value={
+            (def as { sectionCollapse?: string }).sectionCollapse ?? 'disabled'
+          }
           onChange={(e) => {
             const value = e.currentTarget.value;
             onUpdate({

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -385,7 +385,7 @@ function SectionEditContent({
         <select
           id={`${instanceId}-editor-collapse-${fieldId}`}
           value={
-            (def as { sectionCollapse?: string }).sectionCollapse ?? 'disabled'
+            (def as { sectionCollapse?: string }).sectionCollapse ?? 'expanded'
           }
           onChange={(e) => {
             const value = e.currentTarget.value;

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -384,25 +384,18 @@ function SectionEditContent({
         </label>
         <select
           id={`${instanceId}-editor-collapse-${fieldId}`}
-          value={
-            (def as { collapsible?: boolean }).collapsible === false
-              ? 'none'
-              : (def as { defaultExpanded?: boolean }).defaultExpanded
-              ? 'expanded'
-              : 'collapsed'
-          }
+          value={(def as { sectionDisplay?: string }).sectionDisplay ?? 'disabled'}
           onChange={(e) => {
             const value = e.currentTarget.value;
             onUpdate({
-              collapsible: value === 'none' ? false : undefined,
-              defaultExpanded: value === 'expanded' ? true : undefined,
+              sectionDisplay: value,
             } as Parameters<typeof onUpdate>[0]);
           }}
           className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
         >
           <option value="collapsed">Collapsible (collapsed by default)</option>
           <option value="expanded">Collapsible (expanded by default)</option>
-          <option value="none">Not collapsible (always expanded)</option>
+          <option value="disabled">Not collapsible (always expanded)</option>
         </select>
       </div>
 

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -384,11 +384,11 @@ function SectionEditContent({
         </label>
         <select
           id={`${instanceId}-editor-collapse-${fieldId}`}
-          value={(def as { sectionDisplay?: string }).sectionDisplay ?? 'disabled'}
+          value={(def as { sectionCollapse?: string }).sectionCollapse ?? 'disabled'}
           onChange={(e) => {
             const value = e.currentTarget.value;
             onUpdate({
-              sectionDisplay: value,
+              sectionCollapse: value,
             } as Parameters<typeof onUpdate>[0]);
           }}
           className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -374,6 +374,38 @@ function SectionEditContent({
         />
       </div>
 
+      {/* Collapse behavior */}
+      <div>
+        <label
+          htmlFor={`${instanceId}-editor-collapse-${fieldId}`}
+          className="edit-label ms:block ms:text-sm ms:font-medium ms:text-mstext ms:mb-1"
+        >
+          Collapse behavior
+        </label>
+        <select
+          id={`${instanceId}-editor-collapse-${fieldId}`}
+          value={
+            (def as { collapsible?: boolean }).collapsible === false
+              ? 'none'
+              : (def as { defaultExpanded?: boolean }).defaultExpanded
+              ? 'expanded'
+              : 'collapsed'
+          }
+          onChange={(e) => {
+            const value = e.currentTarget.value;
+            onUpdate({
+              collapsible: value === 'none' ? false : undefined,
+              defaultExpanded: value === 'expanded' ? true : undefined,
+            } as Parameters<typeof onUpdate>[0]);
+          }}
+          className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
+        >
+          <option value="collapsed">Collapsible (collapsed by default)</option>
+          <option value="expanded">Collapsible (expanded by default)</option>
+          <option value="none">Not collapsible (always expanded)</option>
+        </select>
+      </div>
+
       <div className="ms:space-y-2">
         <div className="ms:flex ms:items-center ms:justify-between ms:gap-2">
           <span className="ms:text-sm ms:font-medium ms:text-mstext">

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -295,7 +295,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'container',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: { fields: [] },
+    defaultProps: { fields: [], sectionCollapse: 'expanded' },
     placeholder: { title: 'Enter section title...' },
   },
 };

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -481,8 +481,8 @@ export interface SectionFieldDefinition extends BaseFieldDefinition {
   /**
    * Collapse behaviour of the section in preview.
    * - `'collapsed'` — collapsible, starts collapsed.
-   * - `'expanded'` — collapsible, starts expanded.
-   * - `'disabled'` (default) — collapsing disabled, always expanded.
+   * - `'expanded'` (default when absent) — collapsible, starts expanded.
+   * - `'disabled'` — collapsing disabled, always expanded.
    */
   sectionCollapse?: 'collapsed' | 'expanded' | 'disabled';
   fields?: FieldDefinition[]; // recursive!

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -478,6 +478,10 @@ export interface DisplayFieldDefinition {
 export interface SectionFieldDefinition extends BaseFieldDefinition {
   fieldType: 'section';
   title?: string;
+  /** Whether the section can expand/collapse in preview. Defaults to `true`. */
+  collapsible?: boolean;
+  /** When collapsible, start expanded instead of collapsed. Defaults to `false`. */
+  defaultExpanded?: boolean;
   fields?: FieldDefinition[]; // recursive!
 }
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -479,12 +479,12 @@ export interface SectionFieldDefinition extends BaseFieldDefinition {
   fieldType: 'section';
   title?: string;
   /**
-   * How the section is displayed in preview.
+   * Collapse behaviour of the section in preview.
    * - `'collapsed'` — collapsible, starts collapsed.
    * - `'expanded'` — collapsible, starts expanded.
    * - `'disabled'` (default) — collapsing disabled, always expanded.
    */
-  sectionDisplay?: 'collapsed' | 'expanded' | 'disabled';
+  sectionCollapse?: 'collapsed' | 'expanded' | 'disabled';
   fields?: FieldDefinition[]; // recursive!
 }
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -478,10 +478,13 @@ export interface DisplayFieldDefinition {
 export interface SectionFieldDefinition extends BaseFieldDefinition {
   fieldType: 'section';
   title?: string;
-  /** Whether the section can expand/collapse in preview. Defaults to `true`. */
-  collapsible?: boolean;
-  /** When collapsible, start expanded instead of collapsed. Defaults to `false`. */
-  defaultExpanded?: boolean;
+  /**
+   * How the section is displayed in preview.
+   * - `'collapsed'` — collapsible, starts collapsed.
+   * - `'expanded'` — collapsible, starts expanded.
+   * - `'disabled'` (default) — collapsing disabled, always expanded.
+   */
+  sectionDisplay?: 'collapsed' | 'expanded' | 'disabled';
   fields?: FieldDefinition[]; // recursive!
 }
 

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -19,9 +19,9 @@ export const SectionField = React.memo(function SectionField({
 }: SectionFieldProps) {
   const def = field.definition as SectionFieldDefinition;
   const title = def.title || 'Section';
-  const collapsible = def.collapsible ?? true;
+  const collapsible = (def.sectionDisplay ?? 'disabled') !== 'disabled';
   const [expanded, setExpanded] = React.useState(
-    collapsible ? def.defaultExpanded ?? false : true
+    (def.sectionDisplay ?? 'disabled') === 'expanded'
   );
   const isExpanded = collapsible ? expanded : true;
 

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -19,17 +19,56 @@ export const SectionField = React.memo(function SectionField({
 }: SectionFieldProps) {
   const def = field.definition as SectionFieldDefinition;
   const title = def.title || 'Section';
+  const collapsible = def.collapsible ?? true;
+  const [expanded, setExpanded] = React.useState(
+    collapsible ? def.defaultExpanded ?? false : true
+  );
+  const isExpanded = collapsible ? expanded : true;
 
   if (isPreview) {
     return (
       <section className="section-field-preview ms:pb-0">
-        <h3 className="ms:text-base ms:font-semibold ms:text-mstext ms:bg-msprimary/10 ms:px-4 ms:py-2 ms:break-words ms:overflow-hidden">
-          {title}
-          {(isRequired || isSoftRequired) && (
-            <span className="ms:text-msdanger ms:ml-1">*</span>
+        <h3 className="ms:text-base ms:font-semibold ms:text-mstext ms:bg-msprimary/10 ms:break-words ms:overflow-hidden">
+          {collapsible ? (
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              onClick={() => setExpanded((prev) => !prev)}
+              className="ms:w-full ms:flex ms:items-center ms:justify-between ms:gap-2 ms:px-4 ms:py-2 ms:text-left ms:text-base ms:font-semibold ms:text-mstext ms:bg-transparent ms:border-0 ms:cursor-pointer"
+            >
+              <span>
+                {title}
+                {(isRequired || isSoftRequired) && (
+                  <span className="ms:text-msdanger ms:ml-1">*</span>
+                )}
+              </span>
+              <svg
+                className={`ms:w-4 ms:h-4 ms:shrink-0 ms:transition-transform ${
+                  isExpanded ? 'ms:rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+          ) : (
+            <span className="ms:block ms:px-4 ms:py-2">
+              {title}
+              {(isRequired || isSoftRequired) && (
+                <span className="ms:text-msdanger ms:ml-1">*</span>
+              )}
+            </span>
           )}
         </h3>
-        {nestedChildren && (
+        {nestedChildren && isExpanded && (
           <div className="ms:bg-mssurface ms:space-y-3 ms:px-4 ms:py-2">
             {nestedChildren}
           </div>

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -19,10 +19,17 @@ export const SectionField = React.memo(function SectionField({
 }: SectionFieldProps) {
   const def = field.definition as SectionFieldDefinition;
   const title = def.title || 'Section';
-  const collapsible = (def.sectionCollapse ?? 'disabled') !== 'disabled';
-  const [expanded, setExpanded] = React.useState(
-    (def.sectionCollapse ?? 'disabled') === 'expanded'
-  );
+  const bodyId = React.useId();
+  const sectionCollapse = def.sectionCollapse ?? 'disabled';
+  const collapsible = sectionCollapse !== 'disabled';
+  const defaultExpanded = collapsible ? sectionCollapse === 'expanded' : true;
+  const [expanded, setExpanded] = React.useState(defaultExpanded);
+  const [prevDefault, setPrevDefault] = React.useState(defaultExpanded);
+  // Re-sync when collapse settings change while mounted (e.g. edited in builder).
+  if (prevDefault !== defaultExpanded) {
+    setPrevDefault(defaultExpanded);
+    setExpanded(defaultExpanded);
+  }
   const isExpanded = collapsible ? expanded : true;
 
   if (isPreview) {
@@ -33,6 +40,7 @@ export const SectionField = React.memo(function SectionField({
             <button
               type="button"
               aria-expanded={isExpanded}
+              aria-controls={bodyId}
               onClick={() => setExpanded((prev) => !prev)}
               className="ms:w-full ms:flex ms:items-center ms:justify-between ms:gap-2 ms:px-4 ms:py-2 ms:text-left ms:text-base ms:font-semibold ms:text-mstext ms:bg-transparent ms:border-0 ms:cursor-pointer"
             >
@@ -69,7 +77,10 @@ export const SectionField = React.memo(function SectionField({
           )}
         </h3>
         {nestedChildren && isExpanded && (
-          <div className="ms:bg-mssurface ms:space-y-3 ms:px-4 ms:py-2">
+          <div
+            id={bodyId}
+            className="ms:bg-mssurface ms:space-y-3 ms:px-4 ms:py-2"
+          >
             {nestedChildren}
           </div>
         )}

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -19,9 +19,9 @@ export const SectionField = React.memo(function SectionField({
 }: SectionFieldProps) {
   const def = field.definition as SectionFieldDefinition;
   const title = def.title || 'Section';
-  const collapsible = (def.sectionDisplay ?? 'disabled') !== 'disabled';
+  const collapsible = (def.sectionCollapse ?? 'disabled') !== 'disabled';
   const [expanded, setExpanded] = React.useState(
-    (def.sectionDisplay ?? 'disabled') === 'expanded'
+    (def.sectionCollapse ?? 'disabled') === 'expanded'
   );
   const isExpanded = collapsible ? expanded : true;
 


### PR DESCRIPTION
Sections are now collapsible in preview by default (collapsed initially). A new Collapse behavior selector in the section editor allows:
- Collapsible, collapsed by default (default)
- Collapsible, expanded by default
- Not collapsible (always expanded)

Adds optional collapsible/defaultExpanded props to SectionFieldDefinition.

https://github.com/user-attachments/assets/a8e5f2bd-9908-4edc-a279-81d8ca7954e2

