### PR TITLE
enhance(fields): update date picker to use mieweb/ui date picker

### DIFF
--- a/packages/fields/src/fields/text/TextField.tsx
+++ b/packages/fields/src/fields/text/TextField.tsx
@@ -4,7 +4,7 @@ import type {
   TextFieldDefinition,
   LongtextFieldDefinition,
 } from '@esheet/core';
-import { Input } from '@mieweb/ui';
+import { Input, DateInput } from '@mieweb/ui';
 
 function formatPhoneNumber(value: string): string {
   if (!value) return value;
@@ -67,6 +67,23 @@ export const TextField = React.memo(function TextField({
   }, [computedValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isPreview) {
+    if (inputType === 'date') {
+      return (
+        <div className="text-field-preview">
+          <DateInput
+            id={`${instanceId}-text-answer-${def.id}`}
+            label={def.question || 'Question'}
+            required={isRequired || isSoftRequired}
+            disabled={!isEnabled}
+            aria-required={isRequired || undefined}
+            value={response?.answer || ''}
+            onChange={(val) => onResponse({ answer: val })}
+            showCalendar
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="text-field-preview ms:relative">
         <Input
@@ -114,24 +131,34 @@ export const TextField = React.memo(function TextField({
           className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary/30 ms:outline-none ms:transition-colors"
         />
       </div>
-      <div className="ms:relative">
-        <input
+      {inputType === 'date' ? (
+        <DateInput
           id={`${instanceId}-canvas-preview-${def.id}`}
           aria-label="Answer preview"
-          type={inputType}
           value=""
-          placeholder={placeholder}
-          className={`ms:px-4 ms:py-2 ms:w-full ms:border ms:border-msborder ms:shadow-sm ms:rounded-lg ms:bg-msbackground ms:text-mstextmuted ${
-            unit ? 'ms:pr-16' : ''
-          }`}
           disabled
+          showCalendar
         />
-        {unit && (
-          <span className="ms:absolute ms:right-3 ms:top-1/2 ms:-translate-y-1/2 ms:text-sm ms:text-mstextmuted">
-            {unit}
-          </span>
-        )}
-      </div>
+      ) : (
+        <div className="ms:relative">
+          <input
+            id={`${instanceId}-canvas-preview-${def.id}`}
+            aria-label="Answer preview"
+            type={inputType}
+            value=""
+            placeholder={placeholder}
+            className={`ms:px-4 ms:py-2 ms:w-full ms:border ms:border-msborder ms:shadow-sm ms:rounded-lg ms:bg-msbackground ms:text-mstextmuted ${
+              unit ? 'ms:pr-16' : ''
+            }`}
+            disabled
+          />
+          {unit && (
+            <span className="ms:absolute ms:right-3 ms:top-1/2 ms:-translate-y-1/2 ms:text-sm ms:text-mstextmuted">
+              {unit}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 });

--- a/packages/fields/src/fields/text/TextField.tsx
+++ b/packages/fields/src/fields/text/TextField.tsx
@@ -132,13 +132,15 @@ export const TextField = React.memo(function TextField({
         />
       </div>
       {inputType === 'date' ? (
-        <DateInput
-          id={`${instanceId}-canvas-preview-${def.id}`}
-          aria-label="Answer preview"
-          value=""
-          disabled
-          showCalendar
-        />
+        <div className="ms:pointer-events-none ms:select-none">
+          <DateInput
+            id={`${instanceId}-canvas-preview-${def.id}`}
+            aria-label="Answer preview"
+            value=""
+            disabled
+            showCalendar
+          />
+        </div>
       ) : (
         <div className="ms:relative">
           <input


### PR DESCRIPTION
## Summary

Updates text fields with `inputType === 'date'` to use the shared `@mieweb/ui` `DateInput` component instead of the native HTML date input, giving date answers the Mieweb calendar picker UI in both respondent preview mode and builder canvas preview mode.

## Changes

- Imported `DateInput` from `@mieweb/ui` alongside the existing `Input` component.
- Added a dedicated date-field rendering path in preview/respondent mode:
  - Uses `DateInput` with the existing field id, label, required state, disabled state, and `aria-required` handling.
  - Preserves response storage by writing `onChange` values back through `onResponse({ answer: val })`.
  - Enables the calendar picker with `showCalendar`.
- Updated the builder/edit canvas preview for date text fields:
  - Renders a disabled `DateInput` preview when the configured text input type is `date`.
  - Keeps non-date text, number, email, tel, time, month, and datetime-local fields on the existing native input preview path.
- Preserved existing behavior for non-date text fields:
  - Phone formatting remains unchanged.
  - Unit suffix rendering remains unchanged.
  - Placeholder handling remains unchanged.
  - Computed-value response seeding remains unchanged.

## Files Changed

- `packages/fields/src/fields/text/TextField.tsx`