### PR TITLE
fix(repo): align Cloudflare Pages output routing for docs and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 eSheet is a TypeScript-first Nx monorepo providing composable packages for embedding a visual form builder and renderer into any React application — no lock-in, no required backend.
 
-- **[Live Demo](https://esheet-demo.os.mieweb.org/)** — builder + renderer playground
-- **[Documentation](https://esheet-docs.os.mieweb.org)** — full API & usage docs
+- **[Live Demo](https://esheet.mieweb.org/demo/)** — builder + renderer playground
+- **[Documentation](https://esheet.mieweb.org/)** — full API & usage docs
 
 ---
 
@@ -208,6 +208,15 @@ chmod +x deploy/scripts/workflow/atomic-deploy.sh
 - Deploy script in repo: `deploy/scripts/workflow/atomic-deploy.sh`
 - Setup helper in repo: `deploy/scripts/manual/setup-nginx.sh`
 - Runbook in repo: `deploy/RUNBOOK-nginx-atomic.md`
+
+### Production Static Deploy (Cloudflare Pages)
+
+Cloudflare Pages publishes the same combined URL layout as the Nginx deployment:
+
+- Documentation at `/`
+- Demo at `/demo/`
+
+Use `npm run build:cf` as the build command and `dist` as the output directory. See [the Cloudflare Pages runbook](deploy/RUNBOOK-cloudflare-pages.md) for the complete project settings, environment variables, routing behavior, and verification steps.
 
 ---
 

--- a/apps/demo/src/views/LandingPage.tsx
+++ b/apps/demo/src/views/LandingPage.tsx
@@ -12,11 +12,7 @@ function DemoCard({
   to: string;
 }) {
   return (
-    <Link
-      to={to}
-      reloadDocument
-      className="demo-card-link block no-underline group"
-    >
+    <Link to={to} className="demo-card-link block no-underline group">
       <Card className="demo-card h-full hover:shadow-xl hover:border-primary-500 transition-all duration-300 hover:-translate-y-1">
         <CardContent className="p-8">
           <h3 className="demo-card-title m-0 mb-3 text-2xl font-bold text-foreground group-hover:text-primary-600 transition-colors">

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -13,8 +13,7 @@ const siteOrigin =
   process.env.ESHEET_SITE_ORIGIN || 'https://esheet.mieweb.org';
 const baseUrl = '/';
 const cloudflarePreviewUrl =
-  process.env.CF_PAGES === '1' &&
-  process.env.CF_PAGES_BRANCH !== 'main'
+  process.env.CF_PAGES === '1' && process.env.CF_PAGES_BRANCH !== 'main'
     ? process.env.CF_PAGES_URL
     : undefined;
 const deploymentOrigin = cloudflarePreviewUrl || siteOrigin;

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -12,7 +12,15 @@ const isDev = process.env.NODE_ENV !== 'production';
 const siteOrigin =
   process.env.ESHEET_SITE_ORIGIN || 'https://esheet.mieweb.org';
 const baseUrl = '/';
-const demoUrl = isDev ? 'http://localhost:3001/' : `${siteOrigin}/demo/`;
+const cloudflarePreviewUrl =
+  process.env.CF_PAGES === '1' &&
+  process.env.CF_PAGES_BRANCH !== 'main'
+    ? process.env.CF_PAGES_URL
+    : undefined;
+const deploymentOrigin = cloudflarePreviewUrl || siteOrigin;
+const demoUrl = isDev
+  ? 'http://localhost:3001/'
+  : `${deploymentOrigin.replace(/\/$/, '')}/demo/`;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ dotenv.config({ path: resolve(process.cwd(), '.env.local') });
 
 const isDev = process.env.NODE_ENV !== 'production';
 const siteOrigin =
-  process.env.ESHEET_SITE_ORIGIN || 'https://esheet.os.mieweb.org';
+  process.env.ESHEET_SITE_ORIGIN || 'https://esheet.mieweb.org';
 const baseUrl = '/';
 const demoUrl = isDev ? 'http://localhost:3001/' : `${siteOrigin}/demo/`;
 

--- a/deploy/RUNBOOK-cloudflare-pages.md
+++ b/deploy/RUNBOOK-cloudflare-pages.md
@@ -11,11 +11,11 @@ This matches the URL layout used by the Nginx atomic deployment.
 
 Configure the Cloudflare Pages project from the repository root with these settings:
 
-| Setting | Value |
-| --- | --- |
-| Build command | `npm run build:cf` |
-| Build output directory | `dist` |
-| Root directory | Repository root |
+| Setting                | Value              |
+| ---------------------- | ------------------ |
+| Build command          | `npm run build:cf` |
+| Build output directory | `dist`             |
+| Root directory         | Repository root    |
 
 The Cloudflare build script defaults the production origin to the Cloudflare custom domain. You can set `ESHEET_SITE_ORIGIN` explicitly to the same value, without a trailing slash:
 

--- a/deploy/RUNBOOK-cloudflare-pages.md
+++ b/deploy/RUNBOOK-cloudflare-pages.md
@@ -1,0 +1,66 @@
+# Cloudflare Pages Deployment
+
+Cloudflare Pages serves the documentation and demo from one static deployment:
+
+- `/` serves the Docusaurus documentation site.
+- `/demo/` serves the Vite demo application.
+
+This matches the URL layout used by the Nginx atomic deployment.
+
+## Pages project settings
+
+Configure the Cloudflare Pages project from the repository root with these settings:
+
+| Setting | Value |
+| --- | --- |
+| Build command | `npm run build:cf` |
+| Build output directory | `dist` |
+| Root directory | Repository root |
+
+The Cloudflare build script defaults the production origin to the Cloudflare custom domain. You can set `ESHEET_SITE_ORIGIN` explicitly to the same value, without a trailing slash:
+
+```txt
+ESHEET_SITE_ORIGIN=https://esheet.mieweb.org
+```
+
+The atomic OS deployment has its own default, `https://esheet.os.mieweb.org`, and can override it through the GitHub Actions `ESHEET_SITE_ORIGIN` environment secret. This keeps each deployment's documentation and demo links on its own origin even when both deployment workflows build the same branch.
+
+Attach the production custom domain to the Pages project in Cloudflare. A DNS record by itself does not associate the domain with the Pages project.
+
+## Build output
+
+`npm run build:cf` runs `deploy/scripts/cf-build.sh`, which builds both Nx applications and merges their static output into `dist/`:
+
+```txt
+dist/
+├── index.html
+├── _redirects
+├── assets/
+└── demo/
+    ├── index.html
+    └── assets/
+```
+
+The generated `_redirects` file normalizes the demo root and provides SPA fallbacks for both applications:
+
+```txt
+/demo     /demo/            301
+/demo/*   /demo/index.html  200
+/*        /index.html       200
+```
+
+Keep the demo rules before the documentation fallback so nested demo routes resolve to the demo application.
+
+## Verify a deployment
+
+After deploying, verify these URLs in the browser and with direct page requests:
+
+- `/` loads the documentation site.
+- `/docs/intro` loads and refreshes without a 404.
+- `/demo` redirects to `/demo/`.
+- `/demo/` loads the demo landing page.
+- The landing cards navigate to `/demo/builder` and `/demo/renderer`.
+- `/demo/builder` and `/demo/renderer` load and refresh without a 404.
+- Documentation links labeled Demo or Live Demo open `/demo/` on the same origin.
+
+If the Pages deployment does not contain `dist/index.html`, `dist/demo/index.html`, and `dist/_redirects`, confirm that the project uses the build command and output directory shown above.

--- a/deploy/RUNBOOK-cloudflare-pages.md
+++ b/deploy/RUNBOOK-cloudflare-pages.md
@@ -17,13 +17,15 @@ Configure the Cloudflare Pages project from the repository root with these setti
 | Build output directory | `dist`             |
 | Root directory         | Repository root    |
 
-The Cloudflare build script defaults the production origin to the Cloudflare custom domain. You can set `ESHEET_SITE_ORIGIN` explicitly to the same value, without a trailing slash:
+The Cloudflare build script defaults the Docusaurus canonical site origin to the Cloudflare custom domain. You can set `ESHEET_SITE_ORIGIN` explicitly to the same value, without a trailing slash:
 
 ```txt
 ESHEET_SITE_ORIGIN=https://esheet.mieweb.org
 ```
 
-The atomic OS deployment has its own default, `https://esheet.os.mieweb.org`, and can override it through the GitHub Actions `ESHEET_SITE_ORIGIN` environment secret. This keeps each deployment's documentation and demo links on its own origin even when both deployment workflows build the same branch.
+The atomic OS deployment has its own canonical-origin default, `https://esheet.os.mieweb.org`, and can override it through the GitHub Actions `ESHEET_SITE_ORIGIN` environment secret.
+
+For non-`main` Cloudflare deployments, documentation-to-demo navigation uses Cloudflare's injected `CF_PAGES_URL`. This produces links on the deployment's unique hashed `*.pages.dev` hostname. Production Cloudflare and atomic deployments continue using their configured `ESHEET_SITE_ORIGIN` values.
 
 Attach the production custom domain to the Pages project in Cloudflare. A DNS record by itself does not associate the domain with the Pages project.
 
@@ -62,5 +64,6 @@ After deploying, verify these URLs in the browser and with direct page requests:
 - The landing cards navigate to `/demo/builder` and `/demo/renderer`.
 - `/demo/builder` and `/demo/renderer` load and refresh without a 404.
 - Documentation links labeled Demo or Live Demo open `/demo/` on the same origin.
+- On a Cloudflare preview deployment, documentation links stay on that preview's `*.pages.dev` hostname.
 
 If the Pages deployment does not contain `dist/index.html`, `dist/demo/index.html`, and `dist/_redirects`, confirm that the project uses the build command and output directory shown above.

--- a/deploy/scripts/cf-build.sh
+++ b/deploy/scripts/cf-build.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 #   dist/        ← docs site (served at /)
 #   dist/demo/   ← demo app  (served at /demo/)
 
+export ESHEET_SITE_ORIGIN="${ESHEET_SITE_ORIGIN:-https://esheet.mieweb.org}"
+
 npx nx build app-docs --outputStyle=static
 npx nx build app-demo --outputStyle=static
 
@@ -17,6 +19,7 @@ cp -r apps/demo/dist/. dist/demo/
 
 # SPA fallback rules for Cloudflare Pages (replaces nginx try_files).
 cat > dist/_redirects <<'EOF'
+/demo     /demo/            301
 /demo/*  /demo/index.html  200
 /*       /index.html       200
 EOF

--- a/deploy/scripts/workflow/atomic-deploy.sh
+++ b/deploy/scripts/workflow/atomic-deploy.sh
@@ -10,6 +10,8 @@ REL_DIR="$RELEASES_DIR/$SHA"
 
 cd "$REPO_ROOT"
 
+export ESHEET_SITE_ORIGIN="${ESHEET_SITE_ORIGIN:-https://esheet.os.mieweb.org}"
+
 CI=1 NX_INTERACTIVE=false npx nx build app-docs --outputStyle=static
 CI=1 NX_INTERACTIVE=false npx nx build app-demo --outputStyle=static
 


### PR DESCRIPTION
# Summary
Fixes production routing and navigation for the combined documentation and demo deployments.
Cloudflare Pages now uses https://esheet.mieweb.org, while the atomic open-source deployment continues using https://esheet.os.mieweb.org. Each deployment defines its own default origin while retaining ESHEET_SITE_ORIGIN as an override.
Fixes #105.

## Changes
- Default Cloudflare builds to https://esheet.mieweb.org.
- Default atomic deployments to https://esheet.os.mieweb.org.
- Preserve ESHEET_SITE_ORIGIN overrides for both deployment workflows.
- Add /demo → /demo/ normalization to Cloudflare redirects.
- Keep demo SPA routes under /demo/*.
- Remove forced document reloads from demo landing cards.
- Ensure builder and renderer navigation resolves to:
  - /demo/builder
  - /demo/renderer

Update README production links to the Cloudflare domain.
- Add a Cloudflare Pages deployment runbook covering:
  -Build command and output directory
- Environment configuration
- Combined docs/demo artifact layout
- Redirect behavior
- Deployment verification

## Deployment Behavior
Deployment	Documentation	Demo
Cloudflare Pages	https://esheet.mieweb.org/	https://esheet.mieweb.org/demo/
Atomic deployment	https://esheet.os.mieweb.org/	https://esheet.os.mieweb.org/demo/