### PR TITLE
enhance(renderer): support responsive field widths in rendered forms

### DIFF
--- a/packages/builder/src/lib/components/Canvas.tsx
+++ b/packages/builder/src/lib/components/Canvas.tsx
@@ -127,7 +127,10 @@ function DraggableFieldItem({
                 FieldComponentProps & { nestedChildren?: React.ReactNode }
               >;
               return (
-                <ContainerComponent {...props} nestedChildren={nestedChildren} />
+                <ContainerComponent
+                  {...props}
+                  nestedChildren={nestedChildren}
+                />
               );
             }
             return <Component {...props} />;

--- a/packages/builder/src/lib/components/Canvas.tsx
+++ b/packages/builder/src/lib/components/Canvas.tsx
@@ -5,71 +5,14 @@ import Sortable from 'sortablejs';
 import { useFormApi } from '../hooks/useFormApi.js';
 import { useUiApi } from '../hooks/useUiApi.js';
 import { FieldWrapper } from './FieldWrapper.js';
-import { getFieldComponent, PageNavigator } from '@esheet/fields';
+import {
+  FieldGrid,
+  FieldGridItem,
+  getFieldComponent,
+  PageNavigator,
+  useFieldGridLayout,
+} from '@esheet/fields';
 import { ViewBigIcon, ViewSmallIcon } from '../icons.js';
-
-// ---------------------------------------------------------------------------
-// Preview row grid
-// ---------------------------------------------------------------------------
-// Preview lays fields out on a 6-column grid so fields can share rows. Each
-// field's `width` decides how many columns it spans; the grid packs them left
-// to right and wraps automatically. On narrow screens the grid collapses to a
-// single stacked column.
-//   full  -> 6 cols (whole row)   half -> 3 cols (2/row)   third -> 2 cols (3/row)
-// The 6-column track is applied via inline style because Tailwind's responsive
-// display utilities (`ms:sm:grid`) are not reliably generated for these packages.
-const PREVIEW_GRID_CLASS = 'ms:gap-3';
-const PREVIEW_GRID_STYLE: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(6, minmax(0, 1fr))',
-  alignItems: 'start',
-};
-
-function previewColSpan(field: {
-  definition: { fieldType: string; width?: 'full' | 'half' | 'third' };
-}): number {
-  if (
-    field.definition.fieldType === 'section' ||
-    field.definition.fieldType === 'pages'
-  )
-    return 6;
-  switch (field.definition.width) {
-    case 'half':
-      return 3;
-    case 'third':
-      return 2;
-    default:
-      return 6;
-  }
-}
-
-// Below this viewport width the preview collapses to a single stacked column
-// (all fields full width), regardless of each field's chosen row width.
-const PREVIEW_STACK_MEDIA_QUERY = '(max-width: 900px)';
-
-/** True when the viewport is at tablet width or narrower. */
-function useIsNarrowPreview(): boolean {
-  const getMatches = () =>
-    typeof window !== 'undefined' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia(PREVIEW_STACK_MEDIA_QUERY).matches;
-
-  const [isNarrow, setIsNarrow] = React.useState(getMatches);
-
-  React.useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      typeof window.matchMedia !== 'function'
-    )
-      return;
-    const mq = window.matchMedia(PREVIEW_STACK_MEDIA_QUERY);
-    const handler = (e: MediaQueryListEvent) => setIsNarrow(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-
-  return isNarrow;
-}
 
 export interface CanvasProps {
   /** The form store */
@@ -95,7 +38,6 @@ function DraggableFieldItem({
   forceExpandVersion,
   forceCollapseVersion,
   nestedChildren,
-  previewGrid = false,
   computedValue,
 }: {
   id: string;
@@ -108,11 +50,11 @@ function DraggableFieldItem({
   forceExpandVersion?: number;
   forceCollapseVersion?: number;
   nestedChildren?: React.ReactNode;
-  previewGrid?: boolean;
   computedValue?: string | number | null;
 }) {
   const handleRef = React.useRef<HTMLDivElement | null>(null);
   const field = form.getState().getField(id);
+  const useGridLayout = useFieldGridLayout();
 
   // True when parentId refers to a section field (in normalized.byId), not a page.
   const parentIsSectionField = parentId
@@ -135,61 +77,64 @@ function DraggableFieldItem({
 
   if (!field) return null;
 
-  const wrapperClass = previewGrid
+  const wrapperClass = useGridLayout
     ? 'field-canvas-wrapper ms:relative'
     : 'field-canvas-wrapper ms:relative ms:pb-1 ms:last:pb-0';
-  const wrapperStyle = previewGrid
-    ? { gridColumn: `span ${previewColSpan(field)}` }
-    : undefined;
 
   return (
-    <div
-      className={wrapperClass}
-      style={wrapperStyle}
-      data-field-id={id}
-      data-field-type={field.definition.fieldType}
-      data-selected={isSelected ? 'true' : 'false'}
+    <FieldGridItem
+      fieldType={field.definition.fieldType}
+      width={field.definition.width}
     >
-      <FieldWrapper
-        fieldId={id}
-        form={form}
-        ui={ui}
-        dragHandleRef={handleRef}
-        forceExpandVersion={forceExpandVersion}
-        forceCollapseVersion={forceCollapseVersion}
-        isSelectedOverride={parentIsSectionField ? isActiveChild : undefined}
-        onSelectOverride={
-          parentIsSectionField ? handleSelectOverride : undefined
-        }
-        selectedVariant={parentIsSectionField ? 'nested' : 'default'}
-        computedValue={computedValue}
+      <div
+        className={wrapperClass}
+        data-field-id={id}
+        data-field-type={field.definition.fieldType}
+        data-selected={isSelected ? 'true' : 'false'}
       >
-        {(props) => {
-          const Component = getFieldComponent(props.field.definition.fieldType);
-
-          if (!Component) {
-            return (
-              <p className="ms:text-sm ms:text-mstextmuted ms:p-2">
-                Unknown field type:{' '}
-                <code className="ms:font-mono">
-                  {props.field.definition.fieldType}
-                </code>
-              </p>
-            );
+        <FieldWrapper
+          fieldId={id}
+          form={form}
+          ui={ui}
+          dragHandleRef={handleRef}
+          forceExpandVersion={forceExpandVersion}
+          forceCollapseVersion={forceCollapseVersion}
+          isSelectedOverride={parentIsSectionField ? isActiveChild : undefined}
+          onSelectOverride={
+            parentIsSectionField ? handleSelectOverride : undefined
           }
-
-          if (props.field.definition.fieldType === 'section') {
-            const ContainerComponent = Component as React.ComponentType<
-              FieldComponentProps & { nestedChildren?: React.ReactNode }
-            >;
-            return (
-              <ContainerComponent {...props} nestedChildren={nestedChildren} />
+          selectedVariant={parentIsSectionField ? 'nested' : 'default'}
+          computedValue={computedValue}
+        >
+          {(props) => {
+            const Component = getFieldComponent(
+              props.field.definition.fieldType
             );
-          }
-          return <Component {...props} />;
-        }}
-      </FieldWrapper>
-    </div>
+
+            if (!Component) {
+              return (
+                <p className="ms:text-sm ms:text-mstextmuted ms:p-2">
+                  Unknown field type:{' '}
+                  <code className="ms:font-mono">
+                    {props.field.definition.fieldType}
+                  </code>
+                </p>
+              );
+            }
+
+            if (props.field.definition.fieldType === 'section') {
+              const ContainerComponent = Component as React.ComponentType<
+                FieldComponentProps & { nestedChildren?: React.ReactNode }
+              >;
+              return (
+                <ContainerComponent {...props} nestedChildren={nestedChildren} />
+              );
+            }
+            return <Component {...props} />;
+          }}
+        </FieldWrapper>
+      </div>
+    </FieldGridItem>
   );
 }
 
@@ -205,8 +150,6 @@ export const Canvas = React.memo(function Canvas({
   const canvasRef = React.useRef<HTMLDivElement | null>(null);
   const { normalized, responses } = useFormApi();
   const { mode, selectedFieldId, selectedFieldChildId } = useUiApi();
-  const isNarrowPreview = useIsNarrowPreview();
-  const showPreviewGrid = mode === 'preview' && !isNarrowPreview;
   const [sectionExpandSignal, setSectionExpandSignal] = React.useState<{
     sectionId: string;
     version: number;
@@ -555,19 +498,19 @@ export const Canvas = React.memo(function Canvas({
       if (mode === 'preview' && childIds.length === 0) return null;
 
       const isEmpty = mode !== 'preview' && childIds.length === 0;
-      const previewGridClass = showPreviewGrid ? ` ${PREVIEW_GRID_CLASS}` : '';
       const containerClass =
         depth === 1
-          ? `section-children${previewGridClass}`
-          : `section-children ms:border-l ms:border-msborder ms:pl-3${previewGridClass}`;
+          ? 'section-children'
+          : 'section-children ms:border-l ms:border-msborder ms:pl-3';
       const emptyClass = isEmpty
         ? ' ms:rounded-lg ms:border-2 ms:border-dashed ms:border-msprimary/30 ms:bg-gradient-to-br ms:from-msbackground ms:to-msbackgroundsecondary'
         : ' ms:min-h-[2rem]';
 
       return (
-        <div
+        <FieldGrid
+          enabled={mode === 'preview'}
           className={`${containerClass}${emptyClass}`}
-          style={showPreviewGrid ? PREVIEW_GRID_STYLE : undefined}
+          stackedClassName="ms:space-y-0"
           data-depth={depth}
           data-sortable-list={dragEnabled ? 'true' : undefined}
           data-parent-id={parentId}
@@ -590,7 +533,6 @@ export const Canvas = React.memo(function Canvas({
               ui={ui}
               parentId={parentId}
               dragEnabled={dragEnabled}
-              previewGrid={showPreviewGrid}
               isSelected={
                 selectedFieldId === parentId && selectedFieldChildId === childId
               }
@@ -607,7 +549,7 @@ export const Canvas = React.memo(function Canvas({
               computedValue={computedValuesMap.get(childId)}
             />
           ))}
-        </div>
+        </FieldGrid>
       );
     },
     [
@@ -620,7 +562,6 @@ export const Canvas = React.memo(function Canvas({
       sectionExpandSignal,
       selectedFieldChildId,
       selectedFieldId,
-      showPreviewGrid,
       ui,
     ]
   );
@@ -873,12 +814,11 @@ export const Canvas = React.memo(function Canvas({
               No fields yet. Add a field from the Tool Panel to get started.
             </div>
           ) : (
-            <div
+            <FieldGrid
               ref={canvasRef}
-              className={`canvas-fields ${
-                showPreviewGrid ? PREVIEW_GRID_CLASS : 'ms:space-y-0'
-              } ms:flex-1 ms:min-h-0 ms:overflow-y-auto ms:px-4 ms:pt-3 ms:pb-4`}
-              style={showPreviewGrid ? PREVIEW_GRID_STYLE : undefined}
+              enabled={mode === 'preview'}
+              className="canvas-fields ms:flex-1 ms:min-h-0 ms:overflow-y-auto ms:px-4 ms:pt-3 ms:pb-4"
+              stackedClassName="ms:space-y-0"
               data-sortable-list={dragEnabled ? 'true' : undefined}
               data-parent-id={activePagesId ?? ''}
             >
@@ -900,7 +840,6 @@ export const Canvas = React.memo(function Canvas({
                     ui={ui}
                     parentId={activePagesId ?? undefined}
                     dragEnabled={dragEnabled}
-                    previewGrid={showPreviewGrid}
                     isSelected={
                       selectedFieldId === id && selectedFieldChildId === null
                     }
@@ -916,7 +855,7 @@ export const Canvas = React.memo(function Canvas({
                   />
                 ))
               )}
-            </div>
+            </FieldGrid>
           );
 
         if (mode === 'preview' && isMultiPage) {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -86,3 +86,11 @@ export * from './lib/touch-mode/index.js';
 // Page navigation
 export { PageNavigator } from './lib/PageNavigator.js';
 export type { PageNavigatorProps } from './lib/PageNavigator.js';
+
+// Field grid layout
+export {
+  FieldGrid,
+  FieldGridItem,
+  useFieldGridLayout,
+} from './lib/FieldGrid.js';
+export type { FieldGridItemProps, FieldGridProps } from './lib/FieldGrid.js';

--- a/packages/fields/src/lib/FieldGrid.tsx
+++ b/packages/fields/src/lib/FieldGrid.tsx
@@ -48,7 +48,8 @@ export const FieldGrid = React.forwardRef<HTMLDivElement, FieldGridProps>(
     { children, className, enabled = true, stackedClassName, style, ...props },
     ref
   ) {
-    const useGridLayout = enabled && !useIsNarrowGrid();
+    const isNarrowGrid = useIsNarrowGrid();
+    const useGridLayout = enabled && !isNarrowGrid;
     const containerClassName = [
       className,
       useGridLayout ? 'ms:gap-3' : stackedClassName,

--- a/packages/fields/src/lib/FieldGrid.tsx
+++ b/packages/fields/src/lib/FieldGrid.tsx
@@ -38,22 +38,14 @@ function useIsNarrowGrid(): boolean {
   return isNarrow;
 }
 
-export interface FieldGridProps
-  extends React.ComponentPropsWithoutRef<'div'> {
+export interface FieldGridProps extends React.ComponentPropsWithoutRef<'div'> {
   enabled?: boolean;
   stackedClassName?: string;
 }
 
 export const FieldGrid = React.forwardRef<HTMLDivElement, FieldGridProps>(
   function FieldGrid(
-    {
-      children,
-      className,
-      enabled = true,
-      stackedClassName,
-      style,
-      ...props
-    },
+    { children, className, enabled = true, stackedClassName, style, ...props },
     ref
   ) {
     const useGridLayout = enabled && !useIsNarrowGrid();

--- a/packages/fields/src/lib/FieldGrid.tsx
+++ b/packages/fields/src/lib/FieldGrid.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import type { FieldWidth } from '@esheet/core';
+
+const GRID_STYLE: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(6, minmax(0, 1fr))',
+  alignItems: 'start',
+};
+
+const STACK_MEDIA_QUERY = '(max-width: 900px)';
+
+const FieldGridContext = React.createContext(false);
+
+export function useFieldGridLayout(): boolean {
+  return React.useContext(FieldGridContext);
+}
+
+function useIsNarrowGrid(): boolean {
+  const getMatches = () =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia(STACK_MEDIA_QUERY).matches;
+
+  const [isNarrow, setIsNarrow] = React.useState(getMatches);
+
+  React.useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    )
+      return;
+    const mediaQuery = window.matchMedia(STACK_MEDIA_QUERY);
+    const handler = (event: MediaQueryListEvent) => setIsNarrow(event.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, []);
+
+  return isNarrow;
+}
+
+export interface FieldGridProps
+  extends React.ComponentPropsWithoutRef<'div'> {
+  enabled?: boolean;
+  stackedClassName?: string;
+}
+
+export const FieldGrid = React.forwardRef<HTMLDivElement, FieldGridProps>(
+  function FieldGrid(
+    {
+      children,
+      className,
+      enabled = true,
+      stackedClassName,
+      style,
+      ...props
+    },
+    ref
+  ) {
+    const useGridLayout = enabled && !useIsNarrowGrid();
+    const containerClassName = [
+      className,
+      useGridLayout ? 'ms:gap-3' : stackedClassName,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <FieldGridContext.Provider value={useGridLayout}>
+        <div
+          {...props}
+          ref={ref}
+          className={containerClassName}
+          style={useGridLayout ? { ...style, ...GRID_STYLE } : style}
+        >
+          {children}
+        </div>
+      </FieldGridContext.Provider>
+    );
+  }
+);
+
+export interface FieldGridItemProps {
+  children: React.ReactElement<{ style?: React.CSSProperties }>;
+  fieldType: string;
+  width?: FieldWidth;
+}
+
+export function FieldGridItem({
+  children,
+  fieldType,
+  width,
+}: FieldGridItemProps) {
+  const useGridLayout = useFieldGridLayout();
+  if (!useGridLayout) return children;
+
+  const columnSpan =
+    fieldType === 'section' || fieldType === 'pages'
+      ? 6
+      : width === 'half'
+      ? 3
+      : width === 'third'
+      ? 2
+      : 6;
+
+  return React.cloneElement(children, {
+    style: { ...children.props.style, gridColumn: `span ${columnSpan}` },
+  });
+}

--- a/packages/renderer/src/lib/EsheetRenderer.spec.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.spec.tsx
@@ -16,6 +16,41 @@ function getRendererHandle(ref: React.RefObject<EsheetRendererHandle | null>) {
 }
 
 describe('EsheetRenderer', () => {
+  it('uses builder row widths to lay fields out on a six-column grid', async () => {
+    const { container } = render(
+      <EsheetRenderer
+        formDataInput={{
+          id: 'row-width-form',
+          pages: [
+            {
+              id: 'page-1',
+              fields: [
+                { id: 'full', fieldType: 'text', width: 'full' },
+                { id: 'half', fieldType: 'text', width: 'half' },
+                { id: 'third', fieldType: 'text', width: 'third' },
+              ],
+            },
+          ],
+        }}
+      />
+    );
+
+    const body = container.querySelector<HTMLElement>('.renderer-body');
+    expect(body?.style.gridTemplateColumns).toBe('repeat(6, minmax(0, 1fr))');
+    expect(
+      container.querySelector<HTMLElement>('[data-field-id="full"]')?.style
+        .gridColumn
+    ).toBe('span 6');
+    expect(
+      container.querySelector<HTMLElement>('[data-field-id="half"]')?.style
+        .gridColumn
+    ).toBe('span 3');
+    expect(
+      container.querySelector<HTMLElement>('[data-field-id="third"]')?.style
+        .gridColumn
+    ).toBe('span 2');
+  });
+
   it('mounts and exposes ref handle', async () => {
     const ref = React.createRef<EsheetRendererHandle>();
     await act(async () => {

--- a/packages/renderer/src/lib/components/FieldNode.tsx
+++ b/packages/renderer/src/lib/components/FieldNode.tsx
@@ -231,47 +231,50 @@ export const FieldNode = React.memo(function FieldNode({
         data-field-id={field.definition.id}
         aria-disabled={!isEnabled || undefined}
       >
-      {presence.length > 0 && (
-        <div
-          className="collab-presence ms:absolute ms:top-2 ms:right-2 ms:flex ms:gap-1"
-          role="img"
-          aria-label={presence.map((peer) => peer.name).join(', ')}
-        >
-          {presence.map((peer) => (
-            <span
-              key={peer.name}
-              title={peer.name}
-              className="ms:inline-block ms:w-2.5 ms:h-2.5 ms:rounded-full ms:border ms:border-mssurface"
-              style={{ backgroundColor: peer.color }}
-            />
-          ))}
-        </div>
-      )}
-      {field.definition.fieldType === 'section' ? (
-        (() => {
-          const ContainerComponent = Component as React.ComponentType<
-            FieldComponentProps & { nestedChildren?: React.ReactNode }
-          >;
-          return (
-            <ContainerComponent {...props} nestedChildren={nestedChildren} />
-          );
-        })()
-      ) : (
-        <Component {...props} />
-      )}
-      {hasProposals && (
-        <div id={adornmentId} className="collab-proposals ms:mt-2 ms:space-y-1">
-          {proposals.map((proposal) => (
-            <ProposalAdornment
-              key={proposal.id}
-              proposal={proposal}
-              fieldId={id}
-              fieldLabel={fieldLabel}
-              collab={collab}
-            />
-          ))}
-        </div>
-      )}
+        {presence.length > 0 && (
+          <div
+            className="collab-presence ms:absolute ms:top-2 ms:right-2 ms:flex ms:gap-1"
+            role="img"
+            aria-label={presence.map((peer) => peer.name).join(', ')}
+          >
+            {presence.map((peer) => (
+              <span
+                key={peer.name}
+                title={peer.name}
+                className="ms:inline-block ms:w-2.5 ms:h-2.5 ms:rounded-full ms:border ms:border-mssurface"
+                style={{ backgroundColor: peer.color }}
+              />
+            ))}
+          </div>
+        )}
+        {field.definition.fieldType === 'section' ? (
+          (() => {
+            const ContainerComponent = Component as React.ComponentType<
+              FieldComponentProps & { nestedChildren?: React.ReactNode }
+            >;
+            return (
+              <ContainerComponent {...props} nestedChildren={nestedChildren} />
+            );
+          })()
+        ) : (
+          <Component {...props} />
+        )}
+        {hasProposals && (
+          <div
+            id={adornmentId}
+            className="collab-proposals ms:mt-2 ms:space-y-1"
+          >
+            {proposals.map((proposal) => (
+              <ProposalAdornment
+                key={proposal.id}
+                proposal={proposal}
+                fieldId={id}
+                fieldLabel={fieldLabel}
+                collab={collab}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </FieldGridItem>
   );

--- a/packages/renderer/src/lib/components/FieldNode.tsx
+++ b/packages/renderer/src/lib/components/FieldNode.tsx
@@ -6,7 +6,7 @@ import type {
   FormStore,
   UIStore,
 } from '@esheet/core';
-import { getFieldComponent } from '@esheet/fields';
+import { FieldGrid, FieldGridItem, getFieldComponent } from '@esheet/fields';
 
 export interface FieldNodeProps {
   id: string;
@@ -101,11 +101,15 @@ export const FieldNode = React.memo(function FieldNode({
     }
     const containerClass =
       depth === 1
-        ? 'section-children ms:space-y-2'
-        : 'section-children ms:space-y-2 ms:border-l ms:border-msborder ms:pl-3';
+        ? 'section-children'
+        : 'section-children ms:border-l ms:border-msborder ms:pl-3';
 
     return (
-      <div className={containerClass} data-depth={depth}>
+      <FieldGrid
+        className={containerClass}
+        stackedClassName="ms:space-y-2"
+        data-depth={depth}
+      >
         {visibleChildIds.map((childId) => (
           <FieldNode
             key={childId}
@@ -116,7 +120,7 @@ export const FieldNode = React.memo(function FieldNode({
             collab={collab}
           />
         ))}
-      </div>
+      </FieldGrid>
     );
   }, [field, visibleChildIds, id, form, ui, depth, collab]);
 
@@ -216,13 +220,17 @@ export const FieldNode = React.memo(function FieldNode({
   const fieldLabel = field.definition.question || field.definition.id;
 
   return (
-    <div
-      ref={wrapperRef}
-      className={wrapperClass}
-      data-field-type={field.definition.fieldType}
-      data-field-id={field.definition.id}
-      aria-disabled={!isEnabled || undefined}
+    <FieldGridItem
+      fieldType={field.definition.fieldType}
+      width={field.definition.width}
     >
+      <div
+        ref={wrapperRef}
+        className={wrapperClass}
+        data-field-type={field.definition.fieldType}
+        data-field-id={field.definition.id}
+        aria-disabled={!isEnabled || undefined}
+      >
       {presence.length > 0 && (
         <div
           className="collab-presence ms:absolute ms:top-2 ms:right-2 ms:flex ms:gap-1"
@@ -264,7 +272,8 @@ export const FieldNode = React.memo(function FieldNode({
           ))}
         </div>
       )}
-    </div>
+      </div>
+    </FieldGridItem>
   );
 });
 

--- a/packages/renderer/src/lib/components/RendererBody.tsx
+++ b/packages/renderer/src/lib/components/RendererBody.tsx
@@ -87,13 +87,7 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
   }, [form, pages, currentPagesIdx, responses]);
 
   const fields = visibleFieldIds.map((id) => (
-    <FieldNode
-      key={id}
-      id={id}
-      form={form}
-      ui={ui}
-      collab={collab}
-    />
+    <FieldNode key={id} id={id} form={form} ui={ui} collab={collab} />
   ));
 
   if (!isMultiPage) {

--- a/packages/renderer/src/lib/components/RendererBody.tsx
+++ b/packages/renderer/src/lib/components/RendererBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CollabDecorations, FormStore, UIStore } from '@esheet/core';
-import { PageNavigator } from '@esheet/fields';
+import { FieldGrid, PageNavigator } from '@esheet/fields';
 import { FieldNode } from './FieldNode.js';
 
 export interface RendererBodyProps {
@@ -87,12 +87,23 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
   }, [form, pages, currentPagesIdx, responses]);
 
   const fields = visibleFieldIds.map((id) => (
-    <FieldNode key={id} id={id} form={form} ui={ui} collab={collab} />
+    <FieldNode
+      key={id}
+      id={id}
+      form={form}
+      ui={ui}
+      collab={collab}
+    />
   ));
 
   if (!isMultiPage) {
     return (
-      <div className="canvas-fields renderer-body ms:space-y-0">{fields}</div>
+      <FieldGrid
+        className="canvas-fields renderer-body"
+        stackedClassName="ms:space-y-0"
+      >
+        {fields}
+      </FieldGrid>
     );
   }
 
@@ -104,9 +115,12 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
       onNext={handleNext}
       blockedCount={unfilledRequiredCount}
     >
-      <div className="canvas-fields renderer-body ms:space-y-0 ms:px-0">
+      <FieldGrid
+        className="canvas-fields renderer-body ms:px-0"
+        stackedClassName="ms:space-y-0"
+      >
         {fields}
-      </div>
+      </FieldGrid>
     </PageNavigator>
   );
 }


### PR DESCRIPTION
## Summary

This PR makes field width settings work consistently in both Builder preview and the standalone Renderer.

It extracts the existing Builder-only six-column preview layout into reusable `FieldGrid` and `FieldGridItem` components in `@esheet/fields`. Fields now use their configured width across rendering surfaces:

- `full`: spans all 6 columns
- `half`: spans 3 columns
- `third`: spans 2 columns
- `section` and `pages`: always span the full row

The grid automatically falls back to the existing stacked field layout at viewports of 900px or narrower. Root-level fields and fields nested inside sections are both supported.

## Changes

- Added shared responsive field grid components and exported them from `@esheet/fields`.
- Replaced the Builder Canvas’s duplicated preview-grid code with the shared layout.
- Applied the grid layout to single-page and multi-page renderer bodies.
- Applied field width spans to renderer field nodes and section children.
- Added renderer coverage for full-, half-, and third-width fields.