### PR TITLE
feat(fields): add configurable date and datetime input support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,19 @@
     "statusBar.background": "#007fff",
     "statusBar.foreground": "#e7e7e7",
     "statusBarItem.hoverBackground": "#3399ff",
-    "statusBarItem.remoteBackground": "#007fff",
+    "statusBarItem.remoteBackground": "#ff9fcf",
     "statusBarItem.remoteForeground": "#e7e7e7",
     "titleBar.activeBackground": "#007fff",
     "titleBar.activeForeground": "#e7e7e7",
     "titleBar.inactiveBackground": "#007fff99",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "titleBar.inactiveForeground": "#e7e7e799",
+    "activityBarTop.activeBackground": "#3399ff",
+    "activityBarTop.background": "#3399ff",
+    "activityBarTop.foreground": "#15202b",
+    "activityBarTop.inactiveForeground": "#15202b99",
+    "commandCenter.foreground": "#e7e7e7",
+    "statusBar.debuggingBackground": "#007fff",
+    "statusBar.debuggingForeground": "#e7e7e7"
   },
   "peacock.color": "#007fff"
 }

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -13,7 +13,7 @@
     "@esheet/field-kerebron": "*",
     "@esheet/fields": "*",
     "@esheet/renderer": "*",
-    "@mieweb/ui": "^0.6.1",
+    "@mieweb/ui": "0.7.0-dev.184",
     "react-router-dom": "^7.11.0"
   }
 }

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -124,36 +124,64 @@ export default defineConfig(({ command, mode }) => {
     // Explicit aliases are needed because Vite's commonjs resolver doesn't respect
     // custom export conditions (@esheet/source) during production builds.
     resolve: {
-      alias: {
-        '@esheet/adapters': resolve(
-          import.meta.dirname,
-          '../../packages/adapters/src/index.ts'
-        ),
-        '@esheet/core': resolve(
-          import.meta.dirname,
-          '../../packages/core/src/index.ts'
-        ),
-        '@esheet/fields': resolve(
-          import.meta.dirname,
-          '../../packages/fields/src/index.ts'
-        ),
-        '@esheet/builder': resolve(
-          import.meta.dirname,
-          '../../packages/builder/src/index.ts'
-        ),
-        '@esheet/renderer': resolve(
-          import.meta.dirname,
-          '../../packages/renderer/src/index.ts'
-        ),
-        '@esheet/field-kerebron': resolve(
-          import.meta.dirname,
-          '../../packages/field-kerebron/src/index.ts'
-        ),
-        '@esheet/field-health': resolve(
-          import.meta.dirname,
-          '../../packages/field-health/src/index.ts'
-        ),
-      },
+      alias: [
+        {
+          find: '@esheet/adapters',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/adapters/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/core',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/core/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/fields',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/fields/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/builder',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/builder/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/renderer',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/renderer/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/field-kerebron',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/field-kerebron/src/index.ts'
+          ),
+        },
+        {
+          find: '@esheet/field-health',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/field-health/src/index.ts'
+          ),
+        },
+        {
+          find: /^@mieweb\/ui$/,
+          replacement: resolve(
+            import.meta.dirname,
+            '../../node_modules/@mieweb/ui'
+          ),
+        },
+      ],
     },
     optimizeDeps: {
       entries: ['index.html', '../../packages/field-health/src/index.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@mieweb/ui": "^0.7.0",
+        "@mieweb/ui": "0.7.0-dev.184",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -80,67 +80,8 @@
         "@esheet/field-kerebron": "*",
         "@esheet/fields": "*",
         "@esheet/renderer": "*",
-        "@mieweb/ui": "^0.6.1",
+        "@mieweb/ui": "0.7.0-dev.184",
         "react-router-dom": "^7.11.0"
-      }
-    },
-    "apps/demo/node_modules/@mieweb/ui": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.6.1.tgz",
-      "integrity": "sha512-M1zHSukvCs9fTXTa/fZfHKueWOhOv8oomq0Mic9QhXcVMkN6i+6/JQdboEEJRtQYUhxGwNoTFbYIzMpbODvoXg==",
-      "hasInstallScript": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@swc/helpers": "^0.5.19",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "google-libphonenumber": "^3.2.44",
-        "lucide-react": "^0.562.0",
-        "luxon": "^3.7.2",
-        "tailwind-merge": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@esheet/builder": ">=0.0.2",
-        "@esheet/renderer": ">=0.0.2",
-        "@ozwell/react": ">=0.1.0",
-        "ag-grid-community": ">=32.0.0",
-        "ag-grid-react": ">=32.0.0",
-        "datavis-ace": "=4.0.0-PRE.2",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
-        "wavesurfer.js": ">=7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@esheet/builder": {
-          "optional": true
-        },
-        "@esheet/renderer": {
-          "optional": true
-        },
-        "@ozwell/react": {
-          "optional": true
-        },
-        "ag-grid-community": {
-          "optional": true
-        },
-        "ag-grid-react": {
-          "optional": true
-        },
-        "datavis-ace": {
-          "optional": true
-        },
-        "react": {
-          "optional": false
-        },
-        "react-dom": {
-          "optional": false
-        },
-        "wavesurfer.js": {
-          "optional": true
-        }
       }
     },
     "apps/demo/node_modules/@swc/helpers": {
@@ -7782,9 +7723,9 @@
       }
     },
     "node_modules/@mieweb/ui": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.7.0.tgz",
-      "integrity": "sha512-H9PY/9s7P/SjX2TUZuyuD6hBcDis6ZL05HSwCoYXw1YIg0vWB0+O45qLC6rr5M9UN30q5NFaUY9Ijw1q+SyXOw==",
+      "version": "0.7.0-dev.184",
+      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.7.0-dev.184.tgz",
+      "integrity": "sha512-ytPfnXqxVplPFoWnuPuRkfC1aBeSd74Uss2/l56UmyEz8CVEO+M8EKpcH7esgOrbFEKGtt3R2t3JAqKDkcEoKA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -33198,6 +33139,123 @@
         "react-dom": "^19.2.4"
       }
     },
+    "packages/field-health/node_modules/@mieweb/ui": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.7.0.tgz",
+      "integrity": "sha512-H9PY/9s7P/SjX2TUZuyuD6hBcDis6ZL05HSwCoYXw1YIg0vWB0+O45qLC6rr5M9UN30q5NFaUY9Ijw1q+SyXOw==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@swc/helpers": "^0.5.19",
+        "@tanstack/react-virtual": "^3.14.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "dompurify": "^3.4.0",
+        "google-libphonenumber": "^3.2.44",
+        "highlight.js": "^11.11.1",
+        "lucide-react": "^0.562.0",
+        "luxon": "^3.7.2",
+        "marked": "^17.0.3",
+        "onnxruntime-web": "1.19.0",
+        "tailwind-merge": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@kerebron/editor": ">=0.7.9",
+        "@kerebron/editor-kits": ">=0.7.9",
+        "@kerebron/wasm": ">=0.7.9",
+        "@mieweb/datavis": "=1.6.0",
+        "ag-grid-community": ">=32.0.0",
+        "ag-grid-react": ">=32.0.0",
+        "datavis-ace": "=4.1.0",
+        "js-yaml": ">=4.0.0",
+        "katex": ">=0.16.0",
+        "mermaid": ">=11.0.0",
+        "papaparse": ">=5.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "react-markdown": ">=9.0.0",
+        "rehype-highlight": ">=7.0.0",
+        "rehype-katex": ">=7.0.0",
+        "rehype-sanitize": ">=6.0.0",
+        "remark-gfm": ">=4.0.0",
+        "remark-math": ">=6.0.0",
+        "wavesurfer.js": ">=7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@kerebron/editor": {
+          "optional": true
+        },
+        "@kerebron/editor-kits": {
+          "optional": true
+        },
+        "@kerebron/wasm": {
+          "optional": true
+        },
+        "@mieweb/datavis": {
+          "optional": true
+        },
+        "ag-grid-community": {
+          "optional": true
+        },
+        "ag-grid-react": {
+          "optional": true
+        },
+        "datavis-ace": {
+          "optional": true
+        },
+        "js-yaml": {
+          "optional": true
+        },
+        "katex": {
+          "optional": true
+        },
+        "mermaid": {
+          "optional": true
+        },
+        "papaparse": {
+          "optional": true
+        },
+        "react": {
+          "optional": false
+        },
+        "react-dom": {
+          "optional": false
+        },
+        "react-markdown": {
+          "optional": true
+        },
+        "rehype-highlight": {
+          "optional": true
+        },
+        "rehype-katex": {
+          "optional": true
+        },
+        "rehype-sanitize": {
+          "optional": true
+        },
+        "remark-gfm": {
+          "optional": true
+        },
+        "remark-math": {
+          "optional": true
+        },
+        "wavesurfer.js": {
+          "optional": true
+        }
+      }
+    },
+    "packages/field-health/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "packages/field-kerebron": {
       "name": "@esheet/field-kerebron",
       "version": "0.0.4-2",
@@ -33263,7 +33321,7 @@
       "version": "0.0.4-2",
       "dependencies": {
         "@esheet/core": "0.0.4-2",
-        "@mieweb/ui": "^0.6.1",
+        "@mieweb/ui": "0.7.0-dev.184",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "sortablejs": "^1.15.7",
@@ -33279,42 +33337,61 @@
       }
     },
     "packages/fields/node_modules/@mieweb/ui": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.6.1.tgz",
-      "integrity": "sha512-M1zHSukvCs9fTXTa/fZfHKueWOhOv8oomq0Mic9QhXcVMkN6i+6/JQdboEEJRtQYUhxGwNoTFbYIzMpbODvoXg==",
+      "version": "0.7.0-dev.184",
+      "resolved": "https://registry.npmjs.org/@mieweb/ui/-/ui-0.7.0-dev.184.tgz",
+      "integrity": "sha512-ytPfnXqxVplPFoWnuPuRkfC1aBeSd74Uss2/l56UmyEz8CVEO+M8EKpcH7esgOrbFEKGtt3R2t3JAqKDkcEoKA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@swc/helpers": "^0.5.19",
+        "@tanstack/react-virtual": "^3.14.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.0",
         "google-libphonenumber": "^3.2.44",
+        "highlight.js": "^11.11.1",
         "lucide-react": "^0.562.0",
         "luxon": "^3.7.2",
+        "marked": "^17.0.3",
+        "onnxruntime-web": "1.19.0",
         "tailwind-merge": "^2.6.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@esheet/builder": ">=0.0.2",
-        "@esheet/renderer": ">=0.0.2",
-        "@ozwell/react": ">=0.1.0",
+        "@kerebron/editor": ">=0.7.9",
+        "@kerebron/editor-kits": ">=0.7.9",
+        "@kerebron/wasm": ">=0.7.9",
+        "@mieweb/datavis": "=1.6.0",
         "ag-grid-community": ">=32.0.0",
         "ag-grid-react": ">=32.0.0",
-        "datavis-ace": "=4.0.0-PRE.2",
+        "datavis-ace": "=4.1.0",
+        "js-yaml": ">=4.0.0",
+        "katex": ">=0.16.0",
+        "mermaid": ">=11.0.0",
+        "papaparse": ">=5.0.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
+        "react-markdown": ">=9.0.0",
+        "rehype-highlight": ">=7.0.0",
+        "rehype-katex": ">=7.0.0",
+        "rehype-sanitize": ">=6.0.0",
+        "remark-gfm": ">=4.0.0",
+        "remark-math": ">=6.0.0",
         "wavesurfer.js": ">=7.0.0"
       },
       "peerDependenciesMeta": {
-        "@esheet/builder": {
+        "@kerebron/editor": {
           "optional": true
         },
-        "@esheet/renderer": {
+        "@kerebron/editor-kits": {
           "optional": true
         },
-        "@ozwell/react": {
+        "@kerebron/wasm": {
+          "optional": true
+        },
+        "@mieweb/datavis": {
           "optional": true
         },
         "ag-grid-community": {
@@ -33326,11 +33403,41 @@
         "datavis-ace": {
           "optional": true
         },
+        "js-yaml": {
+          "optional": true
+        },
+        "katex": {
+          "optional": true
+        },
+        "mermaid": {
+          "optional": true
+        },
+        "papaparse": {
+          "optional": true
+        },
         "react": {
           "optional": false
         },
         "react-dom": {
           "optional": false
+        },
+        "react-markdown": {
+          "optional": true
+        },
+        "rehype-highlight": {
+          "optional": true
+        },
+        "rehype-katex": {
+          "optional": true
+        },
+        "rehype-sanitize": {
+          "optional": true
+        },
+        "remark-gfm": {
+          "optional": true
+        },
+        "remark-math": {
+          "optional": true
         },
         "wavesurfer.js": {
           "optional": true

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     }
   },
   "dependencies": {
-    "@mieweb/ui": "^0.7.0",
+    "@mieweb/ui": "0.7.0-dev.184",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
@@ -106,6 +106,19 @@ export function CommonEditor({
             (def as { inputType?: TextInputType }).inputType ?? 'string'
           }
           unit={(def as { unit?: string }).unit}
+          dateRange={
+            (
+              def as {
+                dateRange?: {
+                  amount: number;
+                  unit: 'days' | 'months' | 'years';
+                };
+              }
+            ).dateRange
+          }
+          timeFormat={
+            (def as { timeFormat?: '12-hour' | '24-hour' }).timeFormat
+          }
           onChange={(patch) =>
             onUpdate(patch as Parameters<typeof onUpdate>[0])
           }

--- a/packages/builder/src/lib/components/edit-panel/InputTypeEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/InputTypeEditor.tsx
@@ -1,6 +1,11 @@
 import type { TextInputType } from '@esheet/core';
 import { useInstanceId } from '../../EsheetBuilder.js';
 
+type RelativeDateRange = {
+  amount: number;
+  unit: 'days' | 'months' | 'years';
+};
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -33,7 +38,14 @@ export interface InputTypeEditorProps {
   fieldId: string;
   inputType: TextInputType;
   unit?: string;
-  onChange: (patch: { inputType?: TextInputType; unit?: string }) => void;
+  dateRange?: RelativeDateRange;
+  timeFormat?: '12-hour' | '24-hour';
+  onChange: (patch: {
+    inputType?: TextInputType;
+    unit?: string;
+    dateRange?: RelativeDateRange;
+    timeFormat?: '12-hour' | '24-hour';
+  }) => void;
 }
 
 /**
@@ -44,10 +56,14 @@ export function InputTypeEditor({
   fieldId,
   inputType,
   unit,
+  dateRange,
+  timeFormat,
   onChange,
 }: InputTypeEditorProps) {
   const instanceId = useInstanceId();
   const showUnit = inputType === 'number';
+  const showDateRange = inputType === 'date' || inputType === 'datetime-local';
+  const showTimeFormat = inputType === 'datetime-local';
 
   return (
     <div className="input-type-editor ms:space-y-2">
@@ -105,6 +121,100 @@ export function InputTypeEditor({
           </select>
         </div>
       )}
+
+      {showDateRange && (
+        <div className="ms:space-y-2">
+          <RelativeDateRangeEditor
+            fieldId={fieldId}
+            instanceId={instanceId}
+            value={dateRange}
+            onChange={(value) => onChange({ dateRange: value })}
+          />
+        </div>
+      )}
+
+      {showTimeFormat && (
+        <div>
+          <label
+            htmlFor={`${instanceId}-editor-timeformat-${fieldId}`}
+            className="edit-label ms:block ms:text-xs ms:font-medium ms:text-mstextmuted ms:mb-1"
+          >
+            Time format
+          </label>
+          <select
+            id={`${instanceId}-editor-timeformat-${fieldId}`}
+            value={timeFormat ?? '24-hour'}
+            onChange={(e) =>
+              onChange({
+                timeFormat: e.currentTarget.value as '12-hour' | '24-hour',
+              })
+            }
+            className="ms:w-full ms:min-w-0 ms:px-2 ms:py-1 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-2 ms:focus:ring-msprimary ms:focus:border-msprimary"
+          >
+            <option value="24-hour">24-hour</option>
+            <option value="12-hour">12-hour</option>
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RelativeDateRangeEditor({
+  fieldId,
+  instanceId,
+  value,
+  onChange,
+}: {
+  fieldId: string;
+  instanceId: string;
+  value?: RelativeDateRange;
+  onChange: (value: RelativeDateRange) => void;
+}) {
+  const amountId = `${instanceId}-editor-daterange-amount-${fieldId}`;
+  const unitId = `${instanceId}-editor-daterange-unit-${fieldId}`;
+  const offset = value ?? { amount: 0, unit: 'years' as const };
+
+  return (
+    <div>
+      <label
+        htmlFor={amountId}
+        className="edit-label ms:block ms:text-xs ms:font-medium ms:text-mstextmuted ms:mb-1"
+      >
+        Date range around today
+      </label>
+      <div className="ms:grid ms:grid-cols-2 ms:gap-2">
+        <input
+          id={amountId}
+          aria-label="Date range amount"
+          type="number"
+          min="0"
+          value={offset.amount}
+          onChange={(e) =>
+            onChange({
+              ...offset,
+              amount: Math.max(0, Number(e.currentTarget.value) || 0),
+            })
+          }
+          className="ms:min-w-0 ms:px-2 ms:py-1 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-2 ms:focus:ring-msprimary ms:focus:border-msprimary"
+        />
+        <select
+          id={unitId}
+          aria-label="Date range unit"
+          value={offset.unit}
+          onChange={(e) =>
+            onChange({
+              ...offset,
+              unit: e.currentTarget.value as RelativeDateRange['unit'],
+            })
+          }
+          className="ms:min-w-0 ms:px-2 ms:py-1 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-2 ms:focus:ring-msprimary ms:focus:border-msprimary"
+        >
+          <option value="days">Days</option>
+          <option value="months">Months</option>
+          <option value="years">Years</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -4,6 +4,15 @@
   "include": ["../../types/**/*.d.ts"],
   "references": [
     {
+      "path": "../fields"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../adapters"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   type FieldDefinition,
   type FieldWidth,
   type OptionLayout,
+  type RelativeDateRange,
   type OptionBearingFieldDefinition,
   hasOptions,
   // Per-field-type interfaces (discriminated union members)

--- a/packages/core/src/lib/types.spec.ts
+++ b/packages/core/src/lib/types.spec.ts
@@ -2,6 +2,7 @@ import {
   FIELD_TYPES,
   formDefinitionSchema,
   fieldDefinitionSchema,
+  normalizeFormDefinition,
 } from './types.js';
 import { registerFieldType, resetFieldTypeRegistry } from './registry.js';
 import type {
@@ -95,6 +96,106 @@ describe('schema types', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('should preserve supported field properties during normalization', () => {
+    const normalized = normalizeFormDefinition({
+      id: 'form',
+      pages: [
+        {
+          id: 'page-1',
+          fields: [
+            {
+              id: 'text',
+              fieldType: 'text',
+              inputType: 'datetime-local',
+              dateRange: { amount: 2, unit: 'years' },
+              timeFormat: '12-hour',
+            },
+            {
+              id: 'longtext',
+              fieldType: 'longtext',
+              dateRange: { amount: 1, unit: 'months' },
+            },
+            {
+              id: 'matrix',
+              fieldType: 'singlematrix',
+              scored: true,
+              scoreStart: 1,
+            },
+            {
+              id: 'multimatrix',
+              fieldType: 'multimatrix',
+              scored: true,
+              scoreStart: 1,
+            },
+            {
+              id: 'openchoice',
+              fieldType: 'openchoice',
+              optionLayout: 'wrap',
+            },
+            {
+              id: 'section',
+              fieldType: 'section',
+              sectionCollapse: 'collapsed',
+            },
+            {
+              id: 'pages',
+              fieldType: 'pages',
+              autoAdvance: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(formDefinitionSchema.safeParse(normalized).success).toBe(true);
+    expect(normalized.pages).toEqual([
+      {
+        id: 'page-1',
+        fields: [
+          {
+            id: 'text',
+            fieldType: 'text',
+            inputType: 'datetime-local',
+            dateRange: { amount: 2, unit: 'years' },
+            timeFormat: '12-hour',
+          },
+          {
+            id: 'longtext',
+            fieldType: 'longtext',
+            dateRange: { amount: 1, unit: 'months' },
+          },
+          {
+            id: 'matrix',
+            fieldType: 'singlematrix',
+            scored: true,
+            scoreStart: 1,
+          },
+          {
+            id: 'multimatrix',
+            fieldType: 'multimatrix',
+            scored: true,
+            scoreStart: 1,
+          },
+          {
+            id: 'openchoice',
+            fieldType: 'openchoice',
+            optionLayout: 'wrap',
+          },
+          {
+            id: 'section',
+            fieldType: 'section',
+            sectionCollapse: 'collapsed',
+          },
+          {
+            id: 'pages',
+            fieldType: 'pages',
+            autoAdvance: true,
+          },
+        ],
+      },
+    ]);
   });
 });
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -269,6 +269,12 @@ export type FieldWidth = 'full' | 'half' | 'third';
  */
 export type OptionLayout = 'stack' | 'wrap';
 
+/** A symmetric date range resolved relative to the day the form is rendered. */
+export interface RelativeDateRange {
+  amount: number;
+  unit: 'days' | 'months' | 'years';
+}
+
 // ---------------------------------------------------------------------------
 // Base Interfaces
 // ---------------------------------------------------------------------------
@@ -311,12 +317,16 @@ export interface TextFieldDefinition extends BaseFieldDefinition {
   fieldType: 'text';
   inputType?: TextInputType;
   unit?: string;
+  dateRange?: RelativeDateRange;
+  timeFormat?: '12-hour' | '24-hour';
 }
 
 export interface LongtextFieldDefinition extends BaseFieldDefinition {
   fieldType: 'longtext';
   inputType?: TextInputType;
   unit?: string;
+  dateRange?: RelativeDateRange;
+  timeFormat?: '12-hour' | '24-hour';
 }
 
 export interface MultitextFieldDefinition extends BaseFieldDefinition {
@@ -567,8 +577,8 @@ export function hasOptions(
 /** Properties allowed for each field type (beyond base properties). */
 const FIELD_TYPE_PROPERTIES: Record<FieldType, readonly string[]> = {
   // Text category
-  text: ['inputType', 'unit'],
-  longtext: ['inputType', 'unit'],
+  text: ['inputType', 'unit', 'dateRange', 'timeFormat'],
+  longtext: ['inputType', 'unit', 'dateRange', 'timeFormat'],
   multitext: ['options', 'optionLayout'],
   // Selection category
   radio: ['options', 'optionLayout'],
@@ -581,15 +591,15 @@ const FIELD_TYPE_PROPERTIES: Record<FieldType, readonly string[]> = {
   ranking: ['options'],
   slider: ['options'],
   // Matrix category
-  singlematrix: ['rows', 'columns'],
-  multimatrix: ['rows', 'columns'],
+  singlematrix: ['rows', 'columns', 'scored', 'scoreStart'],
+  multimatrix: ['rows', 'columns', 'scored', 'scoreStart'],
   // Rich category
   image: ['imageUri', 'altText', 'caption'],
   html: ['htmlContent', 'iframeHeight'],
   signature: ['padPlaceholder'],
   diagram: ['imageUri', 'padPlaceholder'],
   file: ['accept', 'maxFileSize', 'maxFiles'],
-  openchoice: ['options', 'maxCustomOptions', 'otherLabel'],
+  openchoice: ['options', 'maxCustomOptions', 'otherLabel', 'optionLayout'],
   display: ['content'],
   // Organization category
   section: ['title', 'fields', 'sectionCollapse'],
@@ -729,12 +739,19 @@ const baseFieldProps = {
   _conversionWarnings: z.optional(z.array(z.unknown())),
 };
 
+const relativeDateRangeSchema = z.object({
+  amount: z.number(),
+  unit: z.enum(['days', 'months', 'years']),
+});
+
 // Text category schemas
 const textFieldSchema = z.strictObject({
   ...baseFieldProps,
   fieldType: z.literal('text'),
   inputType: z.optional(textInputTypeSchema),
   unit: z.optional(z.string()),
+  dateRange: z.optional(relativeDateRangeSchema),
+  timeFormat: z.optional(z.enum(['12-hour', '24-hour'])),
 });
 
 const longtextFieldSchema = z.strictObject({
@@ -742,6 +759,8 @@ const longtextFieldSchema = z.strictObject({
   fieldType: z.literal('longtext'),
   inputType: z.optional(textInputTypeSchema),
   unit: z.optional(z.string()),
+  dateRange: z.optional(relativeDateRangeSchema),
+  timeFormat: z.optional(z.enum(['12-hour', '24-hour'])),
 });
 
 const multitextFieldSchema = z.strictObject({
@@ -809,6 +828,8 @@ const singleMatrixFieldSchema = z.strictObject({
   fieldType: z.literal('singlematrix'),
   rows: z.optional(z.array(matrixRowSchema)),
   columns: z.optional(z.array(matrixColumnSchema)),
+  scored: z.optional(z.boolean()),
+  scoreStart: z.optional(z.number()),
 });
 
 const multiMatrixFieldSchema = z.strictObject({
@@ -816,6 +837,8 @@ const multiMatrixFieldSchema = z.strictObject({
   fieldType: z.literal('multimatrix'),
   rows: z.optional(z.array(matrixRowSchema)),
   columns: z.optional(z.array(matrixColumnSchema)),
+  scored: z.optional(z.boolean()),
+  scoreStart: z.optional(z.number()),
 });
 
 // Rich category schemas
@@ -861,6 +884,7 @@ const openChoiceFieldSchema = z.strictObject({
   options: z.optional(z.array(fieldOptionSchema)),
   maxCustomOptions: z.optional(z.number()),
   otherLabel: z.optional(z.string()),
+  optionLayout: z.optional(z.enum(['stack', 'wrap'])),
 });
 
 const displayBaseFieldProps = {
@@ -883,6 +907,19 @@ const sectionFieldSchema = z.strictObject({
   ...baseFieldProps,
   fieldType: z.literal('section'),
   title: z.optional(z.string()),
+  sectionCollapse: z.optional(z.enum(['collapsed', 'expanded', 'disabled'])),
+  fields: z.optional(
+    z.lazy(
+      (): z.ZodMiniType<FieldDefinition[]> => z.array(fieldDefinitionSchema)
+    )
+  ),
+});
+
+const pagesFieldSchema = z.strictObject({
+  ...baseFieldProps,
+  fieldType: z.literal('pages'),
+  title: z.optional(z.string()),
+  autoAdvance: z.optional(z.boolean()),
   fields: z.optional(
     z.lazy(
       (): z.ZodMiniType<FieldDefinition[]> => z.array(fieldDefinitionSchema)
@@ -919,6 +956,7 @@ const builtInFieldDefinitionSchema = z.discriminatedUnion('fieldType', [
   displayFieldSchema,
   // Organization
   sectionFieldSchema,
+  pagesFieldSchema,
 ]);
 
 /**

--- a/packages/field-kerebron/tsconfig.json
+++ b/packages/field-kerebron/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["../../types/**/*.d.ts"],
   "references": [
     {
+      "path": "../core"
+    },
+    {
       "path": "./tsconfig.lib.json"
     }
   ],

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@esheet/core": "0.0.4-2",
-    "@mieweb/ui": "^0.6.1",
+    "@mieweb/ui": "0.7.0-dev.184",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "sortablejs": "^1.15.7",

--- a/packages/fields/src/fields/text/TextField.spec.tsx
+++ b/packages/fields/src/fields/text/TextField.spec.tsx
@@ -1,0 +1,120 @@
+import { render } from '@testing-library/react';
+import type { FieldComponentProps } from '@esheet/core';
+import { TextField } from './TextField.js';
+
+const mocks = vi.hoisted(() => ({
+  dateInput: vi.fn((..._args: unknown[]) => null),
+}));
+
+vi.mock('@mieweb/ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@mieweb/ui')>()),
+  DateInput: mocks.dateInput,
+}));
+
+function createProps(definition: Record<string, unknown>): FieldComponentProps {
+  return {
+    field: { definition },
+    form: { getState: () => ({ instanceId: 'test' }) },
+    isPreview: true,
+    isEnabled: true,
+    onResponse: vi.fn(),
+  } as unknown as FieldComponentProps;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TextField', () => {
+  it('stores DateInput values as ISO dates', () => {
+    const onResponse = vi.fn();
+
+    render(
+      <TextField
+        {...createProps({
+          fieldType: 'text',
+          id: 'appointment-date',
+          inputType: 'date',
+        })}
+        onResponse={onResponse}
+      />
+    );
+
+    const props = mocks.dateInput.mock.calls[0][0] as {
+      onChange: (value: string) => void;
+    };
+    props.onChange('07/15/2026');
+
+    expect(onResponse).toHaveBeenCalledWith({ answer: '2026-07-15' });
+  });
+
+  it('formats stored ISO dates for DateInput', () => {
+    render(
+      <TextField
+        {...createProps({
+          fieldType: 'text',
+          id: 'appointment-date',
+          inputType: 'date',
+        })}
+        response={{ answer: '2026-07-15' }}
+      />
+    );
+
+    expect(mocks.dateInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: '07/15/2026',
+        name: 'esheet-date-answer-appointment-date',
+      }),
+      undefined
+    );
+  });
+
+  it('resolves relative date bounds when the field is rendered', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 28));
+
+    render(
+      <TextField
+        {...createProps({
+          fieldType: 'text',
+          id: 'appointment-date',
+          inputType: 'date',
+          dateRange: { amount: 2, unit: 'years' },
+        })}
+      />
+    );
+
+    expect(mocks.dateInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minDate: '07/28/2024',
+        maxDate: '07/28/2028',
+      }),
+      undefined
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('renders Date and Time fields with DateInput', () => {
+    render(
+      <TextField
+        {...createProps({
+          fieldType: 'text',
+          id: 'appointment-date-time',
+          inputType: 'datetime-local',
+          timeFormat: '12-hour',
+        })}
+      />
+    );
+
+    expect(mocks.dateInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputType: 'datetime-local',
+        timeFormat: '12-hour',
+        validateOnBlur: true,
+        name: 'esheet-datetime-local-answer-appointment-date-time',
+      }),
+      undefined
+    );
+  });
+});

--- a/packages/fields/src/fields/text/TextField.tsx
+++ b/packages/fields/src/fields/text/TextField.tsx
@@ -28,6 +28,62 @@ function formatPhoneNumber(value: string): string {
   return value;
 }
 
+function toDateInputValue(value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  return match ? `${match[2]}/${match[3]}/${match[1]}` : value;
+}
+
+function toStoredDateValue(value: string): string {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value);
+  return match ? `${match[3]}-${match[1]}-${match[2]}` : value;
+}
+
+function formatDateInputValue(date: Date): string {
+  return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(
+    date.getDate()
+  ).padStart(2, '0')}/${date.getFullYear()}`;
+}
+
+function applyDateRangeOffset(
+  date: Date,
+  amount: number,
+  unit: 'days' | 'months' | 'years'
+): Date {
+  const result = new Date(date);
+  if (unit === 'days') {
+    result.setDate(result.getDate() + amount);
+  } else {
+    const monthOffset = unit === 'months' ? amount : amount * 12;
+    const day = result.getDate();
+    result.setDate(1);
+    result.setMonth(result.getMonth() + monthOffset);
+    const lastDay = new Date(
+      result.getFullYear(),
+      result.getMonth() + 1,
+      0
+    ).getDate();
+    result.setDate(Math.min(day, lastDay));
+  }
+
+  return result;
+}
+
+function resolveDateRange(
+  range: { amount: number; unit: 'days' | 'months' | 'years' } | undefined
+): { minDate?: string; maxDate?: string } {
+  if (!range) return {};
+  const today = new Date();
+  const amount = Math.abs(range.amount);
+  return {
+    minDate: formatDateInputValue(
+      applyDateRangeOffset(today, -amount, range.unit)
+    ),
+    maxDate: formatDateInputValue(
+      applyDateRangeOffset(today, amount, range.unit)
+    ),
+  };
+}
+
 const PLACEHOLDER: Record<string, string> = {
   string: 'Enter text',
   number: 'Enter number',
@@ -57,6 +113,7 @@ export const TextField = React.memo(function TextField({
   const unit = def.unit || '';
   const isTel = inputType === 'tel';
   const placeholder = PLACEHOLDER[inputType] || 'Type your answer';
+  const dateRange = resolveDateRange(def.dateRange);
 
   // When a computed value arrives and the user hasn't answered yet, seed it as
   // the response so it behaves like any other answered field (overwritable).
@@ -67,17 +124,31 @@ export const TextField = React.memo(function TextField({
   }, [computedValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isPreview) {
-    if (inputType === 'date') {
+    if (inputType === 'date' || inputType === 'datetime-local') {
       return (
         <div className="text-field-preview">
           <DateInput
             id={`${instanceId}-text-answer-${def.id}`}
+            name={`esheet-${inputType}-answer-${def.id}`}
             label={def.question || 'Question'}
             required={isRequired || isSoftRequired}
             disabled={!isEnabled}
             aria-required={isRequired || undefined}
-            value={response?.answer || ''}
-            onChange={(val) => onResponse({ answer: val })}
+            value={
+              inputType === 'date'
+                ? toDateInputValue(response?.answer || '')
+                : response?.answer || ''
+            }
+            onChange={(val) =>
+              onResponse({
+                answer: inputType === 'date' ? toStoredDateValue(val) : val,
+              })
+            }
+            inputType={inputType}
+            timeFormat={def.timeFormat}
+            minDate={dateRange.minDate}
+            maxDate={dateRange.maxDate}
+            validateOnBlur
             showCalendar
           />
         </div>
@@ -131,12 +202,13 @@ export const TextField = React.memo(function TextField({
           className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary/30 ms:outline-none ms:transition-colors"
         />
       </div>
-      {inputType === 'date' ? (
+      {inputType === 'date' || inputType === 'datetime-local' ? (
         <div className="ms:pointer-events-none ms:select-none">
           <DateInput
             id={`${instanceId}-canvas-preview-${def.id}`}
             aria-label="Answer preview"
             value=""
+            inputType={inputType}
             disabled
             showCalendar
           />

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["../../types/**/*.d.ts"],
   "references": [
     {
+      "path": "../core"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -4,6 +4,15 @@
   "include": ["../../types/**/*.d.ts"],
   "references": [
     {
+      "path": "../fields"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../adapters"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds configurable date and datetime input support for text and longtext fields, including relative date bounds and selectable 12/24-hour time formatting. It also expands form-definition schema support for properties already used by related fields and updates the demo to the required `@mieweb/ui` prerelease.

## Changes

- **Core**
  - Adds and exports `RelativeDateRange`.
  - Adds optional `dateRange` and `timeFormat` properties to text and longtext definitions and schemas.
  - Preserves matrix scoring, open-choice layout, section collapse, and page auto-advance during definition validation.
  - Adds schema normalization coverage.
  - Simplifies form instance ID generation to module-local sequencing.

- **Builder**
  - Adds relative date-range amount/unit controls for `date` and `datetime-local`.
  - Adds a 12-hour/24-hour selector for `datetime-local`.

- **Fields**
  - Renders `date` and `datetime-local` text fields through `DateInput`.
  - Stores date-only answers as ISO `YYYY-MM-DD`, while displaying `MM/DD/YYYY`.
  - Resolves symmetric date bounds relative to the render date.
  - Adds focused `TextField` tests for date conversion, bounds, and datetime configuration.
  - Updates field integrations for the new UI package API.

- **Dependency and configuration**
  - Updates root, demo, and fields dependencies to `@mieweb/ui@0.7.0-dev.184` and refreshes package-lock.json.
  - Updates demo Vite aliases for the hoisted UI package.
  - Updates local VS Code color settings.

## Notes

- Date bounds are calculated from the client’s local date at render time; month-end, leap-year, and timezone-boundary behavior are relevant review points.
- The UI dependency is a development prerelease and declares a Node engine constraint of `^20.19.0 || >=22.12.0`.
- The branch has no commits ahead of `origin/main`; these changes are currently in the working tree, including untracked TextField.spec.tsx.