### PR TITLE
feat(core): add field layout defaults and section width inheritance

### DIFF
--- a/apps/docs/docs/adapters/fhir/extensions.md
+++ b/apps/docs/docs/adapters/fhir/extensions.md
@@ -20,11 +20,12 @@ Controls the column width a questionnaire item occupies in a row-based layout gr
 
 | `valueCode` | Description                             |
 | ----------- | --------------------------------------- |
-| `full`      | Spans the full row width (default)      |
+| `full`      | Spans the full row width                |
 | `half`      | Takes up half the row (2 per row)       |
 | `third`     | Takes up a third of the row (3 per row) |
 
-When absent the field renders at `full` width.
+When absent, text, selection, and rating fields render at `third` width.
+Rich, matrix, and organization fields render at `full` width.
 
 ### Example
 
@@ -58,10 +59,10 @@ Controls how the answer options of a choice item are rendered. Corresponds to th
 
 | `valueCode` | Description                                         |
 | ----------- | --------------------------------------------------- |
-| `stack`     | One option per line, stacked vertically (default)   |
+| `stack`     | One option per line, stacked vertically             |
 | `wrap`      | Options flow horizontally and wrap to the next line |
 
-When absent the options render in `stack` layout.
+When absent, fields that support this property render options in `wrap` layout.
 
 ### Example
 

--- a/apps/docs/docs/schema-format.md
+++ b/apps/docs/docs/schema-format.md
@@ -137,11 +137,14 @@ interface FieldDefinition {
 
 The optional `width` property controls how much of a row a field occupies:
 
-| Value   | Description                       |
-| ------- | --------------------------------- |
-| `full`  | Uses the full row width (default) |
-| `half`  | Uses half of the row              |
-| `third` | Uses one third of the row         |
+| Value   | Description               |
+| ------- | ------------------------- |
+| `full`  | Uses the full row width   |
+| `half`  | Uses half of the row      |
+| `third` | Uses one third of the row |
+
+Text, selection, and rating fields default to `third`. Rich, matrix, and
+organization fields default to `full`.
 
 ```ts
 type FieldWidth = 'full' | 'half' | 'third';
@@ -154,8 +157,10 @@ arranged:
 
 | Value   | Description                                         |
 | ------- | --------------------------------------------------- |
-| `stack` | Displays one option per line (default)              |
+| `stack` | Displays one option per line                        |
 | `wrap`  | Displays options horizontally and wraps as required |
+
+Fields that support `optionLayout` default to `wrap`.
 
 ```ts
 type OptionLayout = 'stack' | 'wrap';

--- a/packages/builder/src/lib/components/Canvas.tsx
+++ b/packages/builder/src/lib/components/Canvas.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { FieldComponentProps, FormStore, UIStore } from '@esheet/core';
-import { buildRenderTree } from '@esheet/core';
+import { buildRenderTree, getInheritedSectionWidth } from '@esheet/core';
 import Sortable from 'sortablejs';
 import { useFormApi } from '../hooks/useFormApi.js';
 import { useUiApi } from '../hooks/useUiApi.js';
@@ -85,6 +85,7 @@ function DraggableFieldItem({
     <FieldGridItem
       fieldType={field.definition.fieldType}
       width={field.definition.width}
+      inheritedWidth={getInheritedSectionWidth(form.getState().normalized, id)}
     >
       <div
         className={wrapperClass}

--- a/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
@@ -5,7 +5,7 @@ import type {
   OptionLayout,
   TextInputType,
 } from '@esheet/core';
-import { slugifyQuestion } from '@esheet/core';
+import { getDefaultProp, slugifyQuestion } from '@esheet/core';
 import { useFormStore } from '@esheet/fields';
 import { useInstanceId } from '../../EsheetBuilder.js';
 import { DraftIdEditor } from './DraftIdEditor.js';
@@ -36,15 +36,22 @@ export function CommonEditor({
     def.fieldType === 'text' || def.fieldType === 'longtext';
   const formStore = useFormStore();
   const dangerouslyAllowJS = useStore(formStore, (s) => s.dangerouslyAllowJS);
+  const defaultWidth = getDefaultProp<FieldWidth>(def.fieldType, 'width');
   const calculation = (def as { calculation?: string }).calculation ?? '';
-  const width = (def as { width?: FieldWidth }).width ?? 'full';
+  const width = (def as { width?: FieldWidth }).width ?? defaultWidth ?? 'full';
   const showOptionLayout =
     def.fieldType === 'radio' ||
     def.fieldType === 'check' ||
     def.fieldType === 'multitext' ||
     def.fieldType === 'openchoice';
+  const defaultOptionLayout = getDefaultProp<OptionLayout>(
+    def.fieldType,
+    'optionLayout'
+  );
   const optionLayout =
-    (def as { optionLayout?: OptionLayout }).optionLayout ?? 'stack';
+    (def as { optionLayout?: OptionLayout }).optionLayout ??
+    defaultOptionLayout ??
+    'stack';
   const question = (def as { question?: string }).question ?? '';
   const suggestedId = slugifyQuestion(question);
   const showSuggestion = suggestedId !== '' && suggestedId !== def.id;
@@ -136,14 +143,13 @@ export function CommonEditor({
         <select
           id={`${instanceId}-editor-width-${fieldId}`}
           value={width}
-          onChange={(e) =>
+          onChange={(e) => {
+            const nextWidth = e.currentTarget.value as FieldWidth;
             onUpdate({
               width:
-                e.currentTarget.value === 'full'
-                  ? undefined
-                  : (e.currentTarget.value as FieldWidth),
-            } as Parameters<typeof onUpdate>[0])
-          }
+                nextWidth === (defaultWidth ?? 'full') ? undefined : nextWidth,
+            } as Parameters<typeof onUpdate>[0]);
+          }}
           className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
         >
           <option value="full">Full (whole row)</option>
@@ -164,14 +170,15 @@ export function CommonEditor({
           <select
             id={`${instanceId}-editor-optionlayout-${fieldId}`}
             value={optionLayout}
-            onChange={(e) =>
+            onChange={(e) => {
+              const nextOptionLayout = e.currentTarget.value as OptionLayout;
               onUpdate({
                 optionLayout:
-                  e.currentTarget.value === 'stack'
+                  nextOptionLayout === (defaultOptionLayout ?? 'stack')
                     ? undefined
-                    : (e.currentTarget.value as OptionLayout),
-              } as Parameters<typeof onUpdate>[0])
-            }
+                    : nextOptionLayout,
+              } as Parameters<typeof onUpdate>[0]);
+            }}
             className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
           >
             <option value="stack">Stack (one per line)</option>

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   getFieldTypeMeta,
   type FieldDefinition,
+  type FieldWidth,
   type FieldOption,
   type MatrixColumn,
   type MatrixRow,
@@ -249,6 +250,43 @@ interface SectionEditContentProps {
   onRenameId: (newId: string) => boolean;
 }
 
+interface SectionWidthEditorProps {
+  fieldId: string;
+  width?: FieldWidth;
+  onUpdate: (patch: Partial<Omit<FieldDefinition, 'fields'>>) => void;
+}
+
+function SectionWidthEditor({
+  fieldId,
+  width,
+  onUpdate,
+}: SectionWidthEditorProps) {
+  const instanceId = useInstanceId();
+
+  return (
+    <div>
+      <label
+        htmlFor={`${instanceId}-editor-child-width-${fieldId}`}
+        className="edit-label ms:block ms:text-sm ms:font-medium ms:text-mstext ms:mb-1"
+      >
+        Child row width
+      </label>
+      <select
+        id={`${instanceId}-editor-child-width-${fieldId}`}
+        value={width ?? 'full'}
+        onChange={(e) =>
+          onUpdate({ width: e.currentTarget.value as FieldWidth })
+        }
+        className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
+      >
+        <option value="full">Full (whole row)</option>
+        <option value="half">Half (2 per row)</option>
+        <option value="third">Third (3 per row)</option>
+      </select>
+    </div>
+  );
+}
+
 function SectionEditContent({
   fieldId,
   def,
@@ -401,6 +439,12 @@ function SectionEditContent({
         </select>
       </div>
 
+      <SectionWidthEditor
+        fieldId={fieldId}
+        width={def.width}
+        onUpdate={onUpdate}
+      />
+
       <div className="ms:space-y-2">
         <div className="ms:flex ms:items-center ms:justify-between ms:gap-2">
           <span className="ms:text-sm ms:font-medium ms:text-mstext">
@@ -492,6 +536,11 @@ function SectionEditContent({
                   className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:placeholder:text-mstextmuted ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
                 />
               </div>
+              <SectionWidthEditor
+                fieldId={activeChildDef.id}
+                width={activeChildDef.width}
+                onUpdate={handleUpdateChild}
+              />
             </div>
           ) : (
             <CommonEditor

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export {
 export {
   registerFieldType,
   getFieldTypeMeta,
+  getDefaultProp,
   getRegisteredFieldTypes,
   registerFieldElements,
   // NOTE: resetFieldTypeRegistry intentionally not exported - internal/test-only
@@ -96,6 +97,7 @@ export {
 export {
   normalizeDefinition,
   hydrateDefinition,
+  getInheritedSectionWidth,
   type FieldNode,
   type NormalizedDefinition,
   type NormalizedPage,

--- a/packages/core/src/lib/functions/normalize.spec.ts
+++ b/packages/core/src/lib/functions/normalize.spec.ts
@@ -1,4 +1,4 @@
-import { normalizeDefinition } from './normalize.js';
+import { getInheritedSectionWidth, normalizeDefinition } from './normalize.js';
 import type {
   FieldDefinition,
   SectionFieldDefinition,
@@ -164,6 +164,55 @@ describe('normalizeDefinition', () => {
 
     expect(result.byId['deep'].childIds).toEqual([]);
     expect(result.byId['deep'].parentId).toBe('inner');
+  });
+
+  it('should resolve the nearest defined section width for descendants', () => {
+    const result = normalizeDefinition([
+      {
+        id: 'page-1',
+        fields: [
+          {
+            id: 'outer',
+            fieldType: 'section',
+            width: 'half',
+            fields: [
+              {
+                id: 'inner',
+                fieldType: 'section',
+                fields: [{ id: 'deep', fieldType: 'text' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(getInheritedSectionWidth(result, 'deep')).toBe('half');
+  });
+
+  it('should prefer an inner section width over an outer section width', () => {
+    const result = normalizeDefinition([
+      {
+        id: 'page-1',
+        fields: [
+          {
+            id: 'outer',
+            fieldType: 'section',
+            width: 'half',
+            fields: [
+              {
+                id: 'inner',
+                fieldType: 'section',
+                width: 'third',
+                fields: [{ id: 'deep', fieldType: 'text' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(getInheritedSectionWidth(result, 'deep')).toBe('third');
   });
 
   it('should handle section with empty fields array', () => {

--- a/packages/core/src/lib/functions/normalize.ts
+++ b/packages/core/src/lib/functions/normalize.ts
@@ -4,6 +4,7 @@
 
 import type {
   FieldDefinition,
+  FieldWidth,
   PageEntry,
   SectionFieldDefinition,
 } from '../types.js';
@@ -93,6 +94,30 @@ export function normalizeDefinition(
   });
 
   return { byId, pages: normalizedPages };
+}
+
+/** Resolve the nearest defined section width for a field. */
+export function getInheritedSectionWidth(
+  normalized: NormalizedDefinition,
+  fieldId: string
+): FieldWidth | undefined {
+  let parentId = normalized.byId[fieldId]?.parentId;
+
+  while (parentId) {
+    const parent = normalized.byId[parentId];
+    if (!parent) return undefined;
+
+    if (
+      parent.definition.fieldType === 'section' &&
+      parent.definition.width !== undefined
+    ) {
+      return parent.definition.width;
+    }
+
+    parentId = parent.parentId;
+  }
+
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/lib/registry.spec.ts
+++ b/packages/core/src/lib/registry.spec.ts
@@ -1,5 +1,6 @@
 import {
   registerFieldType,
+  getDefaultProp,
   getFieldTypeMeta,
   getRegisteredFieldTypes,
   resetFieldTypeRegistry,
@@ -98,6 +99,60 @@ describe('field type registry', () => {
     // Non-option fields should not have defaultOptionCount
     const text = getFieldTypeMeta('text')!;
     expect(text.defaultOptionCount).toBeUndefined();
+  });
+
+  it('should define the default layout for built-in field types', () => {
+    const thirdWidthTypes = [
+      'text',
+      'longtext',
+      'multitext',
+      'radio',
+      'check',
+      'boolean',
+      'dropdown',
+      'multiselectdropdown',
+      'openchoice',
+      'rating',
+      'ranking',
+      'slider',
+    ];
+    for (const fieldType of thirdWidthTypes) {
+      expect(getFieldTypeMeta(fieldType)?.defaultProps.width).toBe('third');
+    }
+
+    for (const fieldType of ['multitext', 'radio', 'check', 'openchoice']) {
+      expect(getFieldTypeMeta(fieldType)?.defaultProps.optionLayout).toBe(
+        'wrap'
+      );
+    }
+
+    for (const fieldType of [
+      'singlematrix',
+      'multimatrix',
+      'image',
+      'html',
+      'signature',
+      'diagram',
+      'file',
+      'display',
+      'section',
+      'pages',
+    ]) {
+      expect(getFieldTypeMeta(fieldType)?.defaultProps.width).toBe('full');
+    }
+  });
+
+  it('should resolve option layout defaults from field metadata', () => {
+    expect(getDefaultProp('radio', 'optionLayout')).toBe('wrap');
+    expect(getDefaultProp('check', 'optionLayout')).toBe('wrap');
+    expect(getDefaultProp('signature', 'optionLayout')).toBeUndefined();
+    expect(getDefaultProp('unknown', 'optionLayout')).toBeUndefined();
+  });
+
+  it('should resolve any default property from field metadata', () => {
+    expect(getDefaultProp('text', 'inputType')).toBe('string');
+    expect(getDefaultProp('text', 'width')).toBe('third');
+    expect(getDefaultProp('signature', 'width')).toBe('full');
   });
 
   it('should batch-register element classes via registerFieldElements', () => {

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -18,6 +18,14 @@ export function getFieldTypeMeta(key: string): FieldTypeMeta | undefined {
   return registry[key];
 }
 
+/** Get a configured default property for a field type. */
+export function getDefaultProp<T = unknown>(
+  fieldType: string,
+  property: string
+): T | undefined {
+  return registry[fieldType]?.defaultProps[property] as T | undefined;
+}
+
 /** Get all currently registered field type keys. */
 export function getRegisteredFieldTypes(): string[] {
   return Object.keys(registry);
@@ -56,7 +64,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'text',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: { inputType: 'string' },
+    defaultProps: { inputType: 'string', width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       answer: 'Enter answer...',
@@ -68,7 +76,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'text',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       answer: 'Enter detailed answer...',
@@ -80,7 +88,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'multitext',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third', optionLayout: 'wrap' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -93,7 +101,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'selection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third', optionLayout: 'wrap' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -106,7 +114,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'multiselection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third', optionLayout: 'wrap' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -120,7 +128,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     hasOptions: true,
     hasMatrix: false,
     defaultOptionCount: 2,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: { question: 'Enter your question...' },
   },
   dropdown: {
@@ -129,7 +137,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'selection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -142,7 +150,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'multiselection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -155,7 +163,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'selection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third', optionLayout: 'wrap' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter option text...',
@@ -168,7 +176,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'selection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter rating level...',
@@ -181,7 +189,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'multiselection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter item to rank...',
@@ -194,7 +202,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'selection',
     hasOptions: true,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       options: 'Enter scale label...',
@@ -207,7 +215,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'matrix',
     hasOptions: false,
     hasMatrix: true,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: {
       question: 'Enter your question...',
       rows: 'Enter row label...',
@@ -221,7 +229,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'matrix',
     hasOptions: false,
     hasMatrix: true,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: {
       question: 'Enter your question...',
       rows: 'Enter row label...',
@@ -235,7 +243,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'display',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: { question: 'Image Block' },
   },
   html: {
@@ -244,7 +252,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'display',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: { htmlContent: '<p>Enter your HTML content here...</p>' },
   },
   signature: {
@@ -253,7 +261,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'media',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: { question: 'Enter your question...', pad: 'Sign here' },
   },
   diagram: {
@@ -262,7 +270,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'media',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: {
       question: 'Enter your question...',
       pad: 'Draw on the diagram',
@@ -274,7 +282,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'media',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: { question: 'Upload a file' },
   },
   display: {
@@ -283,7 +291,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'display',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: {},
+    defaultProps: { width: 'full' },
     placeholder: {
       content:
         'Your BMI is **{weight-kg} / (({height-cm}/100) * ({height-cm}/100))**',
@@ -295,7 +303,11 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'container',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: { fields: [], sectionCollapse: 'expanded' },
+    defaultProps: {
+      fields: [],
+      sectionCollapse: 'expanded',
+      width: 'full',
+    },
     placeholder: { title: 'Enter section title...' },
   },
   pages: {
@@ -304,7 +316,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'container',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: { fields: [], autoAdvance: false },
+    defaultProps: { fields: [], autoAdvance: false, width: 'full' },
     placeholder: { title: 'Enter pages title...' },
   },
 };

--- a/packages/core/src/lib/stores/form-store.spec.ts
+++ b/packages/core/src/lib/stores/form-store.spec.ts
@@ -210,6 +210,23 @@ describe('createFormStore', () => {
         expect(s.normalized.byId[id!].parentId).toBeNull();
       });
 
+      it('applies the field layout defaults', () => {
+        store = createFormStore(form([]));
+        const radioId = store.getState().addField('radio');
+        const matrixId = store.getState().addField('singlematrix');
+        const signatureId = store.getState().addField('signature');
+
+        expect(
+          store.getState().normalized.byId[radioId!].definition
+        ).toMatchObject({ width: 'third', optionLayout: 'wrap' });
+        expect(
+          store.getState().normalized.byId[matrixId!].definition
+        ).toMatchObject({ width: 'full' });
+        expect(
+          store.getState().normalized.byId[signatureId!].definition
+        ).toMatchObject({ width: 'full' });
+      });
+
       it('inserts at specific root index', () => {
         store = createFormStore(form([field('a'), field('b')]));
         const id = store

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -295,7 +295,7 @@ interface BaseFieldDefinition {
    */
   required?: boolean | 'soft';
   // readOnly?: boolean; // TODO: implement readOnly properly (see INTERNAL-TICKETS/readonly-fields.md)
-  /** Layout width in a row grid (`full` | `half` | `third`). Defaults to `full`. */
+  /** Layout width in a row grid (`full` | `half` | `third`). Defaults by field category. */
   width?: FieldWidth;
   /** Validation rules applied to the field's response. */
   validators?: FieldValidator[];
@@ -332,7 +332,7 @@ export interface LongtextFieldDefinition extends BaseFieldDefinition {
 export interface MultitextFieldDefinition extends BaseFieldDefinition {
   fieldType: 'multitext';
   options?: FieldOption[];
-  /** How inputs are arranged (`stack` | `wrap`). Defaults to `stack`. */
+  /** How inputs are arranged (`stack` | `wrap`). Defaults to `wrap`. */
   optionLayout?: OptionLayout;
 }
 
@@ -343,14 +343,14 @@ export interface MultitextFieldDefinition extends BaseFieldDefinition {
 export interface RadioFieldDefinition extends BaseFieldDefinition {
   fieldType: 'radio';
   options?: FieldOption[];
-  /** How options are arranged (`stack` | `wrap`). Defaults to `stack`. */
+  /** How options are arranged (`stack` | `wrap`). Defaults to `wrap`. */
   optionLayout?: OptionLayout;
 }
 
 export interface CheckFieldDefinition extends BaseFieldDefinition {
   fieldType: 'check';
   options?: FieldOption[];
-  /** How options are arranged (`stack` | `wrap`). Defaults to `stack`. */
+  /** How options are arranged (`stack` | `wrap`). Defaults to `wrap`. */
   optionLayout?: OptionLayout;
 }
 
@@ -459,7 +459,7 @@ export interface OpenChoiceFieldDefinition extends BaseFieldDefinition {
   maxCustomOptions?: number;
   /** Label for the "Other, please specify" option (optional). */
   otherLabel?: string;
-  /** Controls whether options flow horizontally (wrap) or stack vertically (default). */
+  /** Controls whether options flow horizontally (wrap) or stack vertically. Defaults to `wrap`. */
   optionLayout?: OptionLayout;
 }
 
@@ -472,7 +472,7 @@ export interface DisplayFieldDefinition {
   content?: string;
   /** Display fields are never required. */
   required?: never;
-  /** Layout width in a row grid (`full` | `half` | `third`). Defaults to `full`. */
+  /** Layout width in a row grid (`full` | `half` | `third`). Defaults by field category. */
   width?: FieldWidth;
   /** Conditional rules controlling visibility. */
   rules?: ConditionalRule[];

--- a/packages/field-health/src/AllergyListField.tsx
+++ b/packages/field-health/src/AllergyListField.tsx
@@ -96,6 +96,7 @@ export function registerAllergyListFieldType(options: {
       hasMatrix: false,
       defaultProps: {
         question: 'Allergies',
+        width: 'full',
       },
       component: Field,
     },

--- a/packages/field-health/src/MedicationListField.tsx
+++ b/packages/field-health/src/MedicationListField.tsx
@@ -83,6 +83,7 @@ export function registerMedicationListFieldType(options: {
       hasMatrix: false,
       defaultProps: {
         question: 'Presenting medications',
+        width: 'full',
         quickAddOptions: [
           'aspirin 81 mg tablet',
           'atorvastatin 20 mg tablet',

--- a/packages/field-kerebron/src/index.ts
+++ b/packages/field-kerebron/src/index.ts
@@ -24,7 +24,7 @@ registerFieldType('richtext', {
   answerType: 'text',
   hasOptions: false,
   hasMatrix: false,
-  defaultProps: {},
+  defaultProps: { width: 'full' },
   placeholder: { question: 'Enter your question...' },
 });
 

--- a/packages/fields/src/fields/selection/CheckField.tsx
+++ b/packages/fields/src/fields/selection/CheckField.tsx
@@ -4,6 +4,7 @@ import type {
   SelectedOption,
   CheckFieldDefinition,
 } from '@esheet/core';
+import { getDefaultProp } from '@esheet/core';
 import { Checkbox } from '@mieweb/ui';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 
@@ -21,7 +22,10 @@ export const CheckField = React.memo(function CheckField({
   const def = field.definition as CheckFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const isWrap = def.optionLayout === 'wrap';
+  const optionLayout =
+    def.optionLayout ??
+    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
+  const isWrap = optionLayout === 'wrap';
   const selectedArr =
     (response?.selected as SelectedOption[] | undefined) ?? [];
   const selectedIds = selectedArr.map((s) => s.id);

--- a/packages/fields/src/fields/selection/OpenChoiceField.tsx
+++ b/packages/fields/src/fields/selection/OpenChoiceField.tsx
@@ -5,6 +5,7 @@ import type {
   OpenChoiceFieldDefinition,
   FieldOption,
 } from '@esheet/core';
+import { getDefaultProp } from '@esheet/core';
 import { RadioGroup, Radio } from '@mieweb/ui';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 
@@ -34,7 +35,10 @@ export const OpenChoiceField = React.memo(function OpenChoiceField({
   if (isPreview) {
     const otherText =
       selectedId === otherOptionId && selected?.value ? selected.value : '';
-    const isWrap = def.optionLayout === 'wrap';
+    const optionLayout =
+      def.optionLayout ??
+      getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
+    const isWrap = optionLayout === 'wrap';
 
     return (
       <div className="openchoice-field-preview ms:space-y-1.5">

--- a/packages/fields/src/fields/selection/RadioField.tsx
+++ b/packages/fields/src/fields/selection/RadioField.tsx
@@ -4,6 +4,7 @@ import type {
   SelectedOption,
   RadioFieldDefinition,
 } from '@esheet/core';
+import { getDefaultProp } from '@esheet/core';
 import { RadioGroup, Radio } from '@mieweb/ui';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 
@@ -21,7 +22,10 @@ export const RadioField = React.memo(function RadioField({
   const def = field.definition as RadioFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const isWrap = def.optionLayout === 'wrap';
+  const optionLayout =
+    def.optionLayout ??
+    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
+  const isWrap = optionLayout === 'wrap';
   const selectedId =
     (response?.selected as SelectedOption | undefined)?.id ?? null;
 

--- a/packages/fields/src/fields/text/MultiTextField.tsx
+++ b/packages/fields/src/fields/text/MultiTextField.tsx
@@ -3,6 +3,7 @@ import type {
   FieldComponentProps,
   MultitextFieldDefinition,
 } from '@esheet/core';
+import { getDefaultProp } from '@esheet/core';
 import { Input } from '@mieweb/ui';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 
@@ -20,7 +21,10 @@ export const MultiTextField = React.memo(function MultiTextField({
   const def = field.definition as MultitextFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const isWrap = def.optionLayout === 'wrap';
+  const optionLayout =
+    def.optionLayout ??
+    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
+  const isWrap = optionLayout === 'wrap';
   const multitextAnswers = response?.multitextAnswers || {};
 
   if (isPreview) {

--- a/packages/fields/src/lib/FieldGrid.tsx
+++ b/packages/fields/src/lib/FieldGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { FieldWidth } from '@esheet/core';
+import { getDefaultProp, type FieldWidth } from '@esheet/core';
 
 const GRID_STYLE: React.CSSProperties = {
   display: 'grid',
@@ -76,22 +76,29 @@ export interface FieldGridItemProps {
   children: React.ReactElement<{ style?: React.CSSProperties }>;
   fieldType: string;
   width?: FieldWidth;
+  inheritedWidth?: FieldWidth;
+}
+
+function getDefaultWidth(fieldType: string): FieldWidth {
+  return getDefaultProp<FieldWidth>(fieldType, 'width') ?? 'full';
 }
 
 export function FieldGridItem({
   children,
   fieldType,
   width,
+  inheritedWidth,
 }: FieldGridItemProps) {
   const useGridLayout = useFieldGridLayout();
   if (!useGridLayout) return children;
 
+  const effectiveWidth = inheritedWidth ?? width ?? getDefaultWidth(fieldType);
   const columnSpan =
     fieldType === 'section' || fieldType === 'pages'
       ? 6
-      : width === 'half'
+      : effectiveWidth === 'half'
       ? 3
-      : width === 'third'
+      : effectiveWidth === 'third'
       ? 2
       : 6;
 

--- a/packages/renderer/src/lib/EsheetRenderer.spec.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.spec.tsx
@@ -51,6 +51,34 @@ describe('EsheetRenderer', () => {
     ).toBe('span 2');
   });
 
+  it('uses a section row width for all of its children', () => {
+    const { container } = render(
+      <EsheetRenderer
+        formDataInput={{
+          id: 'section-width-form',
+          pages: [
+            {
+              id: 'page-1',
+              fields: [
+                {
+                  id: 'section',
+                  fieldType: 'section',
+                  width: 'half',
+                  fields: [{ id: 'child', fieldType: 'text', width: 'third' }],
+                },
+              ],
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector<HTMLElement>('[data-field-id="child"]')?.style
+        .gridColumn
+    ).toBe('span 3');
+  });
+
   it('mounts and exposes ref handle', async () => {
     const ref = React.createRef<EsheetRendererHandle>();
     await act(async () => {

--- a/packages/renderer/src/lib/components/FieldNode.tsx
+++ b/packages/renderer/src/lib/components/FieldNode.tsx
@@ -6,6 +6,7 @@ import type {
   FormStore,
   UIStore,
 } from '@esheet/core';
+import { getInheritedSectionWidth } from '@esheet/core';
 import { FieldGrid, FieldGridItem, getFieldComponent } from '@esheet/fields';
 
 export interface FieldNodeProps {
@@ -223,6 +224,7 @@ export const FieldNode = React.memo(function FieldNode({
     <FieldGridItem
       fieldType={field.definition.fieldType}
       width={field.definition.width}
+      inheritedWidth={getInheritedSectionWidth(normalized, field.definition.id)}
     >
       <div
         ref={wrapperRef}


### PR DESCRIPTION
## Overview

This change introduces registry-driven default layout behavior for eSheet fields. Fields now receive sensible default widths and option layouts based on their field type, while sections can control the row width of their descendants.

The builder, renderer, custom field packages, documentation, and test coverage have all been updated to use the same layout rules.

## What Changed

### Field Type Defaults

The core field registry now defines default properties for built-in field types.

Text, selection, rating, and similar input fields default to:

- `width: 'third'`

Matrix, rich, display, media, and container fields default to:

- `width: 'full'`

The following option-based fields default to horizontal wrapping:

- `multitext`
- `radio`
- `check`
- `openchoice`

The new `getDefaultProp` API provides access to these registry defaults.

### Section Width Inheritance

Section widths are now inherited by their descendants.

For example, a section with `width: 'half'` causes its child fields to render using half-row width. Nested sections can define their own width, which takes precedence over the outer section.

The new `getInheritedSectionWidth` helper resolves the nearest configured section width.

### Builder Updates

The builder now uses registry defaults when displaying field properties.

The edit panel includes controls for:

- Section row width
- Child row width
- Option layout

When a selected value matches the field type’s default, the property is removed from the saved definition. This keeps schemas smaller and preserves the distinction between defaults and explicit overrides.

### Renderer and Field Updates

The field grid now resolves width in this order:

1. Inherited section width
2. Explicit field width
3. Registry default width
4. Full-width fallback

Radio, checkbox, open-choice, and multi-text fields now resolve their option layout from registry metadata when no explicit value is present.

### Custom Field Packages

The following custom field types now explicitly default to full width:

- Health allergy list
- Health medication list
- Kerebron rich text

### Documentation

Updated:

- Schema format documentation
- FHIR extension documentation

The documentation now describes field-category defaults instead of treating full width and stacked options as universal defaults.

## Tests Added

Coverage was added for:

- Built-in field type layout metadata
- Registry default property lookup
- Default properties applied during field creation
- Inherited section widths
- Nested section precedence
- Renderer behavior for section-controlled child widths

Relevant tests include:

- normalize.spec.ts
- registry.spec.ts
- form-store.spec.ts
- EsheetRenderer.spec.tsx

## Compatibility

This is backward-compatible with existing schemas:

- Explicit `width` values remain supported.
- Explicit `optionLayout` values remain supported.
- Existing schemas without these properties receive the new field-type defaults.
- No database or schema migration is required.