### PR TITLE
feat(renderer): add configurable page navigation

### DIFF
--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -17,14 +17,21 @@ import {
   CardHeader,
   CardTitle,
   DialogOverlay,
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
   Select,
+  Switch,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
   Textarea,
 } from '@mieweb/ui';
-import { ClipboardList, Smartphone } from 'lucide-react';
+import { ClipboardList, SlidersHorizontal, Smartphone } from 'lucide-react';
 import { updateOzwellTools, FLOWIE_KEY } from '../ozwell-setup.js';
 
 interface SubmitResult {
@@ -92,6 +99,10 @@ export function RendererView() {
   const rendererRef = useRef<EsheetRendererHandle>(null);
 
   const [touchMode, setTouchMode] = useState(false);
+  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [topNavigation, setTopNavigation] = useState(false);
+  const [bottomNavigation, setBottomNavigation] = useState(true);
+  const [validateNavigation, setValidateNavigation] = useState(true);
   const [activeTab, setActiveTab] = useState<'form' | 'definition'>('form');
   const [responseFormat, setResponseFormat] =
     useState<ResponseFormat>('native');
@@ -215,8 +226,8 @@ export function RendererView() {
       >
         <div className="sticky top-14 z-30 bg-card border-b border-border">
           <div className="max-w-4xl mx-auto px-3 py-1.5 flex flex-col sm:flex-row sm:items-center sm:h-11 gap-1.5 sm:gap-2">
-            {/* Left: tab triggers + touch mode */}
-            <div className="flex items-center gap-2">
+            {/* Left: view tabs, touch mode, and page navigation settings */}
+            <div className="flex min-w-0 items-center gap-2">
               <TabsList>
                 <TabsTrigger value="form" disabled={!hasForm}>
                   Form
@@ -234,6 +245,17 @@ export function RendererView() {
               >
                 <Smartphone size={14} />
                 <span className="hidden sm:inline ml-1">Touch</span>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => setNavigationOpen(true)}
+                aria-haspopup="dialog"
+                title="Configure page navigation"
+              >
+                <SlidersHorizontal size={14} />
+                <span className="ml-1">Navigation</span>
               </Button>
             </div>
             {/* Right: format select + import + submit */}
@@ -356,6 +378,9 @@ export function RendererView() {
                       allowDangerousJS={true}
                       touchMode="auto"
                       onTouchModeChange={setTouchMode}
+                      topNavigation={topNavigation}
+                      bottomNavigation={bottomNavigation}
+                      validateNavigation={validateNavigation}
                       onRendererToolsReady={onRendererToolsReady}
                       onReady={() => {
                         const def = rendererRef.current
@@ -391,6 +416,56 @@ export function RendererView() {
           )}
         </div>
       </Tabs>
+
+      <Modal open={navigationOpen} onOpenChange={setNavigationOpen}>
+        <ModalHeader>
+          <ModalTitle>Page navigation</ModalTitle>
+          <ModalClose />
+        </ModalHeader>
+        <ModalBody className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            Choose where page navigation appears in the renderer.
+          </p>
+          <div className="divide-y divide-border rounded-lg border border-border">
+            <div className="p-4">
+              <Switch
+                id="renderer-top-navigation"
+                label="Top navigation"
+                description="Show page titles above the form."
+                checked={topNavigation}
+                onCheckedChange={setTopNavigation}
+              />
+            </div>
+            <div className="p-4">
+              <Switch
+                id="renderer-bottom-navigation"
+                label="Bottom navigation"
+                description="Show Previous and Next controls below the form."
+                checked={bottomNavigation}
+                onCheckedChange={setBottomNavigation}
+              />
+            </div>
+            <div className="p-4">
+              <Switch
+                id="renderer-navigation-validation"
+                label="Require page validation"
+                description="Validate required fields before moving forward."
+                checked={validateNavigation}
+                onCheckedChange={setValidateNavigation}
+              />
+            </div>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setNavigationOpen(false)}
+          >
+            Done
+          </Button>
+        </ModalFooter>
+      </Modal>
 
       <DialogOverlay isOpen={pasteOpen} onClose={() => setPasteOpen(false)}>
         <div className="flex flex-col gap-3 p-1">

--- a/apps/docs/docs/field-types/organization/pages.md
+++ b/apps/docs/docs/field-types/organization/pages.md
@@ -6,7 +6,7 @@ slug: /field-types/pages
 
 Pages are a built-in form structure that divides a form into multiple navigable sheets. Unlike field types such as `section`, pages are a **first-class form primitive** — they live at the top level of every form definition rather than inside the field tree.
 
-Every form definition has a `pages` array. A form with a single page behaves identically to a traditional single-scroll form. A form with multiple pages gets automatic Previous / Next navigation in the renderer.
+Every form definition has a `pages` array. A form with a single page behaves identically to a traditional single-scroll form. A multi-page renderer can show page-title tabs at the top, Previous / Next controls at the bottom, or both.
 
 ## Page Entry Properties
 
@@ -58,7 +58,7 @@ A form with one page behaves exactly like a classic single-scroll form — no na
 
 ### Multi-page form
 
-A form with two or more pages shows a navigation bar (← Previous · X / Y · Next →) at the bottom of the renderer.
+A form with two or more pages can show top page tabs and/or a navigation bar (← Previous · X / Y · Next →) at the bottom of the renderer.
 
 ```json
 {
@@ -96,12 +96,31 @@ A form with two or more pages shows a navigation bar (← Previous · X / Y · N
 
 Implemented in [`RendererBody`](../../../packages/renderer/src/lib/components/RendererBody.tsx) and [`PageNavigator`](../../../packages/fields/src/lib/PageNavigator.tsx).
 
-| Condition            | Behavior                                                                                     |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| `pages.length === 1` | Fields render directly, no navigation UI shown                                               |
-| `pages.length > 1`   | `PageNavigator` wraps the active page with a bottom bar: **← Previous · N / total · Next →** |
-| First page           | "Previous" button is disabled                                                                |
-| Last page            | "Next →" button is replaced with "Last page" text                                            |
+Configure navigation on the renderer component:
+
+```tsx
+<EsheetRenderer
+  formDataInput={formDefinition}
+  topNavigation={true}
+  bottomNavigation={false}
+  validateNavigation={true}
+/>
+```
+
+| Prop                 | Default | Behavior                                                                                                        |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `topNavigation`      | `false` | Shows page-title tabs above the active page.                                                                    |
+| `bottomNavigation`   | `true`  | Shows Previous / page count / Next controls below the active page.                                              |
+| `validateNavigation` | `true`  | Blocks forward movement from either navigation surface when required fields on the current page are unanswered. |
+
+Navigation validation is separate from submit validation. Turning `validateNavigation` off allows page changes but does not allow an invalid form to submit or change the behavior of `getValidResponse()`.
+
+| Condition            | Behavior                                                       |
+| -------------------- | -------------------------------------------------------------- |
+| `pages.length === 1` | Fields render directly, no navigation UI shown                 |
+| `pages.length > 1`   | `PageNavigator` renders the enabled top tabs and/or bottom bar |
+| First page           | "Previous" button is disabled                                  |
+| Last page            | "Next →" button is replaced with "Last page" text              |
 
 Visibility rules (`rules`) on individual fields are evaluated per page — hidden fields are excluded from the rendered output on that page.
 

--- a/apps/docs/docs/renderer/overview.md
+++ b/apps/docs/docs/renderer/overview.md
@@ -63,6 +63,9 @@ function SurveyPage() {
 | `onTouchModeChange`    | `(enabled: boolean) => void`     | --         | Callback when touch mode changes                                                                                                                                                           |
 | `onRendererToolsReady` | `(tools: RendererTools) => void` | --         | Called with MCP tool handler when ready                                                                                                                                                    |
 | `collab`               | `CollabDecorations`              | --         | Host-supplied presence and proposal decorations — see [Collaboration](../advanced/collaboration.md)                                                                                        |
+| `topNavigation`        | `boolean`                        | `false`    | Show page-title tabs above the active page when the form has multiple pages                                                                                                                |
+| `bottomNavigation`     | `boolean`                        | `true`     | Show Previous / page count / Next controls below the active page                                                                                                                           |
+| `validateNavigation`   | `boolean`                        | `true`     | Block forward page navigation when required fields on the current page are unanswered. Does not change submit validation                                                                   |
 | `ref`                  | `Ref<EsheetRendererHandle>`      | --         | Imperative handle for accessing responses and stores                                                                                                                                       |
 
 ## Ref API (`EsheetRendererHandle`)
@@ -79,6 +82,21 @@ function SurveyPage() {
 | `resetTouchMode()`      | `void`                                                          | Reset to auto-detection (when `touchMode="auto"`)                                                                                      |
 
 ## Features
+
+## Page Navigation
+
+For multi-page forms, page navigation is configurable per renderer instance. The top and bottom controls are independent, so either or both can be enabled:
+
+```tsx
+<EsheetRenderer
+  formDataInput={formDefinition}
+  topNavigation
+  bottomNavigation={false}
+  validateNavigation
+/>
+```
+
+`validateNavigation` applies only when moving forward between pages from either navigation surface. Backward navigation remains available. Submit validation is separate and continues to run when `onSubmit` is used, regardless of the navigation setting.
 
 ## Touch Mode
 

--- a/packages/fields/src/lib/PageNavigator.tsx
+++ b/packages/fields/src/lib/PageNavigator.tsx
@@ -6,17 +6,27 @@ export interface PageNavigatorProps {
   total: number;
   onPrev: () => void;
   onNext: () => void;
+  /** Optional labels for the top page tabs. */
+  pageTitles?: readonly string[];
+  /** Called when a top page tab requests a specific page. */
+  onPageChange?: (pageIdx: number) => void;
+  /** Show page tabs above the content. */
+  topNavigation?: boolean;
+  /** Show Previous / Next controls below the content. */
+  bottomNavigation?: boolean;
+  /** Block forward page changes while required fields are unanswered. */
+  validateNavigation?: boolean;
   /** Number of unfilled hard-required fields on the current page. Blocks Next when > 0. */
   blockedCount?: number;
 }
 
 /**
- * PageNavigator — wraps a page's content and renders a bottom navigation bar.
+ * PageNavigator — wraps a page's content and renders configurable page navigation.
  *
  * Used in both the renderer and the builder's preview mode so both surfaces
  * share identical navigation UX.
  *
- * Layout: [← Previous]  [currentIdx + 1 / total]  [Next →]
+ * Layout: optional page tabs above content and [← Previous] [currentIdx + 1 / total] [Next →] below.
  * The Next button is replaced with "Last page" text on the final page.
  * The Previous button is disabled (not hidden) on the first page.
  * When blockedCount > 0, clicking Next shows an inline error instead of advancing.
@@ -27,33 +37,70 @@ export function PageNavigator({
   total,
   onPrev,
   onNext,
+  pageTitles,
+  onPageChange,
+  topNavigation = false,
+  bottomNavigation = true,
+  validateNavigation = true,
   blockedCount = 0,
 }: PageNavigatorProps) {
   const isFirst = currentIdx === 0;
   const isLast = currentIdx === total - 1;
   const [showError, setShowError] = React.useState(false);
+  const navigationLabels =
+    pageTitles ??
+    Array.from({ length: total }, (_, index) => `Page ${index + 1}`);
 
   // Clear the error banner whenever the page changes or the required-field count changes.
   React.useEffect(() => {
     setShowError(false);
   }, [currentIdx, blockedCount]);
 
-  const handleNext = () => {
-    if (blockedCount > 0) {
+  const requestPageChange = (nextIdx: number) => {
+    if (nextIdx === currentIdx) return;
+    if (validateNavigation && nextIdx > currentIdx && blockedCount > 0) {
       setShowError(true);
       return;
     }
     setShowError(false);
-    onNext();
-  };
-
-  const handlePrev = () => {
-    setShowError(false);
-    onPrev();
+    if (onPageChange) {
+      onPageChange(nextIdx);
+    } else if (nextIdx < currentIdx) {
+      onPrev();
+    } else {
+      onNext();
+    }
   };
 
   return (
     <div className="pages-navigator ms:flex ms:flex-col ms:flex-1 ms:min-h-0">
+      {topNavigation && (
+        <nav
+          aria-label="Pages"
+          className="pages-nav-top ms:mb-4 ms:shrink-0 ms:border-b ms:border-msborder ms:px-4 ms:py-2"
+        >
+          <div className="ms:flex ms:items-center ms:gap-1 ms:overflow-x-auto">
+            {navigationLabels.map((label, index) => {
+              const isActive = index === currentIdx;
+              return (
+                <button
+                  key={`${label}-${index}`}
+                  type="button"
+                  aria-current={isActive ? 'page' : undefined}
+                  onClick={() => requestPageChange(index)}
+                  className={`ms:shrink-0 ms:rounded ms:px-3 ms:py-2 ms:text-sm ms:font-medium ms:transition-colors ms:outline-none ms:cursor-pointer ${
+                    isActive
+                      ? 'ms:bg-msprimary/10 ms:text-msprimary'
+                      : 'ms:text-mstextmuted ms:hover:bg-msbackgroundhover ms:hover:text-mstext'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+      )}
       <div className="ms:flex-1 ms:min-h-0 ms:overflow-y-auto">{children}</div>
       {showError && blockedCount > 0 && (
         <div
@@ -67,36 +114,38 @@ export function PageNavigator({
           before continuing.
         </div>
       )}
-      <div className="pages-nav-footer ms:flex ms:items-center ms:justify-between ms:px-4 ms:py-3 ms:shrink-0">
-        <button
-          type="button"
-          disabled={isFirst}
-          onClick={handlePrev}
-          className="ms:px-4 ms:py-2 ms:text-sm ms:font-medium ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:transition-colors ms:hover:bg-msbackgroundhover ms:disabled:opacity-40 ms:disabled:cursor-not-allowed ms:outline-none ms:cursor-pointer"
-        >
-          {'\u2190'} Previous
-        </button>
-        <span className="ms:text-sm ms:text-mstextmuted ms:tabular-nums">
-          {currentIdx + 1} / {total}
-        </span>
-        {!isLast ? (
+      {bottomNavigation && (
+        <div className="pages-nav-footer ms:mt-4 ms:flex ms:items-center ms:justify-between ms:px-4 ms:py-3 ms:shrink-0">
           <button
             type="button"
-            onClick={handleNext}
-            className={`ms:px-4 ms:py-2 ms:text-sm ms:font-medium ms:rounded-lg ms:border ms:border-transparent ms:bg-msprimary ms:text-white ms:transition-colors ms:hover:bg-msprimary/90 ms:outline-none ms:cursor-pointer${
-              showError && blockedCount > 0
-                ? ' ms:outline ms:outline-2 ms:outline-msdanger'
-                : ''
-            }`}
+            disabled={isFirst}
+            onClick={() => requestPageChange(currentIdx - 1)}
+            className="ms:px-4 ms:py-2 ms:text-sm ms:font-medium ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:transition-colors ms:hover:bg-msbackgroundhover ms:disabled:opacity-40 ms:disabled:cursor-not-allowed ms:outline-none ms:cursor-pointer"
           >
-            Next {'\u2192'}
+            {'\u2190'} Previous
           </button>
-        ) : (
-          <span className="ms:text-sm ms:text-mstextmuted ms:italic">
-            Last page
+          <span className="ms:text-sm ms:text-mstextmuted ms:tabular-nums">
+            {currentIdx + 1} / {total}
           </span>
-        )}
-      </div>
+          {!isLast ? (
+            <button
+              type="button"
+              onClick={() => requestPageChange(currentIdx + 1)}
+              className={`ms:px-4 ms:py-2 ms:text-sm ms:font-medium ms:rounded-lg ms:border ms:border-transparent ms:bg-msprimary ms:text-white ms:transition-colors ms:hover:bg-msprimary/90 ms:outline-none ms:cursor-pointer${
+                showError && blockedCount > 0
+                  ? ' ms:outline ms:outline-2 ms:outline-msdanger'
+                  : ''
+              }`}
+            >
+              Next {'\u2192'}
+            </button>
+          ) : (
+            <span className="ms:text-sm ms:text-mstextmuted ms:italic">
+              Last page
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/renderer-blaze/src/index.tsx
+++ b/packages/renderer-blaze/src/index.tsx
@@ -32,11 +32,24 @@ function toRendererProps(data: unknown): EsheetRendererProps {
   const initialResponses = isRecord(data.initialResponses)
     ? (data.initialResponses as EsheetRendererProps['initialResponses'])
     : undefined;
+  const topNavigation =
+    typeof data.topNavigation === 'boolean' ? data.topNavigation : undefined;
+  const bottomNavigation =
+    typeof data.bottomNavigation === 'boolean'
+      ? data.bottomNavigation
+      : undefined;
+  const validateNavigation =
+    typeof data.validateNavigation === 'boolean'
+      ? data.validateNavigation
+      : undefined;
 
   return {
     formDataInput: formDataInput as EsheetRendererProps['formDataInput'],
     className,
     initialResponses,
+    topNavigation,
+    bottomNavigation,
+    validateNavigation,
   };
 }
 

--- a/packages/renderer/src/lib/EsheetRenderer.spec.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, act, cleanup } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { EsheetRenderer, type EsheetRendererHandle } from './EsheetRenderer.js';
 
 afterEach(cleanup);
@@ -313,6 +314,170 @@ describe('EsheetRenderer', () => {
 
     expect(result.errors).toEqual([]);
     expect(result.response).toEqual({ trigger: { answer: 'disabled' } });
+  });
+
+  it('renders independently configured top and bottom navigation', async () => {
+    const formDataInput = {
+      id: 'navigation-visibility',
+      pages: [
+        { id: 'page-1', title: 'Case', fields: [] },
+        { id: 'page-2', title: 'Absence & Restrictions', fields: [] },
+      ],
+    };
+
+    const { container, rerender } = render(
+      <EsheetRenderer
+        formDataInput={formDataInput}
+        topNavigation
+        bottomNavigation={false}
+      />
+    );
+
+    expect(container.querySelector('.pages-nav-top')).not.toBeNull();
+    expect(container.querySelector('.pages-nav-footer')).toBeNull();
+
+    rerender(
+      <EsheetRenderer
+        formDataInput={formDataInput}
+        topNavigation={false}
+        bottomNavigation={false}
+      />
+    );
+
+    expect(container.querySelector('.pages-nav-top')).toBeNull();
+    expect(container.querySelector('.pages-nav-footer')).toBeNull();
+  });
+
+  it('uses page titles and shares navigation validation across both controls', async () => {
+    const formDataInput = {
+      id: 'navigation-validation',
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Case',
+          fields: [
+            {
+              id: 'required-field',
+              fieldType: 'text',
+              question: 'Required field',
+              required: true,
+            },
+          ],
+        },
+        {
+          id: 'page-2',
+          title: 'Absence & Restrictions',
+          fields: [
+            { id: 'second-field', fieldType: 'text', question: 'Second' },
+          ],
+        },
+        { id: 'page-3', fields: [] },
+      ],
+    };
+
+    const { container, rerender } = render(
+      <EsheetRenderer
+        formDataInput={formDataInput}
+        topNavigation
+        bottomNavigation
+        validateNavigation
+      />
+    );
+
+    const topNavigationButton = container.querySelector(
+      '.pages-nav-top button:nth-child(2)'
+    );
+    expect(topNavigationButton?.textContent).toBe('Absence & Restrictions');
+
+    await act(async () => {
+      fireEvent.click(topNavigationButton as HTMLButtonElement);
+    });
+
+    expect(
+      container.querySelector('[data-field-id="required-field"]')
+    ).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      '1 required field'
+    );
+
+    const bottomNextButton = Array.from(
+      container.querySelectorAll('.pages-nav-footer button')
+    ).find((button) => button.textContent?.includes('Next'));
+
+    await act(async () => {
+      fireEvent.click(bottomNextButton as HTMLButtonElement);
+    });
+
+    expect(
+      container.querySelector('[data-field-id="required-field"]')
+    ).not.toBeNull();
+
+    rerender(
+      <EsheetRenderer
+        formDataInput={formDataInput}
+        topNavigation
+        bottomNavigation
+        validateNavigation={false}
+      />
+    );
+
+    const nextButtonWithoutValidation = Array.from(
+      container.querySelectorAll('.pages-nav-footer button')
+    ).find((button) => button.textContent?.includes('Next'));
+
+    await act(async () => {
+      fireEvent.click(nextButtonWithoutValidation as HTMLButtonElement);
+    });
+
+    expect(
+      container.querySelector('[data-field-id="second-field"]')
+    ).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(
+        container.querySelector(
+          '.pages-nav-top button:first-child'
+        ) as HTMLButtonElement
+      );
+    });
+
+    expect(
+      container.querySelector('[data-field-id="required-field"]')
+    ).not.toBeNull();
+  });
+
+  it('keeps submit validation independent from navigation validation', async () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <EsheetRenderer
+        formDataInput={{
+          id: 'submit-validation',
+          pages: [
+            {
+              id: 'page-1',
+              fields: [
+                {
+                  id: 'required-field',
+                  fieldType: 'text',
+                  question: 'Required field',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        }}
+        validateNavigation={false}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        container.querySelector('.renderer-submit button') as HTMLButtonElement
+      );
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -86,6 +86,12 @@ export interface EsheetRendererProps {
    * already controls sizing. Defaults to `true`.
    */
   fitToContainer?: boolean;
+  /** Show page tabs above the active page when rendering multiple pages. */
+  topNavigation?: boolean;
+  /** Show Previous / Next controls below the active page. */
+  bottomNavigation?: boolean;
+  /** Block forward page navigation while required fields on the current page are unanswered. */
+  validateNavigation?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -232,6 +238,9 @@ const EsheetRendererInner = React.forwardRef<
     allowDangerousJS = false,
     collab,
     fitToContainer = true,
+    topNavigation = false,
+    bottomNavigation = true,
+    validateNavigation = true,
   },
   ref
 ) {
@@ -372,7 +381,14 @@ const EsheetRendererInner = React.forwardRef<
   return (
     <div className={rootClasses}>
       <ZodIssuesPanel issues={validationErrors} />
-      <RendererBody form={formStore} ui={uiStore} collab={collab} />
+      <RendererBody
+        form={formStore}
+        ui={uiStore}
+        collab={collab}
+        topNavigation={topNavigation}
+        bottomNavigation={bottomNavigation}
+        validateNavigation={validateNavigation}
+      />
       {onSubmit && (
         <div className="renderer-submit ms:mt-6 ms:flex ms:justify-end">
           <button

--- a/packages/renderer/src/lib/components/RendererBody.tsx
+++ b/packages/renderer/src/lib/components/RendererBody.tsx
@@ -8,15 +8,28 @@ export interface RendererBodyProps {
   ui: UIStore;
   /** Optional host-supplied collaboration decorations (see EsheetRendererProps). */
   collab?: CollabDecorations;
+  /** Show page tabs above the active page. */
+  topNavigation?: boolean;
+  /** Show Previous / Next controls below the active page. */
+  bottomNavigation?: boolean;
+  /** Block forward navigation when required fields on the current page are unanswered. */
+  validateNavigation?: boolean;
 }
 
 /**
  * RendererBody - Iterates over pages and renders visible fields.
  *
  * Single-page forms render fields directly.
- * Multi-page forms use PageNavigator for bottom-only Prev / X of Y / Next navigation.
+ * Multi-page forms use PageNavigator for optional top tabs and bottom navigation.
  */
-export function RendererBody({ form, ui, collab }: RendererBodyProps) {
+export function RendererBody({
+  form,
+  ui,
+  collab,
+  topNavigation = false,
+  bottomNavigation = true,
+  validateNavigation = true,
+}: RendererBodyProps) {
   const normalized = React.useSyncExternalStore(
     (cb) => form.subscribe(cb),
     () => form.getState().normalized,
@@ -39,6 +52,7 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
   }, [pages.length, currentPagesIdx]);
 
   const isMultiPage = pages.length > 1;
+  const hasPageNavigation = topNavigation || bottomNavigation;
 
   const handlePrev = React.useCallback(
     () => setCurrentPagesIdx((p) => Math.max(p - 1, 0)),
@@ -90,7 +104,7 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
     <FieldNode key={id} id={id} form={form} ui={ui} collab={collab} />
   ));
 
-  if (!isMultiPage) {
+  if (!isMultiPage || !hasPageNavigation) {
     return (
       <FieldGrid
         className="canvas-fields renderer-body"
@@ -105,9 +119,16 @@ export function RendererBody({ form, ui, collab }: RendererBodyProps) {
     <PageNavigator
       currentIdx={currentPagesIdx}
       total={pages.length}
+      pageTitles={pages.map(
+        (page, index) => page.title?.trim() || `Sheet ${index + 1}`
+      )}
       onPrev={handlePrev}
       onNext={handleNext}
+      onPageChange={setCurrentPagesIdx}
       blockedCount={unfilledRequiredCount}
+      topNavigation={topNavigation}
+      bottomNavigation={bottomNavigation}
+      validateNavigation={validateNavigation}
     >
       <FieldGrid
         className="canvas-fields renderer-body ms:px-0"


### PR DESCRIPTION
## Summary

Adds configurable navigation for multi-page forms rendered by `EsheetRenderer`.

The renderer now supports three new per-instance options:

| Prop | Default | Behavior |
| --- | --- | --- |
| `topNavigation` | `false` | Shows page-title tabs above the active page |
| `bottomNavigation` | `true` | Shows Previous, page count, and Next controls below the page |
| `validateNavigation` | `true` | Prevents forward navigation when the current page has unanswered required fields |

Top and bottom navigation can be enabled independently, together, or both disabled. Single-page forms remain unchanged.

## Implementation Details

- PageNavigator.tsx now renders optional top tabs, supports direct page selection, derives fallback labels, and centralizes navigation validation.
- RendererBody.tsx passes page titles and navigation settings to `PageNavigator`, while rendering the current page without navigation when both controls are disabled.
- EsheetRenderer.tsx exposes and defaults the new props.
- index.tsx maps the new boolean options from Blaze template data into renderer props.
- RendererView.tsx adds a Navigation modal with switches for top controls, bottom controls, and required-field validation.
- Documentation updates describe the API, defaults, and behavior in the pages guide and renderer overview.

## Validation Behavior

- Moving backward is always permitted.
- Moving forward through either top tabs or bottom controls is blocked when `validateNavigation` is enabled and the current page has unanswered required fields.
- Disabling navigation validation allows page changes but does not weaken submit validation or `getValidResponse()` behavior.
- Existing default behavior is preserved: bottom navigation remains enabled and top navigation remains disabled.

## Tests

Adds renderer coverage for:

- Independent top/bottom navigation visibility.
- Page-title tab labels and fallback behavior.
- Required-field blocking from both navigation surfaces.
- Navigation when validation is disabled.
- Submit validation remaining independent of navigation validation.