### PR TITLE
feat(core): add conditional visibility for field options

### DIFF
--- a/apps/demo/src/schemas/option-visibility-playground.json
+++ b/apps/demo/src/schemas/option-visibility-playground.json
@@ -1,0 +1,253 @@
+{
+  "id": "option-visibility-playground",
+  "title": "Option Visibility Playground",
+  "pages": [
+    {
+      "id": "page-1",
+      "title": "Option visibility",
+      "fields": [
+        {
+          "id": "country",
+          "fieldType": "dropdown",
+          "question": "Which country are you visiting?",
+          "options": [
+            {
+              "id": "us",
+              "value": "United States",
+              "text": "United States"
+            },
+            {
+              "id": "ca",
+              "value": "Canada",
+              "text": "Canada"
+            },
+            {
+              "id": "mx",
+              "value": "Mexico",
+              "text": "Mexico"
+            }
+          ]
+        },
+        {
+          "id": "location",
+          "fieldType": "radio",
+          "question": "Which location should we use?",
+          "options": [
+            {
+              "id": "houston-hq",
+              "value": "Houston HQ",
+              "text": "Houston HQ",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "country",
+                      "operator": "equals",
+                      "expected": "us"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "austin-office",
+              "value": "Austin Office",
+              "text": "Austin Office",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "country",
+                      "operator": "equals",
+                      "expected": "us"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "toronto-office",
+              "value": "Toronto Office",
+              "text": "Toronto Office",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "country",
+                      "operator": "equals",
+                      "expected": "ca"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "vancouver-office",
+              "value": "Vancouver Office",
+              "text": "Vancouver Office",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "country",
+                      "operator": "equals",
+                      "expected": "ca"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "mexico-city-office",
+              "value": "Mexico City Office",
+              "text": "Mexico City Office",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "country",
+                      "operator": "equals",
+                      "expected": "mx"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "remote",
+              "value": "Remote",
+              "text": "Remote"
+            }
+          ]
+        },
+        {
+          "id": "department",
+          "fieldType": "dropdown",
+          "question": "Which department should receive the request?",
+          "options": [
+            {
+              "id": "us-support",
+              "value": "United States Support",
+              "text": "United States Support",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "houston-hq"
+                    }
+                  ]
+                },
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "austin-office"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "canada-support",
+              "value": "Canada Support",
+              "text": "Canada Support",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "toronto-office"
+                    }
+                  ]
+                },
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "vancouver-office"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "mexico-support",
+              "value": "Mexico Support",
+              "text": "Mexico Support",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "mexico-city-office"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "general-support",
+              "value": "General Support",
+              "text": "General Support",
+              "rules": [
+                {
+                  "effect": "visible",
+                  "logic": "AND",
+                  "conditions": [
+                    {
+                      "conditionType": "field",
+                      "targetId": "location",
+                      "operator": "equals",
+                      "expected": "remote"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "request-details",
+          "fieldType": "longtext",
+          "question": "Anything else we should know?"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/docs/docs/conditional-logic.md
+++ b/apps/docs/docs/conditional-logic.md
@@ -41,6 +41,42 @@ interface ConditionalRule {
 
 When a field has **multiple rules with the same effect**, they combine with **OR** semantics -- if any rule evaluates to true, the effect is applied.
 
+## Option-Scoped Visibility
+
+Rules can also be placed on an individual option. A rule inside `field.rules` affects the field; a rule inside `field.options[n].rules` affects only that option. In both cases, `condition.targetId` identifies the source field whose response is evaluated.
+
+Option rules use the existing `ConditionalRule` shape, but only the `visible` effect applies:
+
+```json
+{
+  "id": "incidentLocation",
+  "fieldType": "dropdown",
+  "question": "Incident location",
+  "options": [
+    {
+      "id": "houston-hq",
+      "value": "Houston HQ",
+      "rules": [
+        {
+          "effect": "visible",
+          "logic": "AND",
+          "conditions": [
+            {
+              "conditionType": "field",
+              "targetId": "incidentCountry",
+              "operator": "equals",
+              "expected": "us"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Here, `incidentLocation` owns the option, `houston-hq` is the affected option, and `incidentCountry` is the controlling field. Options without a matching visible rule remain visible. Hidden selected options remain in the response and produce a hard availability validation error.
+
 ## Condition Types
 
 ### Field Conditions

--- a/apps/docs/docs/schema-format.md
+++ b/apps/docs/docs/schema-format.md
@@ -223,6 +223,8 @@ interface FieldOption {
   /** Optional numeric score for scored surveys (e.g. PHQ-9, GAD-7). When present on
    * any option, the field's answer value is the sum of scores for all selected options. */
   score?: number;
+  /** Conditional visibility rules for this option. Only the `visible` effect applies. */
+  rules?: ConditionalRule[];
 }
 ```
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -33,7 +33,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/core": "0.0.6",
+    "@esheet/core": "workspace:*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -39,9 +39,9 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/adapters": "0.0.6",
-    "@esheet/core": "0.0.6",
-    "@esheet/fields": "0.0.6",
+    "@esheet/adapters": "workspace:*",
+    "@esheet/core": "workspace:*",
+    "@esheet/fields": "workspace:*",
     "@mieweb/ui": "0.7.1",
     "@monaco-editor/react": "^4.7.0",
     "js-yaml": "^5.2.3",

--- a/packages/builder/src/lib/components/FieldWrapper.tsx
+++ b/packages/builder/src/lib/components/FieldWrapper.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import type { FieldComponentProps, FormStore, UIStore } from '@esheet/core';
+import {
+  getFieldForRender,
+  type FieldComponentProps,
+  type FormStore,
+  type UIStore,
+} from '@esheet/core';
 import { useFormApi } from '../hooks/useFormApi.js';
 import { useUiApi } from '../hooks/useUiApi.js';
 import {
@@ -140,6 +145,8 @@ export function FieldWrapper({
     return null;
   }
 
+  const renderField = getFieldForRender(field, form, isPreview);
+
   // In preview mode, hide fields whose visibility rules evaluate to false.
   if (isPreview && !isVisible) {
     return null;
@@ -160,7 +167,7 @@ export function FieldWrapper({
         aria-disabled={!isEnabled || undefined}
       >
         {children({
-          field,
+          field: renderField,
           form,
           ui,
           isSelected: false,
@@ -322,7 +329,7 @@ export function FieldWrapper({
         hidden={!effectiveExpanded || undefined}
       >
         {children({
-          field,
+          field: renderField,
           form,
           ui,
           isSelected,

--- a/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
@@ -25,8 +25,11 @@ import { useFormStore } from '@esheet/fields';
 export interface LogicEditorProps {
   fieldId: string;
   rules: readonly ConditionalRule[];
+  scope?: 'field' | 'option';
+  idPrefix?: string;
   def?: { required?: boolean | 'soft'; readOnly?: boolean };
   onUpdateDef?: (patch: Record<string, unknown>) => void;
+  onUpdateRules?: (rules: ConditionalRule[]) => void;
 }
 
 /**
@@ -40,8 +43,11 @@ export interface LogicEditorProps {
 export function LogicEditor({
   fieldId,
   rules,
+  scope = 'field',
+  idPrefix,
   def,
   onUpdateDef,
+  onUpdateRules,
 }: LogicEditorProps) {
   const instanceId = useInstanceId();
   const { normalized, field_ } = useFormApi(fieldId);
@@ -54,7 +60,11 @@ export function LogicEditor({
   );
 
   const updateRules = (next: ConditionalRule[]) => {
-    field_.update({ rules: next });
+    if (onUpdateRules) {
+      onUpdateRules(next);
+    } else {
+      field_.update({ rules: next });
+    }
   };
 
   // ── Handlers ────────────────────────────────────────────────
@@ -135,6 +145,33 @@ export function LogicEditor({
 
   // ── Group rules by effect ──────────────────────────────────
   const grouped = groupByEffect(rules);
+
+  if (scope === 'option') {
+    return (
+      <div className="logic-editor option-logic-editor ms:space-y-2">
+        {otherFields.length === 0 && (
+          <div className="ms:text-xs ms:text-mstextmuted ms:italic ms:pb-1">
+            Add more fields to create option visibility rules.
+          </div>
+        )}
+        <EffectSection
+          instanceId={instanceId}
+          fieldId={idPrefix ?? fieldId}
+          effect="visible"
+          ruleEntries={grouped.visible}
+          otherFields={otherFields}
+          dangerouslyAllowJS={dangerouslyAllowJS}
+          subject="option"
+          onAddRule={() => handleAddRule('visible')}
+          onRemoveRule={handleRemoveRule}
+          onUpdateRule={handleUpdateRule}
+          onAddCondition={handleAddCondition}
+          onRemoveCondition={handleRemoveCondition}
+          onUpdateCondition={handleUpdateCondition}
+        />
+      </div>
+    );
+  }
 
   const handleSetRequiredState = (state: 'off' | 'required' | 'soft') => {
     if (!onUpdateDef) return;
@@ -357,6 +394,7 @@ interface EffectSectionProps {
   ruleEntries: { rule: ConditionalRule; globalIdx: number }[];
   otherFields: readonly TargetField[];
   dangerouslyAllowJS: boolean;
+  subject?: 'field' | 'option';
   /** Static default value for effects that have one (required/softRequired/readOnly). */
   staticDefault?: boolean;
   /** Callback to flip the static default boolean on the field definition. */
@@ -394,6 +432,7 @@ function EffectSection({
   ruleEntries,
   otherFields,
   dangerouslyAllowJS,
+  subject = 'field',
   staticDefault,
   onToggleStaticDefault,
   onAddRule,
@@ -492,7 +531,9 @@ function EffectSection({
       {/* Hint when no rules */}
       {!hasRules && (
         <div className="ms:text-xs ms:text-mstextmuted ms:italic">
-          {EFFECT_DESCRIPTIONS[effect]}
+          {subject === 'option'
+            ? 'Show this option when…'
+            : EFFECT_DESCRIPTIONS[effect]}
         </div>
       )}
     </div>

--- a/packages/builder/src/lib/components/edit-panel/OptionListEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/OptionListEditor.tsx
@@ -3,6 +3,7 @@ import type { FieldOption } from '@esheet/core';
 import { TrashIcon } from '@esheet/fields';
 import { useInstanceId } from '../../EsheetBuilder.js';
 import { useFormApi } from '../../hooks/useFormApi.js';
+import { LogicEditor } from './LogicEditor.js';
 
 export interface OptionListEditorProps {
   fieldId: string;
@@ -24,6 +25,9 @@ export function OptionListEditor({
   const instanceId = useInstanceId();
   const { option } = useFormApi(fieldId);
   const listRef = React.useRef<HTMLDivElement>(null);
+  const [expandedRules, setExpandedRules] = React.useState<Set<string>>(
+    () => new Set()
+  );
   const isBoolean = fieldType === 'boolean';
   const canScore = fieldType !== 'multitext' && fieldType !== 'ranking';
   const isScored = canScore && options.some((o) => o.score != null);
@@ -46,6 +50,15 @@ export function OptionListEditor({
         if (o.score == null) option.setScore(o.id, 0);
       });
     }
+  };
+
+  const toggleRules = (optionId: string) => {
+    setExpandedRules((current) => {
+      const next = new Set(current);
+      if (next.has(optionId)) next.delete(optionId);
+      else next.add(optionId);
+      return next;
+    });
   };
 
   return (
@@ -74,39 +87,66 @@ export function OptionListEditor({
         {options.map((opt, idx) => (
           <div
             key={opt.id}
-            className="option-row ms:flex ms:items-center ms:gap-2 ms:px-3 ms:py-2 ms:border ms:border-msborder ms:rounded-lg ms:shadow-sm ms:hover:border-msprimary/50 ms:transition-colors"
+            className="option-row ms:px-3 ms:py-2 ms:border ms:border-msborder ms:rounded-lg ms:shadow-sm ms:hover:border-msprimary/50 ms:transition-colors"
           >
-            <input
-              id={`${instanceId}-editor-option-${fieldId}-${opt.id}`}
-              aria-label={`Option ${idx + 1}`}
-              type="text"
-              value={opt.value}
-              onChange={(e) => option.update(opt.id, e.currentTarget.value)}
-              placeholder={`Option ${idx + 1}`}
-              className="ms:flex-1 ms:min-w-0 ms:outline-none ms:bg-transparent ms:text-mstext ms:placeholder:text-mstextmuted ms:border-0 ms:text-sm"
-            />
-            {isScored && (
+            <div className="ms:flex ms:items-center ms:gap-2">
               <input
-                id={`${instanceId}-editor-option-score-${fieldId}-${opt.id}`}
-                aria-label={`Option ${idx + 1} score`}
-                type="number"
-                value={opt.score ?? 0}
-                onChange={(e) => {
-                  const v = parseFloat(e.currentTarget.value);
-                  option.setScore(opt.id, Number.isNaN(v) ? 0 : v);
-                }}
-                className="ms:w-16 ms:shrink-0 ms:outline-none ms:bg-transparent ms:text-mstext ms:border ms:border-msborder ms:rounded ms:px-1 ms:py-0.5 ms:text-sm ms:text-right"
+                id={`${instanceId}-editor-option-${fieldId}-${opt.id}`}
+                aria-label={`Option ${idx + 1}`}
+                type="text"
+                value={opt.value}
+                onChange={(e) => option.update(opt.id, e.currentTarget.value)}
+                placeholder={`Option ${idx + 1}`}
+                className="ms:flex-1 ms:min-w-0 ms:outline-none ms:bg-transparent ms:text-mstext ms:placeholder:text-mstextmuted ms:border-0 ms:text-sm"
               />
-            )}
-            {!isBoolean && (
+              {isScored && (
+                <input
+                  id={`${instanceId}-editor-option-score-${fieldId}-${opt.id}`}
+                  aria-label={`Option ${idx + 1} score`}
+                  type="number"
+                  value={opt.score ?? 0}
+                  onChange={(e) => {
+                    const v = parseFloat(e.currentTarget.value);
+                    option.setScore(opt.id, Number.isNaN(v) ? 0 : v);
+                  }}
+                  className="ms:w-16 ms:shrink-0 ms:outline-none ms:bg-transparent ms:text-mstext ms:border ms:border-msborder ms:rounded ms:px-1 ms:py-0.5 ms:text-sm ms:text-right"
+                />
+              )}
               <button
                 type="button"
-                onClick={() => option.remove(opt.id)}
-                aria-label={`Remove option ${idx + 1}`}
-                className="remove-option-btn ms:shrink-0 ms:p-0.5 ms:rounded ms:bg-transparent ms:text-mstextmuted ms:hover:text-msdanger ms:border-0 ms:outline-none ms:focus:outline-none ms:transition-colors ms:cursor-pointer"
+                onClick={() => toggleRules(opt.id)}
+                aria-expanded={expandedRules.has(opt.id)}
+                aria-label={`${
+                  expandedRules.has(opt.id) ? 'Hide' : 'Show'
+                } visibility rules for option ${idx + 1}`}
+                className="ms:shrink-0 ms:px-2 ms:py-1 ms:text-xs ms:font-medium ms:rounded ms:border ms:border-msprimary/40 ms:bg-transparent ms:text-msprimary ms:hover:bg-msprimary/10 ms:outline-none ms:focus:outline-none ms:cursor-pointer"
               >
-                <TrashIcon className="ms:w-4 ms:h-4" />
+                Visibility rules
               </button>
+              {!isBoolean && (
+                <button
+                  type="button"
+                  onClick={() => option.remove(opt.id)}
+                  aria-label={`Remove option ${idx + 1}`}
+                  className="remove-option-btn ms:shrink-0 ms:p-0.5 ms:rounded ms:bg-transparent ms:text-mstextmuted ms:hover:text-msdanger ms:border-0 ms:outline-none ms:focus:outline-none ms:transition-colors ms:cursor-pointer"
+                >
+                  <TrashIcon className="ms:w-4 ms:h-4" />
+                </button>
+              )}
+            </div>
+            {expandedRules.has(opt.id) && (
+              <div className="ms:pt-3">
+                <div className="ms:mb-2 ms:text-xs ms:font-medium ms:text-mstextmuted">
+                  Visibility rules for {opt.value || `Option ${idx + 1}`}
+                </div>
+                <LogicEditor
+                  fieldId={fieldId}
+                  idPrefix={`${fieldId}-option-${opt.id}`}
+                  scope="option"
+                  rules={opt.rules ?? []}
+                  onUpdateRules={(rules) => option.updateRules(opt.id, rules)}
+                />
+              </div>
             )}
           </div>
         ))}

--- a/packages/builder/src/lib/hooks/useFormApi.ts
+++ b/packages/builder/src/lib/hooks/useFormApi.ts
@@ -8,6 +8,7 @@ import type {
   FieldType,
   FormStore,
   NormalizedDefinition,
+  ConditionalRule,
 } from '@esheet/core';
 import { useFormStore } from '@esheet/fields';
 
@@ -50,6 +51,7 @@ export interface FormApi {
   option: {
     add: (value?: string) => string | null;
     update: (optId: string, value: string) => boolean;
+    updateRules: (optId: string, rules: ConditionalRule[]) => boolean;
     setScore: (optId: string, score: number | undefined) => boolean;
     remove: (optId: string) => boolean;
   };
@@ -148,6 +150,10 @@ export function useFormApi(fieldId?: string): FormApi {
           fieldId ? form.getState().addOption(fieldId, value) : null,
         update: (optId: string, value: string) =>
           fieldId ? form.getState().updateOption(fieldId, optId, value) : false,
+        updateRules: (optId: string, rules: ConditionalRule[]) =>
+          fieldId
+            ? form.getState().updateOptionRules(fieldId, optId, rules)
+            : false,
         setScore: (optId: string, score: number | undefined) =>
           fieldId
             ? form.getState().setOptionScore(fieldId, optId, score)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export {
 export {
   evaluateCondition,
   evaluateRule,
+  evaluateOptionVisibility,
   isExpressionValid,
   evaluateExpression,
   evaluateJsExpression,
@@ -159,6 +160,7 @@ export {
   type FieldPresence,
   type FieldProposal,
   type CollabDecorations,
+  getFieldForRender,
 } from './lib/field-component-props.js';
 
 export {

--- a/packages/core/src/lib/field-component-props.ts
+++ b/packages/core/src/lib/field-component-props.ts
@@ -44,6 +44,30 @@ export interface FieldComponentProps {
   onResponse: (response: FieldResponse) => void;
 }
 
+export function getFieldForRender(
+  field: FieldNode,
+  form: FormStore,
+  isPreview: boolean
+): FieldNode {
+  const definition = field.definition;
+
+  if (
+    !isPreview ||
+    !('options' in definition) ||
+    !Array.isArray(definition.options)
+  ) {
+    return field;
+  }
+
+  return {
+    ...field,
+    definition: {
+      ...definition,
+      options: form.getState().getVisibleOptions(definition.id),
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // CollabDecorations — optional, host-supplied collaboration decorations
 // (presence + change proposals) that the renderer displays per field. eSheet

--- a/packages/core/src/lib/logic/conditions.spec.ts
+++ b/packages/core/src/lib/logic/conditions.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   evaluateCondition,
+  evaluateOptionVisibility,
   evaluateRule,
   evaluateExpression,
 } from './conditions.js';
@@ -730,6 +731,56 @@ describe('evaluateRule', () => {
 
       expect(evaluateRule(rule, exprNormalized, {})).toBe(false);
     });
+  });
+});
+
+describe('evaluateOptionVisibility', () => {
+  const normalized = norm({
+    country: node(
+      radioDef('country', [
+        { id: 'us', value: 'United States' },
+        { id: 'ca', value: 'Canada' },
+      ])
+    ),
+  });
+
+  it('evaluates option rules against the controlling field response', () => {
+    const option: FieldOption = {
+      id: 'houston-hq',
+      value: 'Houston HQ',
+      rules: [
+        {
+          effect: 'visible',
+          logic: 'AND',
+          conditions: [cond('country', 'equals', 'us')],
+        },
+      ],
+    };
+
+    expect(
+      evaluateOptionVisibility(option, normalized, {
+        country: {
+          selected: { id: 'us', value: 'United States' },
+        },
+      })
+    ).toBe(true);
+    expect(
+      evaluateOptionVisibility(option, normalized, {
+        country: {
+          selected: { id: 'ca', value: 'Canada' },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('keeps options without visible rules visible', () => {
+    expect(
+      evaluateOptionVisibility(
+        { id: 'always-visible', value: 'Always visible' },
+        normalized,
+        {}
+      )
+    ).toBe(true);
   });
 });
 

--- a/packages/core/src/lib/logic/conditions.ts
+++ b/packages/core/src/lib/logic/conditions.ts
@@ -6,6 +6,7 @@ import type {
   Condition,
   ConditionalRule,
   FieldDefinition,
+  FieldOption,
   FieldResponse,
   FieldResponseMap,
   SelectedOption,
@@ -66,6 +67,22 @@ export function evaluateRule(
   });
 
   return rule.logic === 'OR' ? results.some(Boolean) : results.every(Boolean);
+}
+
+export function evaluateOptionVisibility(
+  option: FieldOption,
+  normalized: NormalizedDefinition,
+  responses: FieldResponseMap,
+  dangerouslyAllowJS?: boolean
+): boolean {
+  const visibilityRules = option.rules?.filter(
+    (rule) => rule.effect === 'visible'
+  );
+  if (!visibilityRules || visibilityRules.length === 0) return true;
+
+  return visibilityRules.some((rule) =>
+    evaluateRule(rule, normalized, responses, dangerouslyAllowJS)
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/lib/logic/validate.spec.ts
+++ b/packages/core/src/lib/logic/validate.spec.ts
@@ -48,6 +48,108 @@ function enableRule(targetId: string, expected: string): ConditionalRule {
 // ---------------------------------------------------------------------------
 
 describe('validateField', () => {
+  describe('option visibility', () => {
+    it('reports a selected option that is no longer visible', () => {
+      const trigger = def('country', 'text');
+      const field = def('location', 'radio', {
+        options: [
+          {
+            id: 'houston-hq',
+            value: 'Houston HQ',
+            rules: [visibleRule('country', 'us')],
+          },
+        ],
+      });
+      const normalized = norm([trigger, field]);
+      const errors = validateField('location', normalized, {
+        country: { answer: 'ca' },
+        location: {
+          selected: { id: 'houston-hq', value: 'Houston HQ' },
+        },
+      });
+
+      expect(errors).toContainEqual({
+        fieldId: 'location',
+        rule: 'optionVisibility',
+        message: 'One or more selected options are no longer available',
+        severity: 'hard',
+      });
+    });
+
+    it('accepts a selected option that remains visible', () => {
+      const trigger = def('country', 'text');
+      const field = def('location', 'radio', {
+        options: [
+          {
+            id: 'houston-hq',
+            value: 'Houston HQ',
+            rules: [visibleRule('country', 'us')],
+          },
+        ],
+      });
+      const normalized = norm([trigger, field]);
+
+      expect(
+        validateField('location', normalized, {
+          country: { answer: 'us' },
+          location: {
+            selected: { id: 'houston-hq', value: 'Houston HQ' },
+          },
+        })
+      ).toEqual([]);
+    });
+
+    it('reports a non-empty hidden multitext answer', () => {
+      const trigger = def('country', 'text');
+      const field = def('contacts', 'multitext', {
+        options: [
+          {
+            id: 'us-contact',
+            value: 'United States contact',
+            rules: [visibleRule('country', 'us')],
+          },
+        ],
+      });
+      const normalized = norm([trigger, field]);
+      const errors = validateField('contacts', normalized, {
+        country: { answer: 'ca' },
+        contacts: {
+          multitextAnswers: { 'us-contact': 'Alice' },
+        },
+      });
+
+      expect(errors).toContainEqual({
+        fieldId: 'contacts',
+        rule: 'optionVisibility',
+        message: 'One or more selected options are no longer available',
+        severity: 'hard',
+      });
+    });
+
+    it('allows an empty hidden multitext answer', () => {
+      const trigger = def('country', 'text');
+      const field = def('contacts', 'multitext', {
+        options: [
+          {
+            id: 'us-contact',
+            value: 'United States contact',
+            rules: [visibleRule('country', 'us')],
+          },
+        ],
+      });
+      const normalized = norm([trigger, field]);
+
+      expect(
+        validateField('contacts', normalized, {
+          country: { answer: 'ca' },
+          contacts: {
+            multitextAnswers: { 'us-contact': '' },
+          },
+        })
+      ).toEqual([]);
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Required — basic
   // -----------------------------------------------------------------------

--- a/packages/core/src/lib/logic/validate.ts
+++ b/packages/core/src/lib/logic/validate.ts
@@ -3,11 +3,14 @@
 // ---------------------------------------------------------------------------
 
 import type {
+  FieldOption,
   FieldResponse,
   FieldResponseMap,
   FieldValidator,
+  SelectedOption,
 } from '../types.js';
 import type { NormalizedDefinition } from '../functions/normalize.js';
+import { evaluateOptionVisibility } from './conditions.js';
 import {
   isFieldEffectivelyActive,
   resolveEffect,
@@ -133,6 +136,38 @@ export function validateField(
     });
   }
 
+  const options = (definition as { options?: FieldOption[] }).options;
+  const selectedOptionIds = getSelectedOptionIds(response?.selected);
+  const answeredMultitextOptionIds = getAnsweredMultitextOptionIds(
+    response?.multitextAnswers
+  );
+  const answeredOptionIds = [
+    ...selectedOptionIds,
+    ...answeredMultitextOptionIds,
+  ];
+  if (options && answeredOptionIds.length > 0) {
+    const visibleOptionIds = new Set(
+      options
+        .filter((option) =>
+          evaluateOptionVisibility(
+            option,
+            normalized,
+            responses,
+            dangerouslyAllowJS
+          )
+        )
+        .map((option) => option.id)
+    );
+    if (answeredOptionIds.some((id) => !visibleOptionIds.has(id))) {
+      errors.push({
+        fieldId,
+        rule: 'optionVisibility',
+        message: 'One or more selected options are no longer available',
+        severity: 'hard',
+      });
+    }
+  }
+
   // --- Soft required check ---
   if (def.softRequired && isResponseEmpty(response)) {
     errors.push({
@@ -215,6 +250,29 @@ function isResponseEmpty(response: FieldResponse | undefined): boolean {
   if (response.markupData && response.markupData.trim() !== '') return false;
 
   return true;
+}
+
+function getSelectedOptionIds(selected: FieldResponse['selected']): string[] {
+  if (!selected) return [];
+  if (Array.isArray(selected)) {
+    return selected
+      .map((option) => option.id)
+      .filter((id): id is string => typeof id === 'string');
+  }
+  if ('id' in selected) {
+    const option = selected as SelectedOption;
+    return typeof option.id === 'string' ? [option.id] : [];
+  }
+  return [];
+}
+
+function getAnsweredMultitextOptionIds(
+  answers: FieldResponse['multitextAnswers']
+): string[] {
+  if (!answers) return [];
+  return Object.entries(answers)
+    .filter(([, value]) => value.trim() !== '')
+    .map(([optionId]) => optionId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/lib/stores/form-store.spec.ts
+++ b/packages/core/src/lib/stores/form-store.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createFormStore } from './form-store.js';
 import type { FormStore } from './form-store.js';
+import { getFieldForRender } from '../field-component-props.js';
 import type {
   FormDefinition,
   FieldDefinition,
@@ -424,6 +425,31 @@ describe('createFormStore', () => {
         expect(rule.conditions[0].targetId).toBe('q1-new');
       });
 
+      it('updates option rule condition.targetId on rename', () => {
+        store = createFormStore(
+          form([
+            field('q1', 'radio', {
+              options: [{ id: 'yes', value: 'Yes' }],
+            }),
+            field('q2', 'radio', {
+              options: [
+                {
+                  id: 'dependent',
+                  value: 'Dependent',
+                  rules: [visibleRule('q1', 'yes')],
+                },
+              ],
+            }),
+          ])
+        );
+        store.getState().updateField('q1', { id: 'q1-new' });
+        const option = (
+          store.getState().normalized.byId['q2']
+            .definition as RadioFieldDefinition
+        ).options![0];
+        expect(option.rules![0].conditions[0].targetId).toBe('q1-new');
+      });
+
       it('updates {fieldId} references in condition.expression on rename', () => {
         store = createFormStore(
           form([
@@ -645,6 +671,115 @@ describe('createFormStore', () => {
             .definition as RadioFieldDefinition
         ).options;
         expect(opts![0].value).toBe('New');
+      });
+
+      it('updates option rules and filters visible options', () => {
+        store = createFormStore(
+          form([
+            field('country', 'radio', {
+              options: [
+                { id: 'us', value: 'United States' },
+                { id: 'ca', value: 'Canada' },
+              ],
+            }),
+            field('location', 'radio', {
+              options: [
+                { id: 'houston', value: 'Houston', rules: [] },
+                { id: 'toronto', value: 'Toronto' },
+              ],
+            }),
+          ])
+        );
+        const rules = [visibleRule('country', 'us')];
+        expect(
+          store.getState().updateOptionRules('location', 'houston', rules)
+        ).toBe(true);
+        store.getState().setResponse('country', {
+          selected: { id: 'us', value: 'United States' },
+        });
+        expect(
+          store
+            .getState()
+            .getVisibleOptions('location')
+            .map((o) => o.id)
+        ).toEqual(['houston', 'toronto']);
+
+        store
+          .getState()
+          .setResponse('country', { selected: { id: 'ca', value: 'Canada' } });
+        expect(
+          store
+            .getState()
+            .getVisibleOptions('location')
+            .map((o) => o.id)
+        ).toEqual(['toronto']);
+      });
+
+      it('projects visible options only for preview rendering', () => {
+        store = createFormStore(
+          form([
+            field('country', 'radio', {
+              options: [
+                { id: 'us', value: 'United States' },
+                { id: 'ca', value: 'Canada' },
+              ],
+            }),
+            field('location', 'radio', {
+              options: [
+                {
+                  id: 'houston',
+                  value: 'Houston',
+                  rules: [visibleRule('country', 'us')],
+                },
+                { id: 'toronto', value: 'Toronto' },
+              ],
+            }),
+          ])
+        );
+        store.getState().setResponse('country', {
+          selected: { id: 'ca', value: 'Canada' },
+        });
+
+        const fieldNode = store.getState().getField('location');
+        expect(fieldNode).toBeDefined();
+        if (!fieldNode) return;
+
+        const projected = getFieldForRender(fieldNode, store, true)
+          .definition as RadioFieldDefinition;
+        expect(projected.options?.map((option) => option.id)).toEqual([
+          'toronto',
+        ]);
+        expect(getFieldForRender(fieldNode, store, false)).toBe(fieldNode);
+      });
+
+      it('projects visible multitext inputs only for preview rendering', () => {
+        store = createFormStore(
+          form([
+            field('country', 'text'),
+            field('contacts', 'multitext', {
+              options: [
+                {
+                  id: 'us-contact',
+                  value: 'United States contact',
+                  rules: [visibleRule('country', 'us')],
+                },
+                { id: 'general-contact', value: 'General contact' },
+              ],
+            }),
+          ])
+        );
+        store.getState().setResponse('country', { answer: 'ca' });
+
+        const fieldNode = store.getState().getField('contacts');
+        expect(fieldNode).toBeDefined();
+        if (!fieldNode) return;
+
+        const projected = getFieldForRender(fieldNode, store, true);
+        expect(
+          (projected.definition as { options?: { id: string }[] }).options?.map(
+            (option) => option.id
+          )
+        ).toEqual(['general-contact']);
       });
 
       it('removeOption deletes an option', () => {

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -14,6 +14,7 @@ import type {
   FormResponse,
   FormDefinition,
   FieldDefinition,
+  ConditionalRule,
 } from '../types.js';
 import { getFieldTypeMeta } from '../registry.js';
 import {
@@ -31,7 +32,10 @@ import {
 } from '../functions/normalize.js';
 import { hydrateResponse } from '../functions/hydrate-response.js';
 import { resolveEffect } from '../logic/resolve.js';
-import { evaluateJsExpression } from '../logic/conditions.js';
+import {
+  evaluateJsExpression,
+  evaluateOptionVisibility,
+} from '../logic/conditions.js';
 import {
   validateField,
   validateForm,
@@ -128,6 +132,12 @@ export interface FormState {
   addOption: (fieldId: string, value?: string) => string | null;
   /** Update an option's value. */
   updateOption: (fieldId: string, optionId: string, value: string) => boolean;
+  /** Update an option's conditional visibility rules. */
+  updateOptionRules: (
+    fieldId: string,
+    optionId: string,
+    rules: ConditionalRule[]
+  ) => boolean;
   /** Set or clear an option's numeric score. Pass `undefined` to remove. */
   setOptionScore: (
     fieldId: string,
@@ -160,6 +170,8 @@ export interface FormState {
   getField: (fieldId: string) => FieldNode | undefined;
   /** Look up a field's current response. */
   getResponse: (fieldId: string) => FieldResponse | undefined;
+  /** Return the options currently visible for a field. */
+  getVisibleOptions: (fieldId: string) => FieldOption[];
   /** Whether a field is currently visible. */
   isVisible: (fieldId: string) => boolean;
   /** Whether a field is currently enabled. */
@@ -261,27 +273,44 @@ function rewriteFieldRefs(
 
   let changed = false;
 
-  const updatedRules = def.rules?.map((rule) => ({
-    ...rule,
-    conditions: rule.conditions.map((cond) => {
-      let c = cond;
-      if (c.targetId === oldId) {
-        c = { ...c, targetId: newId };
-        changed = true;
-      }
-      if (c.expression) {
-        const next =
-          c.conditionType === 'js'
-            ? replaceJs(c.expression)
-            : replaceExpr(c.expression);
-        if (next !== c.expression) {
-          c = { ...c, expression: next };
+  const rewriteRules = (rules?: readonly ConditionalRule[]) => {
+    if (!rules) return rules;
+    let rulesChanged = false;
+    const nextRules = rules.map((rule) => ({
+      ...rule,
+      conditions: rule.conditions.map((cond) => {
+        let c = cond;
+        if (c.targetId === oldId) {
+          c = { ...c, targetId: newId };
+          rulesChanged = true;
           changed = true;
         }
-      }
-      return c;
-    }),
-  }));
+        if (c.expression) {
+          const next =
+            c.conditionType === 'js'
+              ? replaceJs(c.expression)
+              : replaceExpr(c.expression);
+          if (next !== c.expression) {
+            c = { ...c, expression: next };
+            rulesChanged = true;
+            changed = true;
+          }
+        }
+        return c;
+      }),
+    }));
+    return rulesChanged ? nextRules : rules;
+  };
+
+  const updatedRules = rewriteRules(def.rules);
+  const options = (def as unknown as { options?: FieldOption[] }).options;
+  const updatedOptions = options?.map((option) => {
+    const rules = rewriteRules(option.rules);
+    return rules === option.rules ? option : { ...option, rules };
+  });
+  const optionsChanged = updatedOptions?.some(
+    (option, index) => option !== options?.[index]
+  );
 
   // Update display field content (inline `{fieldId}` expression placeholders)
   const defAny = def as unknown as Record<string, unknown>;
@@ -298,6 +327,7 @@ function rewriteFieldRefs(
   return {
     ...def,
     ...(updatedRules && { rules: updatedRules }),
+    ...(optionsChanged && { options: updatedOptions }),
     ...(updatedContent !== content && { content: updatedContent }),
     ...(updatedCalc !== calc && { calculation: updatedCalc }),
   } as FieldDefinition;
@@ -894,6 +924,26 @@ export function createFormStore(
       return true;
     },
 
+    updateOptionRules: (fieldId, optionId, rules) => {
+      const result = patchField(get().normalized, fieldId, (def) => {
+        const opts = (def as unknown as { options?: FieldOption[] }).options;
+        if (!opts) return null;
+        let changed = false;
+        const next = opts.map((option) => {
+          if (option.id !== optionId) return option;
+          if (option.rules === rules) return option;
+          changed = true;
+          return { ...option, rules };
+        });
+        return changed
+          ? ({ ...def, options: next } as unknown as FieldDefinition)
+          : null;
+      });
+      if (!result) return false;
+      set({ normalized: result });
+      return true;
+    },
+
     setOptionScore: (fieldId, optionId, score) => {
       const result = patchField(get().normalized, fieldId, (def) => {
         const opts = (def as unknown as { options?: FieldOption[] }).options;
@@ -1082,6 +1132,22 @@ export function createFormStore(
     getField: (fieldId) => get().normalized.byId[fieldId],
 
     getResponse: (fieldId) => get().responses[fieldId],
+
+    getVisibleOptions: (fieldId) => {
+      const { normalized, responses, dangerouslyAllowJS } = get();
+      const node = normalized.byId[fieldId];
+      if (!node) return [];
+      const options = (node.definition as { options?: FieldOption[] }).options;
+      if (!options) return [];
+      return options.filter((option) =>
+        evaluateOptionVisibility(
+          option,
+          normalized,
+          responses,
+          dangerouslyAllowJS
+        )
+      );
+    },
 
     isVisible: (fieldId) => {
       const { normalized, responses, dangerouslyAllowJS } = get();

--- a/packages/core/src/lib/types.spec.ts
+++ b/packages/core/src/lib/types.spec.ts
@@ -100,6 +100,50 @@ describe('schema types', () => {
     expect(result.success).toBe(false);
   });
 
+  it('should accept conditional rules on options', () => {
+    const result = formDefinitionSchema.safeParse({
+      id: 'option-rules',
+      pages: [
+        {
+          id: 'page-1',
+          fields: [
+            {
+              id: 'country',
+              fieldType: 'radio',
+              options: [{ id: 'us', value: 'United States' }],
+            },
+            {
+              id: 'location',
+              fieldType: 'dropdown',
+              options: [
+                {
+                  id: 'houston-hq',
+                  value: 'Houston HQ',
+                  rules: [
+                    {
+                      effect: 'visible',
+                      logic: 'AND',
+                      conditions: [
+                        {
+                          conditionType: 'field',
+                          targetId: 'country',
+                          operator: 'equals',
+                          expected: 'us',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('should preserve supported field properties during normalization', () => {
     const normalized = normalizeFormDefinition({
       id: 'form',

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -330,6 +330,9 @@ export const fieldOptionSchema = z.object({
   text: z.optional(z.string()),
   /** Numeric score for scored surveys (PHQ-9, GAD-7, etc.). */
   score: z.optional(z.number()),
+  rules: z.optional(
+    z.array(z.lazy((): z.ZodMiniType<ConditionalRule> => conditionalRuleSchema))
+  ),
 });
 export type FieldOption = z.infer<typeof fieldOptionSchema>;
 

--- a/packages/field-health/package.json
+++ b/packages/field-health/package.json
@@ -35,8 +35,8 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/core": "0.0.6",
-    "@esheet/fields": "0.0.6",
+    "@esheet/core": "workspace:*",
+    "@esheet/fields": "workspace:*",
     "@mieweb/ui": "0.7.1",
     "lucide-react": "^1.31.0",
     "react": "^19.2.4",

--- a/packages/field-kerebron/package.json
+++ b/packages/field-kerebron/package.json
@@ -31,7 +31,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/core": "0.0.6",
+    "@esheet/core": "workspace:*",
     "@kerebron/editor": "^0.8.9",
     "@kerebron/editor-kits": "^0.8.9",
     "@kerebron/editor-react": "^0.8.9",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -40,7 +40,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/core": "0.0.6",
+    "@esheet/core": "workspace:*",
     "@mieweb/ui": "0.7.1",
     "lucide-react": "^1.31.0",
     "react": "^19.2.4",

--- a/packages/fields/src/fields/selection/BooleanField.tsx
+++ b/packages/fields/src/fields/selection/BooleanField.tsx
@@ -18,13 +18,14 @@ export const BooleanField = React.memo(function BooleanField({
 }: FieldComponentProps) {
   const def = field.definition as BooleanFieldDefinition;
   const instanceId = form.getState().instanceId;
-  const options =
+  const configuredOptions =
     def.options && def.options.length === 2
       ? def.options
       : [
           { id: 'yes', value: 'Yes' },
           { id: 'no', value: 'No' },
         ];
+  const options = isPreview && def.options ? def.options : configuredOptions;
   const selectedId =
     (response?.selected as SelectedOption | undefined)?.id ?? null;
 

--- a/packages/renderer-blaze/package.json
+++ b/packages/renderer-blaze/package.json
@@ -31,7 +31,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/renderer": "0.0.6",
+    "@esheet/renderer": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tslib": "^2.3.0"

--- a/packages/renderer-standalone/package.json
+++ b/packages/renderer-standalone/package.json
@@ -31,7 +31,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/renderer": "0.0.6",
+    "@esheet/renderer": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tslib": "^2.3.0"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -39,9 +39,9 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@esheet/adapters": "0.0.6",
-    "@esheet/core": "0.0.6",
-    "@esheet/fields": "0.0.6",
+    "@esheet/adapters": "workspace:*",
+    "@esheet/core": "workspace:*",
+    "@esheet/fields": "workspace:*",
     "js-yaml": "^5.2.3"
   },
   "peerDependencies": {

--- a/packages/renderer/src/lib/components/FieldNode.tsx
+++ b/packages/renderer/src/lib/components/FieldNode.tsx
@@ -6,7 +6,7 @@ import type {
   FormStore,
   UIStore,
 } from '@esheet/core';
-import { getInheritedSectionWidth } from '@esheet/core';
+import { getFieldForRender, getInheritedSectionWidth } from '@esheet/core';
 import { FieldGrid, FieldGridItem, getFieldComponent } from '@esheet/fields';
 
 export interface FieldNodeProps {
@@ -192,8 +192,10 @@ export const FieldNode = React.memo(function FieldNode({
 
   if (!isVisible) return null;
 
+  const renderField = getFieldForRender(field, form, true);
+
   const props: FieldComponentProps = {
-    field,
+    field: renderField,
     form,
     ui,
     isSelected: false,

--- a/packages/renderer/src/lib/renderer-tools.ts
+++ b/packages/renderer/src/lib/renderer-tools.ts
@@ -129,7 +129,8 @@ export function createRendererTools(formStore: FormStore): RendererTools {
       rows?: { id: string; value: string }[];
       columns?: { id: string; value: string }[];
     },
-    required?: boolean
+    required?: boolean,
+    filterVisibleOptions = false
   ): RendererFieldSummary {
     const response = formStore.getState().responses[id];
     const hasValue =
@@ -155,8 +156,11 @@ export function createRendererTools(formStore: FormStore): RendererTools {
     if (def.inputType) summary.inputType = def.inputType;
     if (def.inputType && INPUT_TYPE_FORMAT[def.inputType])
       summary.valueFormat = INPUT_TYPE_FORMAT[def.inputType];
-    if (def.options && def.options.length > 0)
-      summary.options = def.options.map((o) => o.value);
+    const options = filterVisibleOptions
+      ? formStore.getState().getVisibleOptions(id)
+      : def.options;
+    if (options && options.length > 0)
+      summary.options = options.map((o) => o.value);
     if (def.rows && def.rows.length > 0)
       summary.rows = def.rows.map((r) => r.value);
     if (def.columns && def.columns.length > 0)
@@ -303,8 +307,8 @@ export function createRendererTools(formStore: FormStore): RendererTools {
         def.fieldType
       )
     ) {
-      const opts = def.options ?? [];
-      const match = opts.find(
+      const options = formStore.getState().getVisibleOptions(fieldId);
+      const match = options.find(
         (o) =>
           o.value.toLowerCase() === String(value).toLowerCase() ||
           o.id === value
@@ -312,7 +316,9 @@ export function createRendererTools(formStore: FormStore): RendererTools {
       // For slider/rating, also try matching by numeric index or option value as number
       const numVal = Number(value);
       const numMatch =
-        !match && !isNaN(numVal) ? opts[numVal - 1] ?? opts[numVal] : undefined;
+        !match && !isNaN(numVal)
+          ? options[numVal - 1] ?? options[numVal]
+          : undefined;
       const resolved = match ?? numMatch;
       response = resolved
         ? { selected: { id: resolved.id, value: resolved.value } }
@@ -321,9 +327,9 @@ export function createRendererTools(formStore: FormStore): RendererTools {
       def.fieldType === 'check' ||
       def.fieldType === 'multiselectdropdown'
     ) {
-      const opts = def.options ?? [];
+      const options = formStore.getState().getVisibleOptions(fieldId);
       const vals = Array.isArray(value) ? (value as unknown[]) : [value];
-      const matches = opts.filter((o) =>
+      const matches = options.filter((o) =>
         vals.some(
           (v) => o.value.toLowerCase() === String(v).toLowerCase() || o.id === v
         )
@@ -333,11 +339,11 @@ export function createRendererTools(formStore: FormStore): RendererTools {
       };
     } else if (def.fieldType === 'ranking') {
       // ranking: { selected: SelectedOption[] } in the user-specified order
-      const opts = def.options ?? [];
+      const options = formStore.getState().getVisibleOptions(fieldId);
       const vals = Array.isArray(value) ? (value as unknown[]) : [value];
       const ordered = vals
         .map((v) =>
-          opts.find(
+          options.find(
             (o) =>
               o.value.toLowerCase() === String(v).toLowerCase() || o.id === v
           )
@@ -345,18 +351,21 @@ export function createRendererTools(formStore: FormStore): RendererTools {
         .filter((o): o is { id: string; value: string } => o != null);
       // append any options not mentioned by the user at the end
       const mentioned = new Set(ordered.map((o) => o.id));
-      const remaining = opts.filter((o) => !mentioned.has(o.id));
+      const remaining = options.filter((o) => !mentioned.has(o.id));
       response = { selected: [...ordered, ...remaining] };
     } else if (def.fieldType === 'multitext') {
       // multitext: { multitextAnswers: Record<optionId, string> }
-      const opts = def.options ?? [];
-      const vals = Array.isArray(value)
-        ? (value as unknown[])
-        : typeof value === 'object' && value !== null
-        ? Object.values(value as Record<string, unknown>)
-        : [value];
+      const options = formStore.getState().getVisibleOptions(fieldId);
+      let vals: unknown[];
+      if (Array.isArray(value)) {
+        vals = value;
+      } else if (value !== null && typeof value === 'object') {
+        vals = Object.values(value as Record<string, unknown>);
+      } else {
+        vals = [value];
+      }
       const multitextAnswers: Record<string, string> = {};
-      opts.forEach((opt, i) => {
+      options.forEach((opt, i) => {
         if (vals[i] != null) multitextAnswers[opt.id] = String(vals[i]);
       });
       response = { multitextAnswers };
@@ -364,8 +373,11 @@ export function createRendererTools(formStore: FormStore): RendererTools {
       if (value == null) {
         response = { answer: undefined };
       } else {
-        const normalized = normalizeTextValue(String(value), def.inputType);
-        if (normalized === null) {
+        const normalizedValue = normalizeTextValue(
+          String(value),
+          def.inputType
+        );
+        if (normalizedValue === null) {
           const fmt: Record<string, string> = {
             date: 'YYYY-MM-DD',
             'datetime-local': 'YYYY-MM-DDTHH:mm',
@@ -374,16 +386,10 @@ export function createRendererTools(formStore: FormStore): RendererTools {
           };
           const expected = fmt[def.inputType ?? ''];
           return expected
-            ? `Error: invalid value for inputType "${
-                def.inputType
-              }" — expected format ${expected} (e.g. ${new Date()
-                .toISOString()
-                .slice(0, expected.length)
-                .replace('T', 'T')
-                .replace(/[^\dT:-]/g, '0')})`
+            ? `Error: invalid value for inputType "${def.inputType}" — expected format ${expected}`
             : `Error: invalid value for field`;
         }
-        response = { answer: normalized };
+        response = { answer: normalizedValue };
       }
     }
     formStore.getState().setResponse(fieldId, response);
@@ -407,7 +413,8 @@ export function createRendererTools(formStore: FormStore): RendererTools {
         toFieldSummary(
           node.id,
           node.definition as unknown as FieldDef,
-          node.required
+          node.required,
+          true
         )
       );
       return { formId, fieldCount: fields.length, fields };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
   packages/adapters:
     dependencies:
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -245,14 +245,14 @@ importers:
   packages/builder:
     dependencies:
       '@esheet/adapters':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../adapters
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       '@esheet/fields':
-        specifier: 0.0.6
-        version: 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(remark-gfm@4.0.1)
+        specifier: workspace:*
+        version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
         version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
@@ -319,11 +319,11 @@ importers:
   packages/field-health:
     dependencies:
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       '@esheet/fields':
-        specifier: 0.0.6
-        version: 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(remark-gfm@4.0.1)
+        specifier: workspace:*
+        version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
         version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
@@ -343,8 +343,8 @@ importers:
   packages/field-kerebron:
     dependencies:
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       '@kerebron/editor':
         specifier: ^0.8.9
         version: 0.8.9
@@ -380,8 +380,8 @@ importers:
   packages/fields:
     dependencies:
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       '@mieweb/ui':
         specifier: 0.7.1
         version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
@@ -423,14 +423,14 @@ importers:
   packages/renderer:
     dependencies:
       '@esheet/adapters':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../adapters
       '@esheet/core':
-        specifier: 0.0.6
-        version: 0.0.6(@types/react@19.2.18)(react@19.2.8)
+        specifier: workspace:*
+        version: link:../core
       '@esheet/fields':
-        specifier: 0.0.6
-        version: 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(remark-gfm@4.0.1)
+        specifier: workspace:*
+        version: link:../fields
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3
@@ -448,8 +448,8 @@ importers:
   packages/renderer-blaze:
     dependencies:
       '@esheet/renderer':
-        specifier: 0.0.6
-        version: 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react@19.2.8)(remark-gfm@4.0.1)
+        specifier: workspace:*
+        version: link:../renderer
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -463,8 +463,8 @@ importers:
   packages/renderer-standalone:
     dependencies:
       '@esheet/renderer':
-        specifier: 0.0.6
-        version: 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react@19.2.8)(remark-gfm@4.0.1)
+        specifier: workspace:*
+        version: link:../renderer
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -1751,23 +1751,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.3':
     resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
-
-  '@esheet/adapters@0.0.6':
-    resolution: {integrity: sha512-saJohz1QQLjWowb7BpWqGwxyn20wYO1oRU33lzLVMiHN97Bcs/Cs+12FM52wLN5NJRLDlmKl8Q7f1flGATnQOA==}
-
-  '@esheet/core@0.0.6':
-    resolution: {integrity: sha512-J3QO4M0Rc6PX+MRiXbk/rY7DSF85zx1I6/8FOeREgI1sLvt1LNk/HWSLELlq4ek9FRKriw0r/pdk8oYYzzCoYA==}
-
-  '@esheet/fields@0.0.6':
-    resolution: {integrity: sha512-pZMLc424Fx4TmGI0KXYJlgnxOTVGcrApFx8xp3MTsFbUdQWeMTsJkCD4mYhFoH5UWGwI47GaJ3AboVWNAqvVhw==}
-
-  '@esheet/renderer@0.0.6':
-    resolution: {integrity: sha512-VjTwXBtMELyY1HTh77SLNepRo1TxuiitvsSf/6chWmemqyd/NWJGurftnw3M6ttHHmhcoOrw7lCb0n7UPZmzVA==}
-    peerDependencies:
-      react: '>=19.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@eslint-community/eslint-utils@4.10.1':
     resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
@@ -11557,89 +11540,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esheet/adapters@0.0.6(@types/react@19.2.18)(react@19.2.8)':
-    dependencies:
-      '@esheet/core': 0.0.6(@types/react@19.2.18)(react@19.2.8)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@esheet/core@0.0.6(@types/react@19.2.18)(react@19.2.8)':
-    dependencies:
-      tslib: 2.8.1
-      zod: 4.4.3
-      zustand: 5.0.14(@types/react@19.2.18)(react@19.2.8)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@esheet/fields@0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(remark-gfm@4.0.1)':
-    dependencies:
-      '@esheet/core': 0.0.6(@types/react@19.2.18)(react@19.2.8)
-      '@mieweb/ui': 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
-      lucide-react: 1.31.0(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      sortablejs: 1.15.7
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@kerebron/editor'
-      - '@kerebron/editor-kits'
-      - '@kerebron/wasm'
-      - '@mieweb/datavis'
-      - '@types/react'
-      - ag-grid-community
-      - ag-grid-react
-      - datavis-ace
-      - immer
-      - js-yaml
-      - katex
-      - mermaid
-      - papaparse
-      - react-markdown
-      - rehype-highlight
-      - rehype-katex
-      - rehype-sanitize
-      - remark-gfm
-      - remark-math
-      - use-sync-external-store
-      - wavesurfer.js
-
-  '@esheet/renderer@0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react@19.2.8)(remark-gfm@4.0.1)':
-    dependencies:
-      '@esheet/adapters': 0.0.6(@types/react@19.2.18)(react@19.2.8)
-      '@esheet/core': 0.0.6(@types/react@19.2.18)(react@19.2.8)
-      '@esheet/fields': 0.0.6(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(remark-gfm@4.0.1)
-      js-yaml: 5.2.3
-    optionalDependencies:
-      react: 19.2.8
-    transitivePeerDependencies:
-      - '@kerebron/editor'
-      - '@kerebron/editor-kits'
-      - '@kerebron/wasm'
-      - '@mieweb/datavis'
-      - '@types/react'
-      - ag-grid-community
-      - ag-grid-react
-      - datavis-ace
-      - immer
-      - katex
-      - mermaid
-      - papaparse
-      - react-markdown
-      - rehype-highlight
-      - rehype-katex
-      - rehype-sanitize
-      - remark-gfm
-      - remark-math
-      - use-sync-external-store
-      - wavesurfer.js
-
   '@eslint-community/eslint-utils@4.10.1(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -13535,7 +13435,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13589,7 +13489,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:

--- a/release/release.mjs
+++ b/release/release.mjs
@@ -178,11 +178,13 @@ if (IS_PRERELEASE) {
 }
 
 // ---------------------------------------------------------------------------
-// 7. npm publish — two-phase, all-or-nothing.
+// 7. pnpm publish — two-phase, all-or-nothing.
 //    Phase A: preflight checks (dry-run + registry existence).
 //             Any failure aborts before anything real is published.
 //    Phase B: only if every preflight passes, publish for real.
 //    Done BEFORE the git push so that if publish fails, nothing lands on main.
+//    pnpm resolves workspace:* dependencies to exact versions in the published
+//    package manifest while keeping workspace links in the repository.
 // ---------------------------------------------------------------------------
 
 const publishTag = IS_PRERELEASE ? '--tag next' : '';
@@ -222,7 +224,7 @@ if (DRY_RUN) {
 
     // 2. Dry-run publish (validates package structure and auth, no OIDC needed).
     try {
-      exec(`npm publish ${dryRunFlags}`, { cwd: pkgDir });
+      exec(`pnpm publish ${dryRunFlags}`, { cwd: pkgDir });
       console.log('✓');
       preflight.push({ pkgDir, pkg, ok: true });
     } catch (err) {
@@ -245,14 +247,12 @@ if (DRY_RUN) {
   // Phase B — all preflights passed; publish for real.
   for (const { pkgDir, pkg } of preflight) {
     console.log(`\nPublishing ${pkg.name}@${newVersion}...`);
-    exec(`npm publish ${publishFlags}`, { cwd: pkgDir });
+    exec(`pnpm publish ${publishFlags}`, { cwd: pkgDir });
   }
 }
 
 // ---------------------------------------------------------------------------
 // 8. Git commit + tag + push — only reached if publish succeeded above.
-//    Update the lockfile first so cross-package @esheet/* pinned versions
-//    stay consistent with the bumped package.json files.
 //    (prereleases: no tag, no changelog in commit)
 // ---------------------------------------------------------------------------
 
@@ -263,19 +263,15 @@ if (DRY_RUN) {
     } and push`
   );
 } else {
-  // Sync lockfile with the updated package.json cross-dep versions.
-  console.log('Updating pnpm-lock.yaml...');
-  exec('pnpm install --lockfile-only --ignore-scripts');
-
   if (IS_PRERELEASE) {
     const changedFiles = PACKAGES.map((p) => `${p}/package.json`).join(' ');
-    run(`git add ${changedFiles} pnpm-lock.yaml`);
+    run(`git add ${changedFiles}`);
     run(`git commit -m "chore(release): bump to ${newVersion} [prerelease]"`);
     run('git push origin main');
     console.log(`📦 Committed version bumps for ${newVersion} (no tag)`);
   } else {
     const changedFiles = PACKAGES.map((p) => `${p}/package.json`).join(' ');
-    run(`git add ${changedFiles} CHANGELOG.md pnpm-lock.yaml`);
+    run(`git add ${changedFiles} CHANGELOG.md`);
     run(`git commit -m "chore(release): publish ${newVersion}"`);
     run(`git tag v${newVersion}`);
     run('git push origin main');

--- a/release/versions.mjs
+++ b/release/versions.mjs
@@ -4,11 +4,6 @@ import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { PACKAGES } from './config.mjs';
 
-/** Collect the set of @esheet/* package names from the workspace. */
-function getEsheetPackageNames() {
-  return new Set(PACKAGES.map((dir) => readPkg(dir).name));
-}
-
 export function readPkg(dir) {
   return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
 }
@@ -17,15 +12,8 @@ export function writePkg(dir, pkg) {
   writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
 }
 
-/**
- * Update the version field in every package's package.json.
- * Also pins cross-package @esheet/* dependencies to the new version
- * so published packages don't resolve "*" to the old stable release.
- * @param {string} newVersion
- * @param {boolean} dryRun
- */
+/** Update the version field in every package's package.json. */
 export function bumpAll(newVersion, dryRun) {
-  const esheetNames = getEsheetPackageNames();
   for (const pkgDir of PACKAGES) {
     if (dryRun) {
       console.log(
@@ -35,17 +23,6 @@ export function bumpAll(newVersion, dryRun) {
     }
     const pkg = readPkg(pkgDir);
     pkg.version = newVersion;
-
-    // Pin cross-package @esheet/* deps so published packages reference
-    // the exact prerelease version instead of resolving "*" to latest stable.
-    for (const depField of ['dependencies', 'peerDependencies', 'devDependencies']) {
-      if (!pkg[depField]) continue;
-      for (const depName of Object.keys(pkg[depField])) {
-        if (esheetNames.has(depName)) {
-          pkg[depField][depName] = newVersion;
-        }
-      }
-    }
 
     writePkg(pkgDir, pkg);
     console.log(`✍  ${pkgDir}/package.json → ${newVersion}`);


### PR DESCRIPTION
**PR Summary**

## Overview

Adds conditional visibility support for individual field options. Form authors can now show or hide options based on responses to other fields while preserving existing field-level conditional logic.

## Motivation

Many forms need dependent choices, such as:

- Showing location options based on a selected country
- Showing department options based on a selected location
- Displaying only relevant multitext inputs
- Keeping fallback options visible when no rule applies

Previously, conditional logic could control entire fields but not individual options within a field.

## What Changed

### Schema and Core Logic

- Added optional `rules` to `FieldOption`.
- Reused the existing `ConditionalRule` structure.
- Added option visibility evaluation with these semantics:
  - Only `visible` rules affect option visibility.
  - Multiple visibility rules use OR behavior.
  - Options without visibility rules remain visible.
- Added `getVisibleOptions()` to the form store.
- Added `updateOptionRules()` for editing option rules.
- Updated field-reference rewriting so option rules remain valid when a referenced field is renamed.

### Rendering

- Preview and renderer output now receive only currently visible options.
- Builder editing mode continues to show all options so authors can manage hidden options.
- Renderer tools now:
  - Report only visible options when requested.
  - Resolve responses against visible options.
  - Handle filtered radio, dropdown, multiselect, ranking, and multitext options.
- Boolean fields preserve configured options during preview so option visibility rules can be applied correctly.

### Validation

- Added hard validation errors when a response contains an option that is no longer visible.
- Supports:
  - Single selected options
  - Multiple selected options
  - Non-empty multitext answers
- Empty hidden multitext answers remain valid.

### Builder

- Added per-option “Visibility rules” controls.
- Reused the existing logic editor for option-level rule authoring.
- Added option-specific rule update wiring through the builder form API.

### Tests

Added coverage for:

- Option rule schema parsing
- Option visibility evaluation
- Unruled options remaining visible
- Selected hidden options
- Hidden multitext answers
- Empty hidden multitext answers
- Option rule updates
- Field ID rename propagation
- Preview-only option filtering
- Renderer tool filtering and response resolution

### Documentation and Demo

- Documented option-scoped visibility rules.
- Updated the schema format documentation.
- Added an option visibility playground schema demonstrating:

```text
country -> location -> department
```