### PR TITLE
fix(renderer): externalize @esheet/fields so custom field types register

### DIFF
--- a/packages/field-health/src/CodeLookup/CodeLookup.tsx
+++ b/packages/field-health/src/CodeLookup/CodeLookup.tsx
@@ -349,7 +349,7 @@ export const CodeLookup = React.forwardRef<HTMLDivElement, CodeLookupProps>(
       <div className="relative" ref={anchorRef}>
         <SearchIcon
           size={16}
-          className="text-muted-foreground absolute top-5 left-3 -translate-y-1/2"
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
         />
         <input
           type="text"
@@ -372,6 +372,7 @@ export const CodeLookup = React.forwardRef<HTMLDivElement, CodeLookupProps>(
           placeholder={effectivePlaceholder}
           disabled={status.state === 'error'}
           className={cn(
+            'code-lookup-input',
             'border-border bg-background text-foreground placeholder:text-muted-foreground',
             'h-10 w-full rounded-md border pr-3 pl-9 text-sm',
             'focus:ring-ring focus:ring-2 focus:outline-none'

--- a/packages/field-health/src/index.css
+++ b/packages/field-health/src/index.css
@@ -2,3 +2,10 @@
 @import 'tailwindcss/utilities';
 
 @source "./**/*.{ts,tsx}";
+
+/* Touch mode forces `padding: .75rem !important` on all inputs, which would
+   put the placeholder under the leading search icon — keep the icon gutter. */
+.esheet-renderer-root input.code-lookup-input[type='text'],
+.ms-builder-root input.code-lookup-input[type='text'] {
+  padding-left: 2.25rem !important;
+}

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -55,6 +55,10 @@ export default defineConfig(() => ({
         'react-dom',
         'react/jsx-runtime',
         '@esheet/core',
+        // Must stay external: the field component registry lives in
+        // @esheet/fields, and registerCustomFieldTypes() only reaches the
+        // renderer when host and renderer share one module instance.
+        '@esheet/fields',
         'tslib',
       ],
     },


### PR DESCRIPTION
## Problem

The [custom field types docs](https://github.com/mieweb/eSheet/blob/main/apps/docs/docs/advanced/custom-field-types.md) say hosts can extend the renderer via `registerCustomFieldTypes()` from `@esheet/fields`. That works in this monorepo (the demo app aliases every package to source), but **not with the published packages**: `packages/renderer/vite.config.ts` doesn't list `@esheet/fields` as external, so the renderer dist inlines its own private copy of the field component registry.

A host's `registerCustomFieldTypes()` call writes to a *different* module instance than the one the renderer reads. Schema validation passes (`@esheet/core` is external and therefore shared), but the field renders the **"Unknown field type: X"** fallback. Reproduced against published 0.0.5 and 0.0.6 (registered a probe component, rendered `<EsheetRenderer>`, got the fallback).

This also silently breaks the published `@esheet/field-health` — its build already externalizes `@esheet/fields` on the assumption that the host and renderer share it.

## Fix

Add `@esheet/fields` to the renderer build's `external` list (it's already a runtime dependency). One line + comment.

## Verification

- Rebuilt the renderer: dist now has `import ... from "@esheet/fields"` and no longer embeds the fields CSS-injection IIFE.
- Probe test: registering `{ probeField: { ..., component } }` via `@esheet/fields` and rendering the **built dist** shows the custom component (previously the unknown-type fallback).
- Full `@esheet/renderer` vitest suite passes (22/22).
- CSS unaffected: the renderer's Tailwind build already `@source`-scans `../fields/src`, and the fields dist self-injects its own styles on import.

## Motivation

Downstream (mieweb/eCase) we want the case form's Assessment tab to be a custom eSheet field wrapping `@mieweb/ui`'s `Assessment` component, following the `field-health` pattern — blocked on this until a release includes it.