### PR TITLE
refactor(core): generalize field definition normalization using registry defaultProps

### DIFF
--- a/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
@@ -104,9 +104,7 @@ export function CommonEditor({
       {showInputType && (
         <InputTypeEditor
           fieldId={fieldId}
-          inputType={
-            (def as { inputType?: TextInputType }).inputType ?? 'string'
-          }
+          inputType={(def as unknown as { inputType: TextInputType }).inputType}
           unit={(def as { unit?: string }).unit}
           dateRange={
             (

--- a/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/CommonEditor.tsx
@@ -5,7 +5,7 @@ import type {
   OptionLayout,
   TextInputType,
 } from '@esheet/core';
-import { getDefaultProp, slugifyQuestion } from '@esheet/core';
+import { slugifyQuestion } from '@esheet/core';
 import { useFormStore } from '@esheet/fields';
 import { useInstanceId } from '../../EsheetBuilder.js';
 import { DraftIdEditor } from './DraftIdEditor.js';
@@ -39,22 +39,14 @@ export function CommonEditor({
     def.fieldType === 'text' || def.fieldType === 'longtext';
   const formStore = useFormStore();
   const dangerouslyAllowJS = useStore(formStore, (s) => s.dangerouslyAllowJS);
-  const defaultWidth = getDefaultProp<FieldWidth>(def.fieldType, 'width');
   const calculation = (def as { calculation?: string }).calculation ?? '';
-  const width = (def as { width?: FieldWidth }).width ?? defaultWidth ?? 'full';
+  const width = (def as { width?: FieldWidth }).width;
   const showOptionLayout =
     def.fieldType === 'radio' ||
     def.fieldType === 'check' ||
     def.fieldType === 'multitext' ||
     def.fieldType === 'openchoice';
-  const defaultOptionLayout = getDefaultProp<OptionLayout>(
-    def.fieldType,
-    'optionLayout'
-  );
-  const optionLayout =
-    (def as { optionLayout?: OptionLayout }).optionLayout ??
-    defaultOptionLayout ??
-    'stack';
+  const optionLayout = (def as { optionLayout?: OptionLayout }).optionLayout;
   const question = (def as { question?: string }).question ?? '';
   const suggestedId = slugifyQuestion(question);
   const showSuggestion = suggestedId !== '' && suggestedId !== def.id;
@@ -149,8 +141,7 @@ export function CommonEditor({
           onChange={(e) => {
             const nextWidth = e.currentTarget.value as FieldWidth;
             onUpdate({
-              width:
-                nextWidth === (defaultWidth ?? 'full') ? undefined : nextWidth,
+              width: nextWidth,
             } as Parameters<typeof onUpdate>[0]);
           }}
           className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"
@@ -195,10 +186,7 @@ export function CommonEditor({
             onChange={(e) => {
               const nextOptionLayout = e.currentTarget.value as OptionLayout;
               onUpdate({
-                optionLayout:
-                  nextOptionLayout === (defaultOptionLayout ?? 'stack')
-                    ? undefined
-                    : nextOptionLayout,
+                optionLayout: nextOptionLayout,
               } as Parameters<typeof onUpdate>[0]);
             }}
             className="ms:w-full ms:min-w-0 ms:px-3 ms:py-2 ms:text-sm ms:bg-mssurface ms:border ms:border-msborder ms:rounded ms:text-mstext ms:focus:outline-none ms:focus:ring-1 ms:focus:ring-msprimary ms:focus:border-msprimary ms:transition-colors"

--- a/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
+++ b/packages/builder/src/lib/components/edit-panel/EditPanel.tsx
@@ -8,6 +8,7 @@ import {
   type MatrixColumn,
   type MatrixRow,
   type EditTab,
+  type SectionFieldDefinition,
   type SectionIconName,
 } from '@esheet/core';
 import { useInstanceId } from '../../EsheetBuilder.js';
@@ -319,6 +320,9 @@ function SectionEditContent({
   onRenameId,
 }: SectionEditContentProps) {
   const instanceId = useInstanceId();
+  const sectionCollapse = (
+    def as { sectionCollapse?: SectionFieldDefinition['sectionCollapse'] }
+  ).sectionCollapse;
   const {
     selectedFieldId,
     selectedFieldChildId,
@@ -447,9 +451,7 @@ function SectionEditContent({
         </label>
         <select
           id={`${instanceId}-editor-collapse-${fieldId}`}
-          value={
-            (def as { sectionCollapse?: string }).sectionCollapse ?? 'expanded'
-          }
+          value={sectionCollapse}
           onChange={(e) => {
             const value = e.currentTarget.value;
             onUpdate({

--- a/packages/core/src/lib/functions/normalize.spec.ts
+++ b/packages/core/src/lib/functions/normalize.spec.ts
@@ -26,7 +26,7 @@ describe('normalizeDefinition', () => {
     expect(result.byId['q2'].definition.fieldType).toBe('radio');
   });
 
-  it('should materialize default widths for every field', () => {
+  it('should materialize registered defaults for every field', () => {
     const result = normalizeDefinition([
       {
         id: 'page-1',
@@ -43,7 +43,14 @@ describe('normalizeDefinition', () => {
 
     expect(result.byId['text'].definition.width).toBe('third');
     expect(result.byId['section'].definition.width).toBe('third');
+    expect(
+      (result.byId['section'].definition as SectionFieldDefinition)
+        .sectionCollapse
+    ).toBe('expanded');
     expect(result.byId['child'].definition.width).toBe('third');
+    expect(
+      (result.byId['child'].definition as { inputType?: string }).inputType
+    ).toBe('string');
   });
 
   it('should materialize default option layouts', () => {

--- a/packages/core/src/lib/functions/normalize.spec.ts
+++ b/packages/core/src/lib/functions/normalize.spec.ts
@@ -26,6 +26,46 @@ describe('normalizeDefinition', () => {
     expect(result.byId['q2'].definition.fieldType).toBe('radio');
   });
 
+  it('should materialize default widths for every field', () => {
+    const result = normalizeDefinition([
+      {
+        id: 'page-1',
+        fields: [
+          { id: 'text', fieldType: 'text' },
+          {
+            id: 'section',
+            fieldType: 'section',
+            fields: [{ id: 'child', fieldType: 'longtext' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(result.byId['text'].definition.width).toBe('third');
+    expect(result.byId['section'].definition.width).toBe('third');
+    expect(result.byId['child'].definition.width).toBe('third');
+  });
+
+  it('should materialize default option layouts', () => {
+    const result = normalizeDefinition([
+      {
+        id: 'page-1',
+        fields: [
+          { id: 'radio', fieldType: 'radio' },
+          { id: 'text', fieldType: 'text' },
+        ],
+      },
+    ]);
+
+    expect(
+      (result.byId['radio'].definition as { optionLayout?: string })
+        .optionLayout
+    ).toBe('wrap');
+    expect(
+      (result.byId['text'].definition as { optionLayout?: string }).optionLayout
+    ).toBeUndefined();
+  });
+
   it('should set parentId to null for top-level fields', () => {
     const fields: FieldDefinition[] = [{ id: 'q1', fieldType: 'text' }];
 
@@ -187,7 +227,7 @@ describe('normalizeDefinition', () => {
       },
     ]);
 
-    expect(getInheritedSectionWidth(result, 'deep')).toBe('half');
+    expect(getInheritedSectionWidth(result, 'deep')).toBe('third');
   });
 
   it('should prefer an inner section width over an outer section width', () => {

--- a/packages/core/src/lib/functions/normalize.ts
+++ b/packages/core/src/lib/functions/normalize.ts
@@ -5,9 +5,11 @@
 import type {
   FieldDefinition,
   FieldWidth,
+  OptionLayout,
   PageEntry,
   SectionFieldDefinition,
 } from '../types.js';
+import { getDefaultProp } from '../registry.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -68,12 +70,21 @@ export function normalizeDefinition(
     for (let i = 0; i < defs.length; i++) {
       const def = defs[i];
       const { fields: children, ...rest } = def as SectionFieldDefinition;
+      const width =
+        rest.width ?? getDefaultProp<FieldWidth>(def.fieldType, 'width');
+      const optionLayout =
+        (rest as { optionLayout?: OptionLayout }).optionLayout ??
+        getDefaultProp<OptionLayout>(def.fieldType, 'optionLayout');
       const childIds =
         def.fieldType === 'section' && Array.isArray(children)
           ? walk(children, def.id)
           : [];
       byId[def.id] = {
-        definition: rest as FieldDefinition,
+        definition: {
+          ...rest,
+          ...(width !== undefined && { width }),
+          ...(optionLayout !== undefined && { optionLayout }),
+        } as FieldDefinition,
         parentId,
         childIds,
         index: i,

--- a/packages/core/src/lib/functions/normalize.ts
+++ b/packages/core/src/lib/functions/normalize.ts
@@ -5,11 +5,10 @@
 import type {
   FieldDefinition,
   FieldWidth,
-  OptionLayout,
   PageEntry,
   SectionFieldDefinition,
 } from '../types.js';
-import { getDefaultProp } from '../registry.js';
+import { getFieldTypeMeta } from '../registry.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -70,21 +69,21 @@ export function normalizeDefinition(
     for (let i = 0; i < defs.length; i++) {
       const def = defs[i];
       const { fields: children, ...rest } = def as SectionFieldDefinition;
-      const width =
-        rest.width ?? getDefaultProp<FieldWidth>(def.fieldType, 'width');
-      const optionLayout =
-        (rest as { optionLayout?: OptionLayout }).optionLayout ??
-        getDefaultProp<OptionLayout>(def.fieldType, 'optionLayout');
+      const { fields: _defaultFields, ...defaultProps } =
+        getFieldTypeMeta(def.fieldType)?.defaultProps ?? {};
+      void _defaultFields;
+      const definition = { ...rest } as FieldDefinition;
+      const definitionValues = definition as unknown as Record<string, unknown>;
+      for (const [property, value] of Object.entries(defaultProps)) {
+        if (definitionValues[property] === undefined)
+          definitionValues[property] = value;
+      }
       const childIds =
         def.fieldType === 'section' && Array.isArray(children)
           ? walk(children, def.id)
           : [];
       byId[def.id] = {
-        definition: {
-          ...rest,
-          ...(width !== undefined && { width }),
-          ...(optionLayout !== undefined && { optionLayout }),
-        } as FieldDefinition,
+        definition,
         parentId,
         childIds,
         index: i,

--- a/packages/core/src/lib/registry.spec.ts
+++ b/packages/core/src/lib/registry.spec.ts
@@ -135,11 +135,12 @@ describe('field type registry', () => {
       'diagram',
       'file',
       'display',
-      'section',
       'pages',
     ]) {
       expect(getFieldTypeMeta(fieldType)?.defaultProps.width).toBe('full');
     }
+
+    expect(getFieldTypeMeta('section')?.defaultProps.width).toBe('third');
   });
 
   it('should resolve option layout defaults from field metadata', () => {

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -76,7 +76,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     answerType: 'text',
     hasOptions: false,
     hasMatrix: false,
-    defaultProps: { width: 'third' },
+    defaultProps: { inputType: 'string', width: 'third' },
     placeholder: {
       question: 'Enter your question...',
       answer: 'Enter detailed answer...',

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -307,7 +307,7 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
       fields: [],
       sectionIcon: 'folder',
       sectionCollapse: 'expanded',
-      width: 'full',
+      width: 'third',
     },
     placeholder: { title: 'Enter section title...' },
   },

--- a/packages/fields/src/fields/section/SectionField.spec.tsx
+++ b/packages/fields/src/fields/section/SectionField.spec.tsx
@@ -19,13 +19,14 @@ function createProps(definition: Record<string, unknown>): FieldComponentProps {
 }
 
 describe('SectionField', () => {
-  it('defaults absent sectionCollapse to an expanded collapsible section', () => {
+  it('renders an expanded collapsible section when configured', () => {
     render(
       <SectionField
         {...createProps({
           id: 'details',
           fieldType: 'section',
           title: 'Details',
+          sectionCollapse: 'expanded',
         })}
         nestedChildren={<div>Child field</div>}
       />

--- a/packages/fields/src/fields/section/SectionField.tsx
+++ b/packages/fields/src/fields/section/SectionField.tsx
@@ -215,7 +215,9 @@ export const SectionField = React.memo(function SectionField({
   const instanceId = form.getState().instanceId;
   const title = def.title || 'Section';
   const bodyId = React.useId();
-  const sectionCollapse = def.sectionCollapse ?? 'expanded';
+  const sectionCollapse = def.sectionCollapse as NonNullable<
+    SectionFieldDefinition['sectionCollapse']
+  >;
   const collapsible = sectionCollapse !== 'disabled';
   const defaultExpanded = collapsible ? sectionCollapse === 'expanded' : true;
   const [expanded, setExpanded] = React.useState(defaultExpanded);

--- a/packages/fields/src/fields/selection/CheckField.tsx
+++ b/packages/fields/src/fields/selection/CheckField.tsx
@@ -4,7 +4,6 @@ import type {
   SelectedOption,
   CheckFieldDefinition,
 } from '@esheet/core';
-import { getDefaultProp } from '@esheet/core';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 import { CustomCheckboxButton } from '../../fields-controls/CustomCheckboxButton.js';
 
@@ -22,10 +21,7 @@ export const CheckField = React.memo(function CheckField({
   const def = field.definition as CheckFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const optionLayout =
-    def.optionLayout ??
-    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
-  const isWrap = optionLayout === 'wrap';
+  const isWrap = def.optionLayout === 'wrap';
   const optionContainerClass =
     isWrap && options.length > 1
       ? 'ms:flex ms:flex-wrap ms:gap-2'

--- a/packages/fields/src/fields/selection/OpenChoiceField.tsx
+++ b/packages/fields/src/fields/selection/OpenChoiceField.tsx
@@ -5,7 +5,6 @@ import type {
   OpenChoiceFieldDefinition,
   FieldOption,
 } from '@esheet/core';
-import { getDefaultProp } from '@esheet/core';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 import { CustomRadioButton } from '../../fields-controls/CustomRadioButton.js';
 
@@ -35,11 +34,7 @@ export const OpenChoiceField = React.memo(function OpenChoiceField({
   if (isPreview) {
     const otherText =
       selectedId === otherOptionId && selected?.value ? selected.value : '';
-    const optionLayout =
-      def.optionLayout ??
-      getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout') ??
-      'wrap';
-    const isWrap = optionLayout === 'wrap';
+    const isWrap = def.optionLayout === 'wrap';
     const optionContainerClass =
       isWrap && options.length + 1 > 1
         ? 'ms:flex ms:flex-wrap ms:gap-2'

--- a/packages/fields/src/fields/selection/RadioField.tsx
+++ b/packages/fields/src/fields/selection/RadioField.tsx
@@ -4,7 +4,6 @@ import type {
   SelectedOption,
   RadioFieldDefinition,
 } from '@esheet/core';
-import { getDefaultProp } from '@esheet/core';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 import { CustomRadioButton } from '../../fields-controls/CustomRadioButton.js';
 
@@ -22,11 +21,7 @@ export const RadioField = React.memo(function RadioField({
   const def = field.definition as RadioFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const optionLayout =
-    def.optionLayout ??
-    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout') ??
-    'wrap';
-  const isWrap = optionLayout === 'wrap';
+  const isWrap = def.optionLayout === 'wrap';
   const optionContainerClass =
     isWrap && options.length > 1
       ? 'ms:flex ms:flex-wrap ms:gap-2'

--- a/packages/fields/src/fields/text/MultiTextField.tsx
+++ b/packages/fields/src/fields/text/MultiTextField.tsx
@@ -3,7 +3,6 @@ import type {
   FieldComponentProps,
   MultitextFieldDefinition,
 } from '@esheet/core';
-import { getDefaultProp } from '@esheet/core';
 import { Input } from '@mieweb/ui';
 import { TrashIcon, PlusIcon } from '../../icons.js';
 
@@ -21,10 +20,7 @@ export const MultiTextField = React.memo(function MultiTextField({
   const def = field.definition as MultitextFieldDefinition;
   const instanceId = form.getState().instanceId;
   const options = def.options || [];
-  const optionLayout =
-    def.optionLayout ??
-    getDefaultProp<'stack' | 'wrap'>(def.fieldType, 'optionLayout');
-  const isWrap = optionLayout === 'wrap';
+  const isWrap = def.optionLayout === 'wrap';
   const multitextAnswers = response?.multitextAnswers || {};
 
   if (isPreview) {

--- a/packages/fields/src/fields/text/TextField.tsx
+++ b/packages/fields/src/fields/text/TextField.tsx
@@ -109,7 +109,7 @@ export const TextField = React.memo(function TextField({
 }: FieldComponentProps) {
   const def = field.definition as TextFieldDefinition | LongtextFieldDefinition;
   const instanceId = form.getState().instanceId;
-  const inputType = def.inputType || 'string';
+  const inputType = def.inputType as NonNullable<typeof def.inputType>;
   const unit = def.unit || '';
   const isTel = inputType === 'tel';
   const placeholder = PLACEHOLDER[inputType] || 'Type your answer';

--- a/packages/fields/src/lib/FieldGrid.tsx
+++ b/packages/fields/src/lib/FieldGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDefaultProp, type FieldWidth } from '@esheet/core';
+import type { FieldWidth } from '@esheet/core';
 
 const GRID_STYLE: React.CSSProperties = {
   display: 'grid',
@@ -79,10 +79,6 @@ export interface FieldGridItemProps {
   inheritedWidth?: FieldWidth;
 }
 
-function getDefaultWidth(fieldType: string): FieldWidth {
-  return getDefaultProp<FieldWidth>(fieldType, 'width') ?? 'full';
-}
-
 export function FieldGridItem({
   children,
   fieldType,
@@ -92,15 +88,19 @@ export function FieldGridItem({
   const useGridLayout = useFieldGridLayout();
   if (!useGridLayout) return children;
 
-  const effectiveWidth = inheritedWidth ?? width ?? getDefaultWidth(fieldType);
+  if (fieldType === 'section' || fieldType === 'pages') {
+    return React.cloneElement(children, {
+      style: { ...children.props.style, gridColumn: 'span 6' },
+    });
+  }
+
+  const effectiveWidth = inheritedWidth ?? width;
+  if (effectiveWidth === undefined) {
+    throw new Error(`Missing width for field '${fieldType}'.`);
+  }
+
   const columnSpan =
-    fieldType === 'section' || fieldType === 'pages'
-      ? 6
-      : effectiveWidth === 'half'
-      ? 3
-      : effectiveWidth === 'third'
-      ? 2
-      : 6;
+    effectiveWidth === 'half' ? 3 : effectiveWidth === 'third' ? 2 : 6;
 
   return React.cloneElement(children, {
     style: { ...children.props.style, gridColumn: `span ${columnSpan}` },


### PR DESCRIPTION
## High Level Summary

Moves field default-property resolution into the core normalization boundary. Every normalized field definition now includes values declared in that field type's registry `defaultProps`, unless the source definition explicitly provides its own value.

This gives the builder and renderer a consistent, complete definition shape. They no longer need to know or repeat individual fallback values such as a text field's `inputType` or a section's `sectionCollapse` state.

## Changes

- Refactor `normalizeDefinition()` to read `defaultProps` from the registered metadata for each field type.
- Apply defaults generically rather than handling specific properties such as `width` and `optionLayout` one at a time.
- Preserve values explicitly supplied in source definitions; registry defaults only fill missing properties.
- Continue normalizing nested fields, including fields inside sections, using the same default-hydration behavior.
- Add `inputType: 'string'` to the text field's registry defaults so text fields always have a concrete input type after normalization.
- Remove local `inputType` fallback handling from builder and field rendering components.
- Remove local `sectionCollapse` fallback handling from the edit panel and section renderer.
- Update `SectionField` test definitions to include the normalized section-collapse value where the component is tested directly.
- Expand core normalization tests to verify generic registry defaults are materialized correctly.

## Breaking Changes

None expected for consumers that use normalized definitions.

Code that intentionally inspects pre-normalized field definitions may now observe explicit default properties where those values were previously `undefined`. Explicitly supplied field values retain precedence over registry defaults.

