### PR TITLE
feat(package): notes field, activity log, and document list field

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,17 @@ Only use grep/text search first when:
 
 Before making code edits, inspect the relevant graph context first, then make the smallest safe change.
 
+## Workspace Documentation Routing
+
+Before repository exploration or implementation, check `.github/workspace-doc/` for task-specific context. Choose the narrowest relevant subfolder based on the request:
+
+- `tracker/` for implementation status, parity checklists, and verification evidence.
+- `todo/` for follow-up work and lightweight task notes.
+- `tickets/` for planned features, technical debt, and scoped implementation proposals.
+- `docs/` for architecture, workflows, domain behavior, and reference material.
+
+Read the relevant documents before relying on code inspection, and cross-reference the user's prompt against them. When a task spans concerns, consult each applicable subfolder. Update the relevant tracker, ticket, or todo in the same change when the implementation changes its status or verification evidence.
+
 ## Project Context
 
 This is a **pnpm workspace** for the **vNext** rewrite of the Questionnaire Builder packages, written in **TypeScript**.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -366,7 +366,7 @@ function getTotal(items) {
 - Keep changes local.
 - Use existing helpers and error patterns.
 - Write short, obvious code.
-- Use one local development server and reuse its existing port; restart the existing server when needed instead of starting additional servers on new ports. Only use another port when the existing server cannot be reused or the user explicitly requests it.
+- Use the pre-existing running application or development server for browser checks and reuse its URL and port.
 - Run `pnpm lint && pnpm test && pnpm typecheck && pnpm build` to verify changes.
 - **Run local CI/CD via `gh act`** — when asked to test CI/CD locally, always follow `.github/workflows/TESTING-LOCALLY.md`. The canonical command for the CI workflow is:
   ```bash
@@ -382,6 +382,7 @@ function getTotal(items) {
 - Use `any` — use `unknown` and narrow.
 - Run `git add`, `git commit`, or `git push` — never stage, commit, or push changes.
 - Do not run npm installation commands locally. Use `pnpm install --frozen-lockfile` from the repository root when dependencies need repair.
+- Do not start a local server, development server, watcher, or another server port. If the pre-existing server is unavailable, report the blocker and ask the user to start or restore it.
 
 ---
 

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,8 @@
 # semver prereleases do not satisfy @mieweb/ui's optional peer range ">=0.0.2",
 # which makes npm ci fail with ERESOLVE. Remove once packages are stable releases.
 legacy-peer-deps=true
+
+# Link workspace packages (pnpm v10 defaults to false): cross-package changes
+# (new @esheet/core types, new @esheet/fields exports) must resolve to the
+# workspace source, not the last published registry tarball.
+link-workspace-packages=true

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -19,6 +19,7 @@
     "@esheet/field-kerebron": "workspace:*",
     "@esheet/fields": "workspace:*",
     "@esheet/renderer": "workspace:*",
+    "@kerebron/wasm": "^0.8.10",
     "@mieweb/ui": "0.7.1",
     "js-yaml": "^5.2.3",
     "lucide-react": "^1.31.0",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -19,7 +19,6 @@
     "@esheet/field-kerebron": "workspace:*",
     "@esheet/fields": "workspace:*",
     "@esheet/renderer": "workspace:*",
-    "@kerebron/wasm": "^0.8.9",
     "@mieweb/ui": "0.7.1",
     "js-yaml": "^5.2.3",
     "lucide-react": "^1.31.0",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -14,6 +14,7 @@
     "@esheet/adapters": "workspace:*",
     "@esheet/builder": "workspace:*",
     "@esheet/core": "workspace:*",
+    "@esheet/document-list-field": "workspace:*",
     "@esheet/field-health": "workspace:*",
     "@esheet/field-kerebron": "workspace:*",
     "@esheet/fields": "workspace:*",

--- a/apps/demo/src/document-list-demo-repository.ts
+++ b/apps/demo/src/document-list-demo-repository.ts
@@ -1,0 +1,158 @@
+import type {
+  DocumentListDocument,
+  DocumentListRepository,
+  DocumentListRepositoryContext,
+  DocumentListSnapshot,
+} from '@esheet/document-list-field';
+
+interface DemoDocumentBucket {
+  readonly documents: Map<string, DocumentListDocument>;
+  readonly listeners: Set<(snapshot: DocumentListSnapshot) => void>;
+  revision: number;
+  seeded: boolean;
+}
+
+export interface DemoDocumentListRepository extends DocumentListRepository {
+  readonly setFile: (documentId: string, file: File) => void;
+}
+
+let nextDemoDocumentId = 1;
+
+function createDemoDocumentId(): string {
+  const id = `demo-created-${nextDemoDocumentId}`;
+  nextDemoDocumentId += 1;
+  return id;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function documentFromUploadedFile(file: File): DocumentListDocument {
+  const id = createDemoDocumentId();
+  return {
+    id,
+    date: today(),
+    title: file.name,
+    subject: 'Uploaded in the eSheet demo',
+    docType: file.type || 'Uploaded document',
+    docId: id,
+    source: 'Demo upload',
+    file: file.name,
+  };
+}
+
+export function createComposedDemoDocument(): DocumentListDocument {
+  const id = createDemoDocumentId();
+  return {
+    id,
+    date: today(),
+    title: 'Composed demo document',
+    subject: 'Created in the eSheet demo',
+    docType: 'Demo document',
+    docId: id,
+    source: 'Demo compose',
+    file: `${id}.txt`,
+  };
+}
+
+function bucketKey(context: DocumentListRepositoryContext): string {
+  return `${context.formInstanceId}:${context.fieldId}`;
+}
+
+function createBucket(): DemoDocumentBucket {
+  return {
+    documents: new Map(),
+    listeners: new Set(),
+    revision: 0,
+    seeded: false,
+  };
+}
+
+function snapshot(bucket: DemoDocumentBucket): DocumentListSnapshot {
+  return {
+    documents: [...bucket.documents.values()],
+    revision: String(bucket.revision),
+  };
+}
+
+function assertNotAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw new DOMException('Operation aborted', 'AbortError');
+}
+
+export function createDemoDocumentListRepository(): DemoDocumentListRepository {
+  const buckets = new Map<string, DemoDocumentBucket>();
+  const files = new Map<string, File>();
+
+  const getBucket = (
+    context: DocumentListRepositoryContext
+  ): DemoDocumentBucket => {
+    const key = bucketKey(context);
+    const existing = buckets.get(key);
+    if (existing) return existing;
+    const created = createBucket();
+    buckets.set(key, created);
+    return created;
+  };
+
+  const notify = (bucket: DemoDocumentBucket): void => {
+    const nextSnapshot = snapshot(bucket);
+    for (const listener of bucket.listeners) listener(nextSnapshot);
+  };
+
+  return {
+    seed: (context, initialSnapshot) => {
+      const bucket = getBucket(context);
+      if (bucket.seeded) return;
+      for (const document of initialSnapshot.documents)
+        bucket.documents.set(document.id, document);
+      bucket.seeded = true;
+    },
+
+    load: async (context, signal) => {
+      assertNotAborted(signal);
+      return snapshot(getBucket(context));
+    },
+
+    save: async (context, document, signal) => {
+      assertNotAborted(signal);
+      const bucket = getBucket(context);
+      bucket.documents.set(document.id, document);
+      bucket.revision += 1;
+      notify(bucket);
+      return document;
+    },
+
+    remove: async (context, documentId, signal) => {
+      assertNotAborted(signal);
+      const bucket = getBucket(context);
+      bucket.documents.delete(documentId);
+      files.delete(documentId);
+      bucket.revision += 1;
+      notify(bucket);
+    },
+
+    loadContent: async (context, document, signal) => {
+      assertNotAborted(signal);
+      const file = files.get(document.id);
+      if (!file) {
+        return { reference: document.file };
+      }
+      return {
+        reference: file.name,
+        contentType: file.type || 'application/octet-stream',
+        size: file.size,
+      };
+    },
+
+    subscribe: (context, onSnapshot) => {
+      const bucket = getBucket(context);
+      bucket.listeners.add(onSnapshot);
+      return () => bucket.listeners.delete(onSnapshot);
+    },
+
+    setFile: (documentId, file) => {
+      files.set(documentId, file);
+    },
+  };
+}

--- a/apps/demo/src/document-list-demo-repository.ts
+++ b/apps/demo/src/document-list-demo-repository.ts
@@ -1,4 +1,6 @@
 import type {
+  DocumentListContent,
+  DocumentListContentInput,
   DocumentListDocument,
   DocumentListRepository,
   DocumentListRepositoryContext,
@@ -7,53 +9,10 @@ import type {
 
 interface DemoDocumentBucket {
   readonly documents: Map<string, DocumentListDocument>;
+  readonly contents: Map<string, DocumentListContentInput>;
   readonly listeners: Set<(snapshot: DocumentListSnapshot) => void>;
   revision: number;
   seeded: boolean;
-}
-
-export interface DemoDocumentListRepository extends DocumentListRepository {
-  readonly setFile: (documentId: string, file: File) => void;
-}
-
-let nextDemoDocumentId = 1;
-
-function createDemoDocumentId(): string {
-  const id = `demo-created-${nextDemoDocumentId}`;
-  nextDemoDocumentId += 1;
-  return id;
-}
-
-function today(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-export function documentFromUploadedFile(file: File): DocumentListDocument {
-  const id = createDemoDocumentId();
-  return {
-    id,
-    date: today(),
-    title: file.name,
-    subject: 'Uploaded in the eSheet demo',
-    docType: file.type || 'Uploaded document',
-    docId: id,
-    source: 'Demo upload',
-    file: file.name,
-  };
-}
-
-export function createComposedDemoDocument(): DocumentListDocument {
-  const id = createDemoDocumentId();
-  return {
-    id,
-    date: today(),
-    title: 'Composed demo document',
-    subject: 'Created in the eSheet demo',
-    docType: 'Demo document',
-    docId: id,
-    source: 'Demo compose',
-    file: `${id}.txt`,
-  };
 }
 
 function bucketKey(context: DocumentListRepositoryContext): string {
@@ -63,6 +22,7 @@ function bucketKey(context: DocumentListRepositoryContext): string {
 function createBucket(): DemoDocumentBucket {
   return {
     documents: new Map(),
+    contents: new Map(),
     listeners: new Set(),
     revision: 0,
     seeded: false,
@@ -80,9 +40,8 @@ function assertNotAborted(signal: AbortSignal): void {
   if (signal.aborted) throw new DOMException('Operation aborted', 'AbortError');
 }
 
-export function createDemoDocumentListRepository(): DemoDocumentListRepository {
+export function createDemoDocumentListRepository(): DocumentListRepository {
   const buckets = new Map<string, DemoDocumentBucket>();
-  const files = new Map<string, File>();
 
   const getBucket = (
     context: DocumentListRepositoryContext
@@ -114,10 +73,11 @@ export function createDemoDocumentListRepository(): DemoDocumentListRepository {
       return snapshot(getBucket(context));
     },
 
-    save: async (context, document, signal) => {
+    save: async (context, document, signal, content) => {
       assertNotAborted(signal);
       const bucket = getBucket(context);
       bucket.documents.set(document.id, document);
+      if (content) bucket.contents.set(document.id, content);
       bucket.revision += 1;
       notify(bucket);
       return document;
@@ -127,21 +87,49 @@ export function createDemoDocumentListRepository(): DemoDocumentListRepository {
       assertNotAborted(signal);
       const bucket = getBucket(context);
       bucket.documents.delete(documentId);
-      files.delete(documentId);
+      bucket.contents.delete(documentId);
       bucket.revision += 1;
       notify(bucket);
     },
 
-    loadContent: async (context, document, signal) => {
+    loadContent: async (
+      context,
+      document,
+      signal
+    ): Promise<DocumentListContent> => {
       assertNotAborted(signal);
-      const file = files.get(document.id);
-      if (!file) {
+      const savedContent = getBucket(context).contents.get(document.id);
+      if (!savedContent) {
         return { reference: document.file };
       }
+      const contentType =
+        savedContent.contentType ||
+        (typeof savedContent.content === 'string'
+          ? 'text/plain'
+          : savedContent.content.type || 'application/octet-stream');
+      const size =
+        savedContent.size ??
+        (typeof savedContent.content === 'string'
+          ? new Blob([savedContent.content]).size
+          : savedContent.content.size);
+      if (typeof savedContent.content === 'string') {
+        return { text: savedContent.content, contentType, size };
+      }
+      if (contentType.startsWith('text/')) {
+        return {
+          text: await savedContent.content.text(),
+          contentType,
+          size,
+        };
+      }
+      if (contentType.startsWith('image/')) {
+        const reference = URL.createObjectURL(savedContent.content);
+        return { reference, contentType, size };
+      }
       return {
-        reference: file.name,
-        contentType: file.type || 'application/octet-stream',
-        size: file.size,
+        reference: document.file,
+        contentType,
+        size,
       };
     },
 
@@ -149,10 +137,6 @@ export function createDemoDocumentListRepository(): DemoDocumentListRepository {
       const bucket = getBucket(context);
       bucket.listeners.add(onSnapshot);
       return () => bucket.listeners.delete(onSnapshot);
-    },
-
-    setFile: (documentId, file) => {
-      files.set(documentId, file);
     },
   };
 }

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -6,10 +6,12 @@ import {
   configureRichTextField,
 } from '@esheet/field-kerebron';
 import { registerHealthFieldTypes } from '@esheet/field-health';
+import { registerDocumentListFieldType } from '@esheet/document-list-field';
 import { createAssetLoad } from '@kerebron/wasm/web';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { ToastContainer, ToastProvider, useToast } from '@mieweb/ui';
 import { LandingPage } from './views/LandingPage';
 import { BuilderView } from './views/BuilderView';
 import { RendererView } from './views/RendererView';
@@ -22,6 +24,7 @@ registerFieldComponents({ richtext: RichTextEditorField });
 registerHealthFieldTypes({
   indexUrl: `${import.meta.env.BASE_URL}codify`.replace(/\/$/, ''),
 });
+registerDocumentListFieldType();
 
 // The Vite plugin serves and emits these assets from the installed package.
 configureRichTextField({
@@ -32,24 +35,32 @@ configureRichTextField({
 
 function App() {
   return (
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <BrandInitializer />
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <>
-              <Navbar />
-              <LandingPage />
-            </>
-          }
-        />
-        <Route path="/builder" element={<BuilderView />} />
-        <Route path="/renderer" element={<RendererView />} />
-        <Route path="/collab-live" element={<CollabPlaygroundView />} />
-      </Routes>
-    </BrowserRouter>
+    <ToastProvider>
+      <DemoToastContainer />
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <BrandInitializer />
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <>
+                <Navbar />
+                <LandingPage />
+              </>
+            }
+          />
+          <Route path="/builder" element={<BuilderView />} />
+          <Route path="/renderer" element={<RendererView />} />
+          <Route path="/collab-live" element={<CollabPlaygroundView />} />
+        </Routes>
+      </BrowserRouter>
+    </ToastProvider>
   );
+}
+
+function DemoToastContainer() {
+  const { toasts, dismiss } = useToast();
+  return <ToastContainer toasts={toasts} onDismiss={dismiss} />;
 }
 
 const root = ReactDOM.createRoot(

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -1,9 +1,16 @@
 import './styles.css';
 import './ozwell-setup.js';
 import { registerFieldComponents } from '@esheet/fields';
-import { RichTextEditorField } from '@esheet/field-kerebron';
+import {
+  configureRichTextField,
+  RichTextEditorField,
+} from '@esheet/field-kerebron';
 import { registerHealthFieldTypes } from '@esheet/field-health';
-import { registerDocumentListFieldType } from '@esheet/document-list-field';
+import {
+  configureDocumentListComposeEditor,
+  registerDocumentListFieldType,
+} from '@esheet/document-list-field';
+import { createAssetLoad } from '@kerebron/wasm/web';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
@@ -21,6 +28,12 @@ registerHealthFieldTypes({
   indexUrl: `${import.meta.env.BASE_URL}codify`.replace(/\/$/, ''),
 });
 registerDocumentListFieldType();
+
+const kerebronAssetLoad = createAssetLoad(
+  `${import.meta.env.BASE_URL}kerebron-wasm`.replace(/\/\//g, '/')
+);
+configureRichTextField({ assetLoad: kerebronAssetLoad });
+configureDocumentListComposeEditor({ assetLoad: kerebronAssetLoad });
 
 function App() {
   return (

--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -1,13 +1,9 @@
 import './styles.css';
 import './ozwell-setup.js';
 import { registerFieldComponents } from '@esheet/fields';
-import {
-  RichTextEditorField,
-  configureRichTextField,
-} from '@esheet/field-kerebron';
+import { RichTextEditorField } from '@esheet/field-kerebron';
 import { registerHealthFieldTypes } from '@esheet/field-health';
 import { registerDocumentListFieldType } from '@esheet/document-list-field';
-import { createAssetLoad } from '@kerebron/wasm/web';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
@@ -25,13 +21,6 @@ registerHealthFieldTypes({
   indexUrl: `${import.meta.env.BASE_URL}codify`.replace(/\/$/, ''),
 });
 registerDocumentListFieldType();
-
-// The Vite plugin serves and emits these assets from the installed package.
-configureRichTextField({
-  assetLoad: createAssetLoad(
-    `${import.meta.env.BASE_URL}kerebron-wasm`.replace(/\/\//g, '/')
-  ),
-});
 
 function App() {
   return (

--- a/apps/demo/src/schemas/document-list.yaml
+++ b/apps/demo/src/schemas/document-list.yaml
@@ -33,3 +33,11 @@ pages:
             docId: '1821'
             source: Internal
             file: browser
+  - id: empty-documents-page
+    title: Empty Documents
+    fields:
+      - id: empty-documents
+        fieldType: documentList
+        question: No documents yet
+        width: full
+        documents: []

--- a/apps/demo/src/schemas/document-list.yaml
+++ b/apps/demo/src/schemas/document-list.yaml
@@ -1,0 +1,35 @@
+id: document-list-demo
+title: Document List Demo
+pages:
+  - id: documents-page
+    title: Documents
+    fields:
+      - id: documents
+        fieldType: documentList
+        question: Patient documents
+        width: full
+        documents:
+          - id: demo-doc-1
+            date: '2026-08-18'
+            title: Hearing Test Results Letter
+            subject: Annual hearing screening
+            docType: Employee Letter
+            docId: '1842'
+            source: WebChart
+            file: 1842.pdf
+          - id: demo-doc-2
+            date: '2026-08-12'
+            title: Occupational Audiogram
+            subject: Audiometric test results
+            docType: Audiometric Test
+            docId: '1836'
+            source: Clinic interface
+            file: 1836.html
+          - id: demo-doc-3
+            date: '2026-07-31'
+            title: Referral note
+            subject: Follow-up requested
+            docType: Clinical Note
+            docId: '1821'
+            source: Internal
+            file: browser

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -1,21 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   EsheetBuilder,
   useBuilderMcpToolHandler,
   type FormDefinition,
 } from '@esheet/builder';
-import {
-  createDocumentListFieldProvider,
-  type DocumentListRuntimeState,
-} from '@esheet/document-list-field';
-import { useToast } from '@mieweb/ui';
+import { createDocumentListFieldProvider } from '@esheet/document-list-field';
 import { Navbar } from '../components/Navbar.js';
 import { updateOzwellTools, FORMIE_KEY } from '../ozwell-setup.js';
-import {
-  createComposedDemoDocument,
-  createDemoDocumentListRepository,
-  documentFromUploadedFile,
-} from '../document-list-demo-repository.js';
+import { createDemoDocumentListRepository } from '../document-list-demo-repository.js';
 
 const INITIAL_DEF: FormDefinition = {
   id: 'demo-builder',
@@ -83,14 +75,10 @@ const INITIAL_DEF: FormDefinition = {
 };
 
 export function BuilderView() {
-  const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
-  const uploadInputRef = useRef<HTMLInputElement>(null);
-  const activeRuntimeRef = useRef<DocumentListRuntimeState | null>(null);
   const documentRepository = useMemo(
     () => createDemoDocumentListRepository(),
     []
   );
-  const { info } = useToast();
 
   useEffect(() => {
     updateOzwellTools(FORMIE_KEY);
@@ -100,69 +88,8 @@ export function BuilderView() {
     eventName: 'ozwell-tool-call',
   });
 
-  const handleUpload = (runtime: DocumentListRuntimeState) => {
-    activeRuntimeRef.current = runtime;
-    info('Choose a document to upload.', { title: 'Upload button clicked' });
-    uploadInputRef.current?.click();
-  };
-
-  const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    const runtime = activeRuntimeRef.current;
-    if (file && runtime) {
-      const document = documentFromUploadedFile(file);
-      documentRepository.setFile(document.id, file);
-      void runtime
-        .saveDocument(document)
-        .then(() => info(`${file.name} uploaded.`, { title: 'Upload' }))
-        .catch(() =>
-          info(`Could not upload ${file.name}.`, { title: 'Upload' })
-        );
-    }
-    activeRuntimeRef.current = null;
-    event.target.value = '';
-  };
-
-  const handleCompose = (runtime: DocumentListRuntimeState) => {
-    const document = createComposedDemoDocument();
-    void runtime
-      .saveDocument(document)
-      .then(() => info('Composed demo document added.', { title: 'Compose' }))
-      .catch(() =>
-        info('Could not compose the document.', { title: 'Compose' })
-      );
-  };
-
   const documentListProvider = createDocumentListFieldProvider(
-    {
-      detailRowsExpanded,
-      onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
-      onCompose: handleCompose,
-      onUpload: handleUpload,
-      renderDetailRow: (row) => (
-        <div className="document-list-demo__detail px-4 py-3">
-          <strong className="block text-sm">{row.title}</strong>
-          <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
-            <div>
-              <dt className="font-medium">Date</dt>
-              <dd>{row.date}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Subject</dt>
-              <dd>{row.subject}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Document type</dt>
-              <dd>{row.docType}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Source</dt>
-              <dd>{row.source}</dd>
-            </div>
-          </dl>
-        </div>
-      ),
-    },
+    {},
     { repository: documentRepository }
   );
 
@@ -178,14 +105,6 @@ export function BuilderView() {
             fieldProviders={[documentListProvider]}
           />
         </div>
-        <input
-          ref={uploadInputRef}
-          id="document-list-demo-upload"
-          type="file"
-          aria-label="Select a document to upload"
-          className="hidden"
-          onChange={handleUploadChange}
-        />
       </div>
     </div>
   );

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -1,13 +1,21 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   EsheetBuilder,
   useBuilderMcpToolHandler,
   type FormDefinition,
 } from '@esheet/builder';
-import { createDocumentListFieldProvider } from '@esheet/document-list-field';
+import {
+  createDocumentListFieldProvider,
+  type DocumentListRuntimeState,
+} from '@esheet/document-list-field';
 import { useToast } from '@mieweb/ui';
 import { Navbar } from '../components/Navbar.js';
 import { updateOzwellTools, FORMIE_KEY } from '../ozwell-setup.js';
+import {
+  createComposedDemoDocument,
+  createDemoDocumentListRepository,
+  documentFromUploadedFile,
+} from '../document-list-demo-repository.js';
 
 const INITIAL_DEF: FormDefinition = {
   id: 'demo-builder',
@@ -77,6 +85,11 @@ const INITIAL_DEF: FormDefinition = {
 export function BuilderView() {
   const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const activeRuntimeRef = useRef<DocumentListRuntimeState | null>(null);
+  const documentRepository = useMemo(
+    () => createDemoDocumentListRepository(),
+    []
+  );
   const { info } = useToast();
 
   useEffect(() => {
@@ -87,49 +100,71 @@ export function BuilderView() {
     eventName: 'ozwell-tool-call',
   });
 
-  const handleUpload = () => {
+  const handleUpload = (runtime: DocumentListRuntimeState) => {
+    activeRuntimeRef.current = runtime;
     info('Choose a document to upload.', { title: 'Upload button clicked' });
     uploadInputRef.current?.click();
   };
 
   const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) info(`${file.name} would be uploaded.`, { title: 'Upload' });
+    const runtime = activeRuntimeRef.current;
+    if (file && runtime) {
+      const document = documentFromUploadedFile(file);
+      documentRepository.setFile(document.id, file);
+      void runtime
+        .saveDocument(document)
+        .then(() => info(`${file.name} uploaded.`, { title: 'Upload' }))
+        .catch(() =>
+          info(`Could not upload ${file.name}.`, { title: 'Upload' })
+        );
+    }
+    activeRuntimeRef.current = null;
     event.target.value = '';
   };
 
-  const documentListProvider = createDocumentListFieldProvider({
-    detailRowsExpanded,
-    onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
-    onCompose: () =>
-      info('Your functionality goes here. Compose button clicked.', {
-        title: 'Compose',
-      }),
-    onUpload: handleUpload,
-    renderDetailRow: (row) => (
-      <div className="document-list-demo__detail px-4 py-3">
-        <strong className="block text-sm">{row.title}</strong>
-        <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
-          <div>
-            <dt className="font-medium">Date</dt>
-            <dd>{row.date}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Subject</dt>
-            <dd>{row.subject}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Document type</dt>
-            <dd>{row.docType}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Source</dt>
-            <dd>{row.source}</dd>
-          </div>
-        </dl>
-      </div>
-    ),
-  });
+  const handleCompose = (runtime: DocumentListRuntimeState) => {
+    const document = createComposedDemoDocument();
+    void runtime
+      .saveDocument(document)
+      .then(() => info('Composed demo document added.', { title: 'Compose' }))
+      .catch(() =>
+        info('Could not compose the document.', { title: 'Compose' })
+      );
+  };
+
+  const documentListProvider = createDocumentListFieldProvider(
+    {
+      detailRowsExpanded,
+      onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
+      onCompose: handleCompose,
+      onUpload: handleUpload,
+      renderDetailRow: (row) => (
+        <div className="document-list-demo__detail px-4 py-3">
+          <strong className="block text-sm">{row.title}</strong>
+          <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
+            <div>
+              <dt className="font-medium">Date</dt>
+              <dd>{row.date}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Subject</dt>
+              <dd>{row.subject}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Document type</dt>
+              <dd>{row.docType}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Source</dt>
+              <dd>{row.source}</dd>
+            </div>
+          </dl>
+        </div>
+      ),
+    },
+    { repository: documentRepository }
+  );
 
   return (
     <div className="demo-builder-view w-full h-screen flex flex-col">

--- a/apps/demo/src/views/BuilderView.tsx
+++ b/apps/demo/src/views/BuilderView.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   EsheetBuilder,
   useBuilderMcpToolHandler,
   type FormDefinition,
 } from '@esheet/builder';
+import { createDocumentListFieldProvider } from '@esheet/document-list-field';
+import { useToast } from '@mieweb/ui';
 import { Navbar } from '../components/Navbar.js';
 import { updateOzwellTools, FORMIE_KEY } from '../ozwell-setup.js';
 
@@ -38,18 +40,95 @@ const INITIAL_DEF: FormDefinition = {
         } as unknown as NonNullable<
           FormDefinition['pages'][number]['fields']
         >[number],
+        {
+          id: 'q5',
+          fieldType: 'documentList',
+          question: 'Documents',
+          documents: [
+            {
+              id: 'builder-doc-1',
+              date: '2026-08-18',
+              title: 'Hearing Test Results Letter',
+              subject: 'Annual hearing screening',
+              docType: 'Employee Letter',
+              docId: '1842',
+              source: 'WebChart',
+              file: '1842.pdf',
+            },
+            {
+              id: 'builder-doc-2',
+              date: '2026-08-12',
+              title: 'Occupational Audiogram',
+              subject: 'Audiometric test results',
+              docType: 'Audiometric Test',
+              docId: '1836',
+              source: 'Clinic interface',
+              file: '1836.html',
+            },
+          ],
+        } as unknown as NonNullable<
+          FormDefinition['pages'][number]['fields']
+        >[number],
       ],
     },
   ],
 };
 
 export function BuilderView() {
+  const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const { info } = useToast();
+
   useEffect(() => {
     updateOzwellTools(FORMIE_KEY);
   }, []);
 
   const onBuilderToolsReady = useBuilderMcpToolHandler({
     eventName: 'ozwell-tool-call',
+  });
+
+  const handleUpload = () => {
+    info('Choose a document to upload.', { title: 'Upload button clicked' });
+    uploadInputRef.current?.click();
+  };
+
+  const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) info(`${file.name} would be uploaded.`, { title: 'Upload' });
+    event.target.value = '';
+  };
+
+  const documentListProvider = createDocumentListFieldProvider({
+    detailRowsExpanded,
+    onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
+    onCompose: () =>
+      info('Your functionality goes here. Compose button clicked.', {
+        title: 'Compose',
+      }),
+    onUpload: handleUpload,
+    renderDetailRow: (row) => (
+      <div className="document-list-demo__detail px-4 py-3">
+        <strong className="block text-sm">{row.title}</strong>
+        <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
+          <div>
+            <dt className="font-medium">Date</dt>
+            <dd>{row.date}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Subject</dt>
+            <dd>{row.subject}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Document type</dt>
+            <dd>{row.docType}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Source</dt>
+            <dd>{row.source}</dd>
+          </div>
+        </dl>
+      </div>
+    ),
   });
 
   return (
@@ -61,8 +140,17 @@ export function BuilderView() {
             definition={INITIAL_DEF}
             onBuilderToolsReady={onBuilderToolsReady}
             allowDangerousJS={true}
+            fieldProviders={[documentListProvider]}
           />
         </div>
+        <input
+          ref={uploadInputRef}
+          id="document-list-demo-upload"
+          type="file"
+          aria-label="Select a document to upload"
+          className="hidden"
+          onChange={handleUploadChange}
+        />
       </div>
     </div>
   );

--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { load } from 'js-yaml';
 import {
   EsheetRenderer,
@@ -6,7 +6,10 @@ import {
   useRendererMcpToolHandler,
   type ResponseFormat,
 } from '@esheet/renderer';
-import { createDocumentListFieldProvider } from '@esheet/document-list-field';
+import {
+  createDocumentListFieldProvider,
+  type DocumentListRuntimeState,
+} from '@esheet/document-list-field';
 import { Navbar } from '../components/Navbar';
 import {
   Alert,
@@ -35,6 +38,11 @@ import {
 } from '@mieweb/ui';
 import { ClipboardList, SlidersHorizontal, Smartphone } from 'lucide-react';
 import { updateOzwellTools, FLOWIE_KEY } from '../ozwell-setup.js';
+import {
+  createComposedDemoDocument,
+  createDemoDocumentListRepository,
+  documentFromUploadedFile,
+} from '../document-list-demo-repository.js';
 
 interface SubmitResult {
   readonly kind: 'success' | 'error';
@@ -114,6 +122,11 @@ export function RendererView() {
   const [pasteError, setPasteError] = useState<string | null>(null);
   const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const activeRuntimeRef = useRef<DocumentListRuntimeState | null>(null);
+  const documentRepository = useMemo(
+    () => createDemoDocumentListRepository(),
+    []
+  );
   const { info } = useToast();
 
   const resetFormKey = useCallback(() => {
@@ -213,47 +226,68 @@ export function RendererView() {
   };
 
   const hasForm = rawInput != null;
-  const handleUpload = () => {
+  const handleUpload = (runtime: DocumentListRuntimeState) => {
+    activeRuntimeRef.current = runtime;
     info('Choose a document to upload.', { title: 'Upload button clicked' });
     uploadInputRef.current?.click();
   };
   const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) info(`${file.name} would be uploaded.`, { title: 'Upload' });
+    const runtime = activeRuntimeRef.current;
+    if (file && runtime) {
+      const document = documentFromUploadedFile(file);
+      documentRepository.setFile(document.id, file);
+      void runtime
+        .saveDocument(document)
+        .then(() => info(`${file.name} uploaded.`, { title: 'Upload' }))
+        .catch(() =>
+          info(`Could not upload ${file.name}.`, { title: 'Upload' })
+        );
+    }
+    activeRuntimeRef.current = null;
     event.target.value = '';
   };
-  const documentListProvider = createDocumentListFieldProvider({
-    detailRowsExpanded,
-    onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
-    onCompose: () =>
-      info('Your functionality goes here. Compose button clicked.', {
-        title: 'Compose',
-      }),
-    onUpload: handleUpload,
-    renderDetailRow: (row) => (
-      <div className="document-list-demo__detail px-4 py-3">
-        <strong className="block text-sm">{row.title}</strong>
-        <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
-          <div>
-            <dt className="font-medium">Date</dt>
-            <dd>{row.date}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Subject</dt>
-            <dd>{row.subject}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Document type</dt>
-            <dd>{row.docType}</dd>
-          </div>
-          <div>
-            <dt className="font-medium">Source</dt>
-            <dd>{row.source}</dd>
-          </div>
-        </dl>
-      </div>
-    ),
-  });
+  const handleCompose = (runtime: DocumentListRuntimeState) => {
+    const document = createComposedDemoDocument();
+    void runtime
+      .saveDocument(document)
+      .then(() => info('Composed demo document added.', { title: 'Compose' }))
+      .catch(() =>
+        info('Could not compose the document.', { title: 'Compose' })
+      );
+  };
+  const documentListProvider = createDocumentListFieldProvider(
+    {
+      detailRowsExpanded,
+      onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
+      onCompose: handleCompose,
+      onUpload: handleUpload,
+      renderDetailRow: (row) => (
+        <div className="document-list-demo__detail px-4 py-3">
+          <strong className="block text-sm">{row.title}</strong>
+          <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
+            <div>
+              <dt className="font-medium">Date</dt>
+              <dd>{row.date}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Subject</dt>
+              <dd>{row.subject}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Document type</dt>
+              <dd>{row.docType}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Source</dt>
+              <dd>{row.source}</dd>
+            </div>
+          </dl>
+        </div>
+      ),
+    },
+    { repository: documentRepository }
+  );
 
   return (
     <>

--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -6,6 +6,7 @@ import {
   useRendererMcpToolHandler,
   type ResponseFormat,
 } from '@esheet/renderer';
+import { createDocumentListFieldProvider } from '@esheet/document-list-field';
 import { Navbar } from '../components/Navbar';
 import {
   Alert,
@@ -30,6 +31,7 @@ import {
   TabsList,
   TabsTrigger,
   Textarea,
+  useToast,
 } from '@mieweb/ui';
 import { ClipboardList, SlidersHorizontal, Smartphone } from 'lucide-react';
 import { updateOzwellTools, FLOWIE_KEY } from '../ozwell-setup.js';
@@ -110,6 +112,9 @@ export function RendererView() {
   const [pasteOpen, setPasteOpen] = useState(false);
   const [pasteText, setPasteText] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
+  const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const { info } = useToast();
 
   const resetFormKey = useCallback(() => {
     setFormKey((prev) => prev + 1);
@@ -208,6 +213,47 @@ export function RendererView() {
   };
 
   const hasForm = rawInput != null;
+  const handleUpload = () => {
+    info('Choose a document to upload.', { title: 'Upload button clicked' });
+    uploadInputRef.current?.click();
+  };
+  const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) info(`${file.name} would be uploaded.`, { title: 'Upload' });
+    event.target.value = '';
+  };
+  const documentListProvider = createDocumentListFieldProvider({
+    detailRowsExpanded,
+    onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
+    onCompose: () =>
+      info('Your functionality goes here. Compose button clicked.', {
+        title: 'Compose',
+      }),
+    onUpload: handleUpload,
+    renderDetailRow: (row) => (
+      <div className="document-list-demo__detail px-4 py-3">
+        <strong className="block text-sm">{row.title}</strong>
+        <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
+          <div>
+            <dt className="font-medium">Date</dt>
+            <dd>{row.date}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Subject</dt>
+            <dd>{row.subject}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Document type</dt>
+            <dd>{row.docType}</dd>
+          </div>
+          <div>
+            <dt className="font-medium">Source</dt>
+            <dd>{row.source}</dd>
+          </div>
+        </dl>
+      </div>
+    ),
+  });
 
   return (
     <>
@@ -219,6 +265,14 @@ export function RendererView() {
         accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml"
         onChange={handleFileImport}
         className="hidden"
+      />
+      <input
+        ref={uploadInputRef}
+        id="renderer-document-upload"
+        type="file"
+        aria-label="Select a document to upload"
+        className="hidden"
+        onChange={handleUploadChange}
       />
 
       <Tabs
@@ -383,6 +437,7 @@ export function RendererView() {
                       bottomNavigation={bottomNavigation}
                       validateNavigation={validateNavigation}
                       onRendererToolsReady={onRendererToolsReady}
+                      fieldProviders={[documentListProvider]}
                       onReady={() => {
                         const def = rendererRef.current
                           ?.getFormStore()

--- a/apps/demo/src/views/RendererView.tsx
+++ b/apps/demo/src/views/RendererView.tsx
@@ -6,10 +6,7 @@ import {
   useRendererMcpToolHandler,
   type ResponseFormat,
 } from '@esheet/renderer';
-import {
-  createDocumentListFieldProvider,
-  type DocumentListRuntimeState,
-} from '@esheet/document-list-field';
+import { createDocumentListFieldProvider } from '@esheet/document-list-field';
 import { Navbar } from '../components/Navbar';
 import {
   Alert,
@@ -34,15 +31,10 @@ import {
   TabsList,
   TabsTrigger,
   Textarea,
-  useToast,
 } from '@mieweb/ui';
 import { ClipboardList, SlidersHorizontal, Smartphone } from 'lucide-react';
 import { updateOzwellTools, FLOWIE_KEY } from '../ozwell-setup.js';
-import {
-  createComposedDemoDocument,
-  createDemoDocumentListRepository,
-  documentFromUploadedFile,
-} from '../document-list-demo-repository.js';
+import { createDemoDocumentListRepository } from '../document-list-demo-repository.js';
 
 interface SubmitResult {
   readonly kind: 'success' | 'error';
@@ -120,14 +112,10 @@ export function RendererView() {
   const [pasteOpen, setPasteOpen] = useState(false);
   const [pasteText, setPasteText] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
-  const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
-  const uploadInputRef = useRef<HTMLInputElement>(null);
-  const activeRuntimeRef = useRef<DocumentListRuntimeState | null>(null);
   const documentRepository = useMemo(
     () => createDemoDocumentListRepository(),
     []
   );
-  const { info } = useToast();
 
   const resetFormKey = useCallback(() => {
     setFormKey((prev) => prev + 1);
@@ -226,66 +214,8 @@ export function RendererView() {
   };
 
   const hasForm = rawInput != null;
-  const handleUpload = (runtime: DocumentListRuntimeState) => {
-    activeRuntimeRef.current = runtime;
-    info('Choose a document to upload.', { title: 'Upload button clicked' });
-    uploadInputRef.current?.click();
-  };
-  const handleUploadChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    const runtime = activeRuntimeRef.current;
-    if (file && runtime) {
-      const document = documentFromUploadedFile(file);
-      documentRepository.setFile(document.id, file);
-      void runtime
-        .saveDocument(document)
-        .then(() => info(`${file.name} uploaded.`, { title: 'Upload' }))
-        .catch(() =>
-          info(`Could not upload ${file.name}.`, { title: 'Upload' })
-        );
-    }
-    activeRuntimeRef.current = null;
-    event.target.value = '';
-  };
-  const handleCompose = (runtime: DocumentListRuntimeState) => {
-    const document = createComposedDemoDocument();
-    void runtime
-      .saveDocument(document)
-      .then(() => info('Composed demo document added.', { title: 'Compose' }))
-      .catch(() =>
-        info('Could not compose the document.', { title: 'Compose' })
-      );
-  };
   const documentListProvider = createDocumentListFieldProvider(
-    {
-      detailRowsExpanded,
-      onToggleDetails: () => setDetailRowsExpanded((expanded) => !expanded),
-      onCompose: handleCompose,
-      onUpload: handleUpload,
-      renderDetailRow: (row) => (
-        <div className="document-list-demo__detail px-4 py-3">
-          <strong className="block text-sm">{row.title}</strong>
-          <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-muted-foreground">
-            <div>
-              <dt className="font-medium">Date</dt>
-              <dd>{row.date}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Subject</dt>
-              <dd>{row.subject}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Document type</dt>
-              <dd>{row.docType}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Source</dt>
-              <dd>{row.source}</dd>
-            </div>
-          </dl>
-        </div>
-      ),
-    },
+    {},
     { repository: documentRepository }
   );
 
@@ -299,14 +229,6 @@ export function RendererView() {
         accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml"
         onChange={handleFileImport}
         className="hidden"
-      />
-      <input
-        ref={uploadInputRef}
-        id="renderer-document-upload"
-        type="file"
-        aria-label="Select a document to upload"
-        className="hidden"
-        onChange={handleUploadChange}
       />
 
       <Tabs

--- a/apps/demo/tsconfig.app.json
+++ b/apps/demo/tsconfig.app.json
@@ -14,6 +14,9 @@
       "@esheet/builder": ["../../packages/builder/src/index.ts"],
       "@esheet/renderer": ["../../packages/renderer/src/index.ts"],
       "@esheet/core": ["../../packages/core/src/index.ts"],
+      "@esheet/document-list-field": [
+        "../../packages/document-list-field/src/index.ts"
+      ],
       "@esheet/fields": ["../../packages/fields/src/index.ts"],
       "@esheet/adapters": ["../../packages/adapters/src/index.ts"]
     }
@@ -46,6 +49,9 @@
     },
     {
       "path": "../../packages/field-health/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/document-list-field/tsconfig.lib.json"
     },
     {
       "path": "../../packages/core/tsconfig.lib.json"

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -18,66 +18,6 @@ const prosemirrorModelPath = require.resolve('prosemirror-model', {
   ],
 });
 
-/**
- * Serves Kerebron WASM directly from its npm package during development and
- * emits the assets into production builds without creating a local copy.
- */
-function kerebronWasmPlugin(command: 'build' | 'serve'): Plugin {
-  const assetsDir = resolve(
-    import.meta.dirname,
-    'node_modules/@kerebron/wasm/assets'
-  );
-
-  function visitWasm(
-    dir: string,
-    relativePath: string,
-    visit: (path: string, relativePath: string) => void
-  ) {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const path = join(dir, entry.name);
-      const nextRelativePath = relativePath
-        ? `${relativePath}/${entry.name}`
-        : entry.name;
-      if (entry.isDirectory()) {
-        visitWasm(path, nextRelativePath, visit);
-      } else if (entry.name.endsWith('.wasm')) {
-        visit(path, nextRelativePath);
-      }
-    }
-  }
-
-  return {
-    name: 'kerebron-wasm',
-    configureServer(server) {
-      server.middlewares.use('/kerebron-wasm', (request, response, next) => {
-        const relativePath = decodeURIComponent(
-          request.url?.split('?')[0] ?? ''
-        ).replace(/^\/+/, '');
-        const assetPath = resolve(assetsDir, relativePath);
-        if (relativePath.includes('..') || !existsSync(assetPath)) {
-          next();
-          return;
-        }
-        response.setHeader('Content-Type', 'application/wasm');
-        response.end(readFileSync(assetPath));
-      });
-    },
-    ...(command === 'build'
-      ? {
-          buildStart() {
-            visitWasm(assetsDir, '', (path, relativePath) => {
-              this.emitFile({
-                type: 'asset',
-                fileName: `kerebron-wasm/${relativePath}`,
-                source: readFileSync(path),
-              });
-            });
-          },
-        }
-      : {}),
-  };
-}
-
 function codifyAssetsPlugin(
   assetsDir: string | undefined,
   command: 'build' | 'serve'
@@ -230,7 +170,6 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       react(),
       tailwindcss(),
-      kerebronWasmPlugin(command),
       codifyAssetsPlugin(
         process.env.CODIFY_ASSETS_DIR ?? env.CODIFY_ASSETS_DIR,
         command

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -18,6 +18,62 @@ const prosemirrorModelPath = require.resolve('prosemirror-model', {
   ],
 });
 
+function kerebronWasmPlugin(command: 'build' | 'serve'): Plugin {
+  const assetsDir = resolve(
+    import.meta.dirname,
+    'node_modules/@kerebron/wasm/assets'
+  );
+
+  function visitWasm(
+    dir: string,
+    relativePath: string,
+    visit: (path: string, relativePath: string) => void
+  ) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      const nextRelativePath = relativePath
+        ? `${relativePath}/${entry.name}`
+        : entry.name;
+      if (entry.isDirectory()) {
+        visitWasm(path, nextRelativePath, visit);
+      } else if (entry.name.endsWith('.wasm')) {
+        visit(path, nextRelativePath);
+      }
+    }
+  }
+
+  return {
+    name: 'kerebron-wasm',
+    configureServer(server) {
+      server.middlewares.use('/kerebron-wasm', (request, response, next) => {
+        const relativePath = decodeURIComponent(
+          request.url?.split('?')[0] ?? ''
+        ).replace(/^\/+/, '');
+        const assetPath = resolve(assetsDir, relativePath);
+        if (relativePath.includes('..') || !existsSync(assetPath)) {
+          next();
+          return;
+        }
+        response.setHeader('Content-Type', 'application/wasm');
+        response.end(readFileSync(assetPath));
+      });
+    },
+    ...(command === 'build'
+      ? {
+          buildStart() {
+            visitWasm(assetsDir, '', (path, relativePath) => {
+              this.emitFile({
+                type: 'asset',
+                fileName: `kerebron-wasm/${relativePath}`,
+                source: readFileSync(path),
+              });
+            });
+          },
+        }
+      : {}),
+  };
+}
+
 function codifyAssetsPlugin(
   assetsDir: string | undefined,
   command: 'build' | 'serve'
@@ -170,6 +226,7 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       react(),
       tailwindcss(),
+      kerebronWasmPlugin(command),
       codifyAssetsPlugin(
         process.env.CODIFY_ASSETS_DIR ?? env.CODIFY_ASSETS_DIR,
         command

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -193,6 +193,13 @@ export default defineConfig(({ command, mode }) => {
           ),
         },
         {
+          find: '@esheet/document-list-field',
+          replacement: resolve(
+            import.meta.dirname,
+            '../../packages/document-list-field/src/index.ts'
+          ),
+        },
+        {
           find: /^@mieweb\/ui$/,
           replacement: resolve(
             import.meta.dirname,

--- a/apps/docs/docs/field-types/overview.md
+++ b/apps/docs/docs/field-types/overview.md
@@ -15,7 +15,7 @@ eSheet includes 19 built-in field types across six categories, plus **Pages** â€
 | Rating       | `rating`, `ranking`, `slider`                                  |
 | Matrix       | `singlematrix`, `multimatrix`                                  |
 | Organization | `section`, `pages` (form structure)                            |
-| Rich         | `display`, `html`, `image`, `signature`, `diagram`             |
+| Rich         | `display`, `html`, `image`, `signature`, `diagram`, `notes`, `activity` |
 
 ## Built-in Fields
 
@@ -56,6 +56,8 @@ eSheet includes 19 built-in field types across six categories, plus **Pages** â€
 - [image](/docs/field-types/image)
 - [signature](/docs/field-types/signature)
 - [diagram](/docs/field-types/diagram)
+- [notes](/docs/field-types/notes) â€” journal of markdown note entries
+- [activity](/docs/field-types/activity) â€” read-only response change log
 
 ## Custom
 

--- a/apps/docs/docs/field-types/rich/activity.md
+++ b/apps/docs/docs/field-types/rich/activity.md
@@ -1,0 +1,51 @@
+---
+slug: /field-types/activity
+---
+
+# activity
+
+Read-only, append-only log of response changes over time. Include an
+`activity` field on any page (commonly its own page) and the form store fills
+it in automatically: whenever a response value changes, an entry is appended
+recording who changed what, when, and the display form of the previous and new
+values.
+
+Entries are debounced per field — consecutive changes to the same field within
+a short window (keystrokes) collapse into one entry that keeps the original
+`from` and the latest `to`. Entries are GUID-keyed and live under the reserved
+`_activity` response key, so concurrent logs union-merge exactly like notes
+(`mergeActivity` from `@esheet/core`).
+
+The field renders the log newest first and offers no mutation affordances.
+
+## Properties
+
+None beyond the base field properties (`question` is used as the heading).
+
+## Log Format (reserved `_activity` response key)
+
+```json
+{
+  "activity": [
+    {
+      "id": "8f14e45f-...-guid",
+      "at": "2026-01-01T10:00:00.000Z",
+      "author": "Dr. Demo",
+      "fieldId": "case-status",
+      "question": "Case status",
+      "from": "Open",
+      "to": "Closed"
+    }
+  ]
+}
+```
+
+`author` is stamped from the renderer `identity` prop when present.
+
+## Example
+
+```yaml
+- id: activity-log
+  fieldType: activity
+  question: Activity
+```

--- a/apps/docs/docs/field-types/rich/notes.md
+++ b/apps/docs/docs/field-types/rich/notes.md
@@ -1,0 +1,78 @@
+---
+slug: /field-types/notes
+---
+
+# notes
+
+Journal-style list of rich (markdown) note entries — progress notes,
+correspondence logs, comments. Each entry carries a stable GUID, timestamps,
+an optional author (stamped from the renderer `identity` prop), a raw-markdown
+body, and optional file attachments.
+
+Because entries are GUID-keyed, `notes[]` merges as a **set keyed by `id`**,
+not a positional array: concurrent adds from two clients union cleanly, and
+same-entry edit conflicts resolve last-writer-wins on
+`updatedAt ?? createdAt`. Hosts with CRDT bindings should call `mergeNotes`
+from `@esheet/core` when both sides changed the field.
+
+## Properties
+
+- `allowAttachments`: Allow file/image attachments per note (default `false`)
+- `accept`: Accept string for the attachment input (same semantics as `file`)
+- `maxFileSize`: Maximum attachment size in bytes
+- `maxAttachments`: Maximum attachments per note
+- `maxNotes`: Maximum number of entries
+- `sortOrder`: `newest` (default) or `oldest`
+- `entryLabel`: Label for one entry, e.g. `Note`, `Letter`, `Comment`
+  (default `Note`)
+
+`required` means the field must contain at least one entry.
+
+## Answer Format
+
+```json
+{
+  "notes": [
+    {
+      "id": "8f14e45f-...-guid",
+      "createdAt": "2026-01-01T10:00:00.000Z",
+      "updatedAt": "2026-01-02T09:00:00.000Z",
+      "author": "Dr. Demo",
+      "markdown": "Patient reports *improvement*.",
+      "attachments": [
+        { "contentType": "application/pdf", "dataUrl": "data:...", "title": "report.pdf", "size": 2048 }
+      ]
+    }
+  ]
+}
+```
+
+## Example
+
+```yaml
+- id: case-notes
+  fieldType: notes
+  question: Case notes
+  entryLabel: Note
+  allowAttachments: true
+  accept: image/*,.pdf
+  maxAttachments: 3
+  sortOrder: newest
+  required: true
+```
+
+## Authorship and edit policy
+
+Pass `identity={{ name: 'Dr. Demo' }}` to `EsheetRenderer` to stamp new
+entries' `author`; without it, entries save unstamped. Who may edit or delete
+a note is **host policy, not field policy**: the field records
+`author`/`createdAt`/`updatedAt` and respects an optional
+`canModify(note) => boolean` hook on the definition, but enforcement belongs
+server-side (the GUID-keyed shape makes rejecting non-author mutations a
+per-entry diff).
+
+## Attachments in host pipelines
+
+Hosts that externalize attachment bytes should use `collectAttachments` /
+`mapAttachments` from `@esheet/core` instead of hardcoding `fileData` — they
+traverse both file-field and notes-field attachments.

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -81,6 +81,8 @@ const sidebars = {
             'field-types/rich/image',
             'field-types/rich/signature',
             'field-types/rich/diagram',
+            'field-types/rich/notes',
+            'field-types/rich/activity',
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "dompurify@<=3.4.11": ">=3.4.12",
       "dompurify@<=3.4.10": ">=3.4.11",
       "dompurify@<3.4.9": ">=3.4.9",
-      "dompurify@<=3.4.12": ">=3.4.13"
+      "dompurify@<=3.4.12": ">=3.4.13",
+      "prosemirror-model": "1.25.9"
     },
     "ignoredBuiltDependencies": [
       "@mieweb/ui",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
       "@swc/core",
       "core-js",
       "protobufjs"
-    ]
+    ],
+    "patchedDependencies": {
+      "@kerebron/extension-menu@0.8.10": "patches/@kerebron__extension-menu@0.8.10.patch"
+    }
   }
 }

--- a/packages/adapters/src/fhir/fhir-adapter.spec.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.spec.ts
@@ -950,6 +950,56 @@ describe('importResponseFromFhir', () => {
 // ---------------------------------------------------------------------------
 
 describe('exportResponseToFhir', () => {
+  it('flattens notes entries to repeating human-readable text answers', () => {
+    const form = {
+      id: 'test',
+      pages: [
+        {
+          id: 'page-1',
+          fields: [
+            {
+              id: 'journal',
+              fieldType: 'notes' as const,
+              question: 'Case notes',
+            },
+          ],
+        },
+      ],
+    };
+
+    const answers = {
+      journal: [
+        {
+          id: 'n1',
+          createdAt: '2026-01-01T10:00:00Z',
+          author: 'Dr. Demo',
+          markdown: 'First *note*',
+          attachments: [
+            { contentType: 'application/pdf', title: 'report.pdf' },
+          ],
+        },
+        {
+          id: 'n2',
+          createdAt: '2026-01-02T10:00:00Z',
+          markdown: 'Second note',
+        },
+      ],
+    };
+
+    const response = exportResponseToFhir(form, answers, {
+      questionnaireUrl: 'test',
+    });
+
+    const answerList = response.item?.[0].answer;
+    expect(answerList).toHaveLength(2);
+    expect(answerList?.[0].valueString).toBe(
+      'Dr. Demo — 2026-01-01T10:00:00Z\nFirst *note*\n[Attachments: report.pdf]'
+    );
+    expect(answerList?.[1].valueString).toBe(
+      '2026-01-02T10:00:00Z\nSecond note'
+    );
+  });
+
   it('exports simple answers to response', () => {
     const form = {
       id: 'test',

--- a/packages/adapters/src/fhir/fhir-adapter.ts
+++ b/packages/adapters/src/fhir/fhir-adapter.ts
@@ -889,6 +889,35 @@ function convertValueToAnswers(
       ];
     }
 
+    case 'notes': {
+      // Human-readable flattening: one valueString per entry — author and
+      // timestamp header, raw markdown body, attachment titles listed.
+      // Structured FHIR round-trip for notes is a deferred follow-up.
+      const notes = Array.isArray(value)
+        ? (value as {
+            author?: string;
+            createdAt?: string;
+            markdown?: string;
+            attachments?: { title?: string; contentType?: string }[];
+          }[])
+        : [];
+      return notes.map((note) => {
+        const header = [note.author, note.createdAt]
+          .filter(Boolean)
+          .join(' — ');
+        const attachments = note.attachments?.length
+          ? `\n[Attachments: ${note.attachments
+              .map((a) => a.title ?? a.contentType ?? 'attachment')
+              .join(', ')}]`
+          : '';
+        return {
+          valueString: `${header ? `${header}\n` : ''}${
+            note.markdown ?? ''
+          }${attachments}`,
+        };
+      });
+    }
+
     default:
       return [{ valueString: String(value) }];
   }

--- a/packages/adapters/src/fhir/utils.ts
+++ b/packages/adapters/src/fhir/utils.ts
@@ -267,6 +267,10 @@ export function mapEsheetTypeToFhir(
     case 'file':
       return { type: 'attachment' };
 
+    case 'notes':
+      // One repeating text item; entry metadata is flattened into the answer.
+      return { type: 'text', repeats: true };
+
     case 'openchoice':
       return { type: 'choice', itemControl: 'open-choice' };
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -20,6 +20,7 @@ export {
   type BuilderTools,
   type FieldSummary,
 } from './lib/EsheetBuilder.js';
+export type { FieldProvider } from '@esheet/fields';
 
 export {
   FieldWrapper,

--- a/packages/builder/src/lib/EsheetBuilder.tsx
+++ b/packages/builder/src/lib/EsheetBuilder.tsx
@@ -13,7 +13,13 @@ import {
   type BuilderTools,
   type FieldSummary,
 } from './builder-tools.js';
-import { FormStoreContext, UIContext, useTouchMode } from '@esheet/fields';
+import {
+  FieldProviderStack,
+  FormStoreContext,
+  UIContext,
+  useTouchMode,
+  type FieldProvider,
+} from '@esheet/fields';
 import {
   convertSurveyJS,
   isSurveyJSSchema,
@@ -93,6 +99,8 @@ export interface EsheetBuilderProps {
   touchMode?: boolean | 'auto';
   /** Called when touch mode changes (via auto-detection or programmatic toggle). */
   onTouchModeChange?: (enabled: boolean) => void;
+  /** Optional wrappers supplied by field add-ons. */
+  fieldProviders?: readonly FieldProvider[];
 }
 
 export interface EsheetBuilderHandle {
@@ -122,6 +130,7 @@ export const EsheetBuilder = React.forwardRef<
     touchMode: touchModeProp,
     onTouchModeChange,
     allowDangerousJS = false,
+    fieldProviders,
   },
   ref
 ) {
@@ -244,72 +253,74 @@ export const EsheetBuilder = React.forwardRef<
   return (
     <FormStoreContext.Provider value={form}>
       <UIContext.Provider value={ui}>
-        <InstanceIdContext.Provider value={instanceId}>
-          <div className={rootClasses}>
-            <div className="ms:sticky ms:top-0 ms:z-40 ms:bg-msbackground">
-              <BuilderHeader allowDangerousJS={allowDangerousJS} />
-            </div>
-            {children}
-            {mode === 'build' && (
-              <div className="builder-layout ms:grid ms:min-w-0 ms:grid-cols-1 ms:lg:grid-cols-[18rem_minmax(0,1fr)_340px] ms:gap-3">
-                <aside className="panel-tools-wrap panel-tools ms:max-lg:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
-                  <ToolPanel />
-                </aside>
-                <main className="panel-canvas ms:min-w-0 ms:self-start ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-hidden ms:flex ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
-                  <Canvas form={form} ui={ui} dragEnabled={dragEnabled} />
-                  <div className="ms:max-lg:flex ms:lg:hidden ms:sticky ms:bottom-0 ms:z-20 ms:pt-2 ms:pb-3 ms:justify-center ms:pointer-events-none">
-                    <button
-                      type="button"
-                      onClick={() => setToolsModalOpen(true)}
-                      className="ms:pointer-events-auto ms:inline-flex ms:items-center ms:gap-1.5 ms:px-3.5 ms:py-2 ms:rounded-full ms:bg-mssurface/95 ms:backdrop-blur-sm ms:text-mstext ms:text-sm ms:font-semibold ms:border ms:border-msprimary/35 ms:shadow-lg ms:shadow-msprimary/10 ms:outline-none ms:focus:outline-none ms:hover:bg-mssurface ms:hover:border-msprimary/50 ms:hover:shadow-xl ms:hover:shadow-msprimary/15 ms:transition-all"
-                      aria-label="Open add field tools"
-                    >
-                      <PlusIcon className="ms:w-3.5 ms:h-3.5 ms:text-msprimary" />
-                      <span>Add field</span>
-                    </button>
-                  </div>
-                </main>
-                <aside className="panel-editor-wrap panel-editor ms:max-lg:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
-                  <EditPanel />
-                </aside>
-
-                <MobileBottomDrawer
-                  title="Add Field"
-                  open={toolsModalOpen}
-                  onClose={() => setToolsModalOpen(false)}
-                >
-                  <ToolPanel />
-                </MobileBottomDrawer>
-
-                <MobileBottomDrawer
-                  title="Edit Field"
-                  open={editModalOpen && !!selectedFieldId}
-                  onClose={() => ui.getState().setEditModalOpen(false)}
-                >
-                  <EditPanel />
-                </MobileBottomDrawer>
+        <FieldProviderStack providers={fieldProviders}>
+          <InstanceIdContext.Provider value={instanceId}>
+            <div className={rootClasses}>
+              <div className="ms:sticky ms:top-0 ms:z-40 ms:bg-msbackground">
+                <BuilderHeader allowDangerousJS={allowDangerousJS} />
               </div>
-            )}
-            {mode === 'code' && (
-              <div className="code-layout ms:flex ms:h-[calc(100dvh-12.5rem)] ms:min-h-0 ms:min-w-0 ms:overflow-hidden ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
-                <CodeView form={form} ui={ui} />
-              </div>
-            )}
-            {mode === 'preview' && (
-              <div className="preview-layout ms:flex-1 ms:min-h-0 ms:min-w-0 ms:w-full ms:max-w-5xl ms:mx-auto ms:p-4 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto">
-                <div className="ms:flex ms:items-center ms:justify-end ms:mb-3">
-                  <Switch
-                    size="sm"
-                    checked={isTouchEnabled}
-                    onCheckedChange={setTouchMode}
-                    label="Touch Mode"
-                  />
+              {children}
+              {mode === 'build' && (
+                <div className="builder-layout ms:grid ms:min-w-0 ms:grid-cols-1 ms:lg:grid-cols-[18rem_minmax(0,1fr)_340px] ms:gap-3">
+                  <aside className="panel-tools-wrap panel-tools ms:max-lg:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                    <ToolPanel />
+                  </aside>
+                  <main className="panel-canvas ms:min-w-0 ms:self-start ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-hidden ms:flex ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                    <Canvas form={form} ui={ui} dragEnabled={dragEnabled} />
+                    <div className="ms:max-lg:flex ms:lg:hidden ms:sticky ms:bottom-0 ms:z-20 ms:pt-2 ms:pb-3 ms:justify-center ms:pointer-events-none">
+                      <button
+                        type="button"
+                        onClick={() => setToolsModalOpen(true)}
+                        className="ms:pointer-events-auto ms:inline-flex ms:items-center ms:gap-1.5 ms:px-3.5 ms:py-2 ms:rounded-full ms:bg-mssurface/95 ms:backdrop-blur-sm ms:text-mstext ms:text-sm ms:font-semibold ms:border ms:border-msprimary/35 ms:shadow-lg ms:shadow-msprimary/10 ms:outline-none ms:focus:outline-none ms:hover:bg-mssurface ms:hover:border-msprimary/50 ms:hover:shadow-xl ms:hover:shadow-msprimary/15 ms:transition-all"
+                        aria-label="Open add field tools"
+                      >
+                        <PlusIcon className="ms:w-3.5 ms:h-3.5 ms:text-msprimary" />
+                        <span>Add field</span>
+                      </button>
+                    </div>
+                  </main>
+                  <aside className="panel-editor-wrap panel-editor ms:max-lg:hidden ms:lg:flex ms:self-start ms:min-h-0 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto ms:flex-col ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                    <EditPanel />
+                  </aside>
+
+                  <MobileBottomDrawer
+                    title="Add Field"
+                    open={toolsModalOpen}
+                    onClose={() => setToolsModalOpen(false)}
+                  >
+                    <ToolPanel />
+                  </MobileBottomDrawer>
+
+                  <MobileBottomDrawer
+                    title="Edit Field"
+                    open={editModalOpen && !!selectedFieldId}
+                    onClose={() => ui.getState().setEditModalOpen(false)}
+                  >
+                    <EditPanel />
+                  </MobileBottomDrawer>
                 </div>
-                <Canvas form={form} ui={ui} dragEnabled={false} />
-              </div>
-            )}
-          </div>
-        </InstanceIdContext.Provider>
+              )}
+              {mode === 'code' && (
+                <div className="code-layout ms:flex ms:h-[calc(100dvh-12.5rem)] ms:min-h-0 ms:min-w-0 ms:overflow-hidden ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface">
+                  <CodeView form={form} ui={ui} />
+                </div>
+              )}
+              {mode === 'preview' && (
+                <div className="preview-layout ms:flex-1 ms:min-h-0 ms:min-w-0 ms:w-full ms:max-w-5xl ms:mx-auto ms:p-4 ms:max-h-[calc(100dvh-12.5rem)] ms:overflow-y-auto">
+                  <div className="ms:flex ms:items-center ms:justify-end ms:mb-3">
+                    <Switch
+                      size="sm"
+                      checked={isTouchEnabled}
+                      onCheckedChange={setTouchMode}
+                      label="Touch Mode"
+                    />
+                  </div>
+                  <Canvas form={form} ui={ui} dragEnabled={false} />
+                </div>
+              )}
+            </div>
+          </InstanceIdContext.Provider>
+        </FieldProviderStack>
       </UIContext.Provider>
     </FormStoreContext.Provider>
   );

--- a/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
+++ b/packages/builder/src/lib/components/edit-panel/LogicEditor.tsx
@@ -1354,6 +1354,11 @@ function getOperatorsForTarget(target: TargetField): ConditionOperator[] {
     return ['empty', 'notEmpty'];
   }
 
+  // Notes answers are entry arrays — only presence checks are meaningful.
+  if (answerType === 'notes') {
+    return ['empty', 'notEmpty'];
+  }
+
   // Single-value selection fields (radio/dropdown/boolean etc.).
   if (answerType === 'selection') {
     const ops: ConditionOperator[] = [

--- a/packages/builder/src/lib/register-defaults.ts
+++ b/packages/builder/src/lib/register-defaults.ts
@@ -31,6 +31,7 @@ import {
   DisplayField,
   FileField,
   NotesField,
+  ActivityField,
 } from '@esheet/fields';
 
 let defaultFieldComponentsRegistered = false;
@@ -59,6 +60,7 @@ export function ensureDefaultFieldComponentsRegistered(): void {
     image: ImageField,
     file: FileField,
     notes: NotesField,
+    activity: ActivityField,
     html: HtmlField,
     display: DisplayField,
   });

--- a/packages/builder/src/lib/register-defaults.ts
+++ b/packages/builder/src/lib/register-defaults.ts
@@ -30,6 +30,7 @@ import {
   HtmlField,
   DisplayField,
   FileField,
+  NotesField,
 } from '@esheet/fields';
 
 let defaultFieldComponentsRegistered = false;
@@ -57,6 +58,7 @@ export function ensureDefaultFieldComponentsRegistered(): void {
     diagram: DiagramField,
     image: ImageField,
     file: FileField,
+    notes: NotesField,
     html: HtmlField,
     display: DisplayField,
   });

--- a/packages/builder/vite.config.ts
+++ b/packages/builder/vite.config.ts
@@ -58,6 +58,11 @@ export default defineConfig(() => ({
         'react-dom',
         'react/jsx-runtime',
         '@esheet/core',
+        // Must stay external for the same reason as the renderer: the field
+        // component registry lives in @esheet/fields, and host-registered
+        // custom field types only reach the builder when host and builder
+        // share one module instance.
+        '@esheet/fields',
         'zustand',
         'tslib',
       ],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,8 @@ export {
   fieldValidatorSchema,
   fieldDefinitionSchema,
   formDefinitionSchema,
+  attachmentAnswerSchema,
+  noteEntrySchema,
   getFormDefinitionJSONSchema,
 
   // Types
@@ -65,6 +67,7 @@ export {
   type MultiMatrixFieldDefinition,
   type ImageFieldDefinition,
   type FileFieldDefinition,
+  type NotesFieldDefinition,
   type HtmlFieldDefinition,
   type SignatureFieldDefinition,
   type DiagramFieldDefinition,
@@ -78,6 +81,7 @@ export {
   type FieldTypeRegistry,
   type RankedAnswer,
   type AttachmentAnswer,
+  type NoteEntry,
   type AnswerValue,
   type ResponseItem,
   type FormResponse as FormResponseEnvelope,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,6 +129,8 @@ export {
   mapAttachments,
 } from './lib/functions/notes.js';
 
+export type { AttachmentManager } from './lib/attachment-manager.js';
+
 export {
   ACTIVITY_RESPONSE_KEY,
   ACTIVITY_DEBOUNCE_MS,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,6 +121,12 @@ export {
 } from './lib/functions/normalize-responses.js';
 
 export {
+  mergeNotes,
+  collectAttachments,
+  mapAttachments,
+} from './lib/functions/notes.js';
+
+export {
   evaluateCondition,
   evaluateRule,
   evaluateOptionVisibility,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,6 +145,8 @@ export {
   type FormState,
   type FormStore,
   type AddFieldOptions,
+  type FormExtensionOptions,
+  type FormExtensionState,
 } from './lib/stores/form-store.js';
 
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   formDefinitionSchema,
   attachmentAnswerSchema,
   noteEntrySchema,
+  activityEntrySchema,
   getFormDefinitionJSONSchema,
 
   // Types
@@ -68,6 +69,7 @@ export {
   type ImageFieldDefinition,
   type FileFieldDefinition,
   type NotesFieldDefinition,
+  type ActivityFieldDefinition,
   type HtmlFieldDefinition,
   type SignatureFieldDefinition,
   type DiagramFieldDefinition,
@@ -82,6 +84,7 @@ export {
   type RankedAnswer,
   type AttachmentAnswer,
   type NoteEntry,
+  type ActivityEntry,
   type AnswerValue,
   type ResponseItem,
   type FormResponse as FormResponseEnvelope,
@@ -125,6 +128,13 @@ export {
   collectAttachments,
   mapAttachments,
 } from './lib/functions/notes.js';
+
+export {
+  ACTIVITY_RESPONSE_KEY,
+  ACTIVITY_DEBOUNCE_MS,
+  mergeActivity,
+  formatActivityValue,
+} from './lib/functions/activity.js';
 
 export {
   evaluateCondition,

--- a/packages/core/src/lib/attachment-manager.ts
+++ b/packages/core/src/lib/attachment-manager.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// AttachmentManager — the seam between a field and wherever bytes really live.
+// ---------------------------------------------------------------------------
+
+import type { AttachmentAnswer } from './types.js';
+
+/**
+ * Host-supplied storage for attachment bytes.
+ *
+ * By default eSheet carries whole files inline as base64 data URLs on the
+ * response. That is fine for a demo and ruinous for a host that persists the
+ * response — base64 costs +33% on every byte, and a CRDT-backed host pays it
+ * again on every edit, forever. A host that supplies a manager gets the bytes
+ * handed to it and keeps only a reference on the response.
+ *
+ * The reference is an `AttachmentAnswer` without a `dataUrl`; what identifies
+ * it is the host's business, so hosts widen the type with their own fields
+ * (a path, a URL, a hash) and eSheet passes them through untouched.
+ *
+ * All three calls are optional to *use*: when no manager is registered the
+ * fields behave exactly as they did before, inline.
+ */
+export interface AttachmentManager {
+  /** Bytes in, reference out. Called before an attachment reaches a response. */
+  store(attachment: AttachmentAnswer): Promise<AttachmentAnswer>;
+  /** Reference in, bytes back. Called when something needs to render or download. */
+  load(attachment: AttachmentAnswer): Promise<AttachmentAnswer>;
+  /** The response no longer refers to this attachment. */
+  remove(attachment: AttachmentAnswer): Promise<void>;
+}

--- a/packages/core/src/lib/functions/activity.spec.ts
+++ b/packages/core/src/lib/functions/activity.spec.ts
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------------------
+// Activity log — recordActivity / mergeActivity / store integration tests
+// ---------------------------------------------------------------------------
+
+import {
+  ACTIVITY_RESPONSE_KEY,
+  formatActivityValue,
+  mergeActivity,
+} from './activity.js';
+import { createFormStore } from '../stores/form-store.js';
+import type { ActivityEntry, FormDefinition } from '../types.js';
+
+const activityForm: FormDefinition = {
+  id: 'activity-form',
+  pages: [
+    {
+      id: 'p1',
+      fields: [
+        { id: 'name', fieldType: 'text', question: 'Your name' },
+        { id: 'log', fieldType: 'activity', question: 'Activity' },
+      ],
+    },
+  ],
+};
+
+const getLog = (
+  store: ReturnType<typeof createFormStore>
+): ActivityEntry[] =>
+  store.getState().responses[ACTIVITY_RESPONSE_KEY]?.activity ?? [];
+
+describe('store activity logging', () => {
+  it('appends an entry when a response changes', () => {
+    const store = createFormStore();
+    store.getState().loadDefinition(activityForm);
+    store.getState().setIdentity({ name: 'Dr. Demo' });
+    store.getState().setResponse('name', { answer: 'Ada' });
+
+    const log = getLog(store);
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({
+      fieldId: 'name',
+      question: 'Your name',
+      author: 'Dr. Demo',
+      to: 'Ada',
+    });
+    expect(log[0].from).toBeUndefined();
+    expect(log[0].id).toMatch(/[0-9a-f-]{36}/);
+  });
+
+  it('debounces keystrokes: rapid same-field changes collapse into one entry', () => {
+    const store = createFormStore();
+    store.getState().loadDefinition(activityForm);
+    store.getState().setResponse('name', { answer: 'A' });
+    store.getState().setResponse('name', { answer: 'Ad' });
+    store.getState().setResponse('name', { answer: 'Ada' });
+
+    const log = getLog(store);
+    expect(log).toHaveLength(1);
+    expect(log[0].from).toBeUndefined(); // original from preserved
+    expect(log[0].to).toBe('Ada');
+  });
+
+  it('separate fields produce separate entries with from/to', () => {
+    const store = createFormStore();
+    store.getState().loadDefinition(activityForm);
+    store.getState().setResponse('name', { answer: 'Ada' });
+    store.getState().setResponse('name', { answer: 'Grace' });
+
+    // same field within debounce → still 1 entry, but now change a different path
+    expect(getLog(store)).toHaveLength(1);
+
+    const withSecondField: FormDefinition = {
+      ...activityForm,
+      pages: [
+        {
+          id: 'p1',
+          fields: [
+            { id: 'a', fieldType: 'text', question: 'A' },
+            { id: 'b', fieldType: 'text', question: 'B' },
+            { id: 'log', fieldType: 'activity' },
+          ],
+        },
+      ],
+    };
+    const store2 = createFormStore();
+    store2.getState().loadDefinition(withSecondField);
+    store2.getState().setResponse('a', { answer: 'one' });
+    store2.getState().setResponse('b', { answer: 'two' });
+    const log2 = getLog(store2);
+    expect(log2).toHaveLength(2);
+    expect(log2.map((e) => e.fieldId)).toEqual(['a', 'b']);
+  });
+
+  it('does not log when the form has no activity field', () => {
+    const store = createFormStore();
+    store.getState().loadDefinition({
+      id: 'plain',
+      pages: [{ id: 'p1', fields: [{ id: 'name', fieldType: 'text' }] }],
+    });
+    store.getState().setResponse('name', { answer: 'Ada' });
+    expect(store.getState().responses[ACTIVITY_RESPONSE_KEY]).toBeUndefined();
+  });
+
+  it('does not log unchanged display values', () => {
+    const store = createFormStore();
+    store.getState().loadDefinition(activityForm);
+    store.getState().setResponse('name', { answer: 'Ada' });
+    const before = getLog(store);
+    store.getState().setResponse('name', { answer: 'Ada' });
+    expect(getLog(store)).toEqual(before);
+  });
+});
+
+describe('mergeActivity', () => {
+  const entry = (id: string, at: string): ActivityEntry => ({
+    id,
+    at,
+    fieldId: 'f',
+    to: id,
+  });
+
+  it('unions concurrent logs and sorts by at', () => {
+    const merged = mergeActivity(
+      [entry('x', '2026-01-02T00:00:00Z')],
+      [entry('y', '2026-01-01T00:00:00Z')]
+    );
+    expect(merged.map((e) => e.id)).toEqual(['y', 'x']);
+  });
+
+  it('deduplicates same-id entries', () => {
+    const a = entry('x', '2026-01-01T00:00:00Z');
+    expect(mergeActivity([a], [a])).toHaveLength(1);
+  });
+});
+
+describe('formatActivityValue', () => {
+  it('formats scalars, selections, and entry arrays', () => {
+    expect(formatActivityValue(undefined)).toBeUndefined();
+    expect(formatActivityValue('')).toBeUndefined();
+    expect(formatActivityValue('text')).toBe('text');
+    expect(formatActivityValue(0)).toBe('0');
+    expect(formatActivityValue({ id: 'opt1', value: 'Yes' })).toBe('Yes');
+    expect(
+      formatActivityValue([
+        { id: 'a', value: 'One' },
+        { id: 'b', value: 'Two' },
+      ])
+    ).toBe('One, Two');
+    expect(
+      formatActivityValue([
+        { id: 'n1', createdAt: 'x', markdown: 'hi' },
+        { id: 'n2', createdAt: 'y', markdown: 'ho' },
+      ])
+    ).toBe('2 entries');
+  });
+});

--- a/packages/core/src/lib/functions/activity.ts
+++ b/packages/core/src/lib/functions/activity.ts
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// Activity log — append-only response change log (activity page type)
+// ---------------------------------------------------------------------------
+
+import type {
+  ActivityEntry,
+  FieldResponseMap,
+  SelectedOption,
+} from '../types.js';
+import type { NormalizedDefinition } from './normalize.js';
+import { extractResponseValue } from './normalize-responses.js';
+import { mergeById } from './notes.js';
+
+/** Reserved response key holding the activity log. */
+export const ACTIVITY_RESPONSE_KEY = '_activity';
+
+/**
+ * Consecutive changes to the same field within this window collapse into the
+ * last log entry (so keystrokes don't flood the log).
+ */
+export const ACTIVITY_DEBOUNCE_MS = 2000;
+
+/**
+ * Merge two activity logs as a set keyed by entry GUID (same semantics as
+ * `mergeNotes`); output sorted by `at`.
+ */
+export function mergeActivity(
+  a: ActivityEntry[] | undefined,
+  b: ActivityEntry[] | undefined
+): ActivityEntry[] {
+  return mergeById(a, b, (entry) => entry.at, (entry) => entry.at);
+}
+
+/** Display form of a response value for the activity log. */
+export function formatActivityValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value === '' ? undefined : value;
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return undefined;
+    if (value.every((v) => typeof v === 'object' && v !== null && 'value' in v))
+      return (value as SelectedOption[]).map((v) => v.value).join(', ');
+    return `${value.length} ${value.length === 1 ? 'entry' : 'entries'}`;
+  }
+  if (typeof value === 'object') {
+    if ('value' in value) return String((value as SelectedOption).value);
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+/**
+ * Record a response change into the reserved `_activity` log.
+ *
+ * No-op (returns `next` unchanged) when the form has no `activity` field,
+ * when the changed field IS the log, or when the display value did not
+ * change. Consecutive changes to the same field within
+ * `ACTIVITY_DEBOUNCE_MS` update the last entry's `to`/`at` in place
+ * (keeping the original `from`) instead of appending.
+ */
+export function recordActivity(
+  state: {
+    normalized: NormalizedDefinition;
+    responses: FieldResponseMap;
+    identity?: { name: string };
+  },
+  fieldId: string,
+  next: FieldResponseMap,
+  nowIso: string = new Date().toISOString()
+): FieldResponseMap {
+  if (fieldId === ACTIVITY_RESPONSE_KEY) return next;
+
+  const hasActivityField = Object.values(state.normalized.byId).some(
+    (node) => node.definition.fieldType === 'activity'
+  );
+  if (!hasActivityField) return next;
+
+  const from = formatActivityValue(
+    extractResponseValue(state.responses[fieldId])
+  );
+  const to = formatActivityValue(extractResponseValue(next[fieldId]));
+  if (from === to) return next;
+
+  const question = (
+    state.normalized.byId[fieldId]?.definition as { question?: string }
+  )?.question;
+
+  const log = next[ACTIVITY_RESPONSE_KEY]?.activity ?? [];
+  const last = log[log.length - 1];
+  const withinDebounce =
+    last !== undefined &&
+    last.fieldId === fieldId &&
+    Date.parse(nowIso) - Date.parse(last.at) < ACTIVITY_DEBOUNCE_MS;
+
+  const nextLog = withinDebounce
+    ? [...log.slice(0, -1), { ...last, to, at: nowIso }]
+    : [
+        ...log,
+        {
+          id: crypto.randomUUID(),
+          at: nowIso,
+          ...(state.identity?.name ? { author: state.identity.name } : {}),
+          fieldId,
+          ...(question !== undefined ? { question } : {}),
+          ...(from !== undefined ? { from } : {}),
+          ...(to !== undefined ? { to } : {}),
+        },
+      ];
+
+  return {
+    ...next,
+    [ACTIVITY_RESPONSE_KEY]: {
+      ...next[ACTIVITY_RESPONSE_KEY],
+      activity: nextLog,
+    },
+  };
+}

--- a/packages/core/src/lib/functions/hydrate-response.ts
+++ b/packages/core/src/lib/functions/hydrate-response.ts
@@ -145,6 +145,8 @@ function extractAnswer(
       return response.selected;
     case 'multitext':
       return response.multitextAnswers;
+    case 'notes':
+      return response.notes;
     case 'media': {
       const dataUrl =
         response.signatureImage ??

--- a/packages/core/src/lib/functions/normalize-responses.ts
+++ b/packages/core/src/lib/functions/normalize-responses.ts
@@ -43,6 +43,11 @@ export function extractResponseValue(
     return response.multitextAnswers;
   }
 
+  // Notes entries (notes field)
+  if (response.notes !== undefined && response.notes.length > 0) {
+    return response.notes;
+  }
+
   // Signature: prefer stroke data, fall back to image
   if (response.signatureData !== undefined) {
     return {

--- a/packages/core/src/lib/functions/notes.spec.ts
+++ b/packages/core/src/lib/functions/notes.spec.ts
@@ -1,0 +1,166 @@
+// ---------------------------------------------------------------------------
+// Notes helpers — mergeNotes / collectAttachments / mapAttachments tests
+// ---------------------------------------------------------------------------
+
+import { mergeNotes, collectAttachments, mapAttachments } from './notes.js';
+import type {
+  AttachmentAnswer,
+  FieldResponse,
+  NoteEntry,
+} from '../types.js';
+
+const note = (
+  id: string,
+  createdAt: string,
+  overrides: Partial<NoteEntry> = {}
+): NoteEntry => ({
+  id,
+  createdAt,
+  markdown: `note ${id}`,
+  ...overrides,
+});
+
+describe('mergeNotes', () => {
+  it('unions concurrent adds from two clients (different GUIDs)', () => {
+    const a = [note('a1', '2026-01-01T10:00:00Z')];
+    const b = [note('b1', '2026-01-01T11:00:00Z')];
+    const merged = mergeNotes(a, b);
+    expect(merged.map((n) => n.id)).toEqual(['a1', 'b1']);
+  });
+
+  it('resolves same-id edit conflicts last-writer-wins on updatedAt', () => {
+    const older = note('n1', '2026-01-01T10:00:00Z', {
+      markdown: 'older edit',
+      updatedAt: '2026-01-02T10:00:00Z',
+    });
+    const newer = note('n1', '2026-01-01T10:00:00Z', {
+      markdown: 'newer edit',
+      updatedAt: '2026-01-03T10:00:00Z',
+    });
+    expect(mergeNotes([older], [newer])[0].markdown).toBe('newer edit');
+    expect(mergeNotes([newer], [older])[0].markdown).toBe('newer edit');
+  });
+
+  it('falls back to createdAt when updatedAt is absent', () => {
+    const unedited = note('n1', '2026-01-01T10:00:00Z');
+    const edited = note('n1', '2026-01-01T10:00:00Z', {
+      markdown: 'edited',
+      updatedAt: '2026-01-01T12:00:00Z',
+    });
+    expect(mergeNotes([unedited], [edited])[0].markdown).toBe('edited');
+    expect(mergeNotes([edited], [unedited])[0].markdown).toBe('edited');
+  });
+
+  it('sorts output by createdAt', () => {
+    const merged = mergeNotes(
+      [note('late', '2026-02-01T00:00:00Z')],
+      [note('early', '2026-01-01T00:00:00Z')]
+    );
+    expect(merged.map((n) => n.id)).toEqual(['early', 'late']);
+  });
+
+  it('handles undefined sides', () => {
+    const a = [note('a1', '2026-01-01T00:00:00Z')];
+    expect(mergeNotes(a, undefined)).toEqual(a);
+    expect(mergeNotes(undefined, a)).toEqual(a);
+    expect(mergeNotes(undefined, undefined)).toEqual([]);
+  });
+});
+
+describe('collectAttachments', () => {
+  const att = (title: string): AttachmentAnswer => ({
+    contentType: 'image/png',
+    dataUrl: `data:${title}`,
+    title,
+  });
+
+  it('collects single and multiple fileData', () => {
+    expect(collectAttachments({ fileData: att('one') })).toHaveLength(1);
+    expect(
+      collectAttachments({ fileData: [att('one'), att('two')] })
+    ).toHaveLength(2);
+  });
+
+  it('collects notes[].attachments', () => {
+    const response: FieldResponse = {
+      notes: [
+        note('n1', '2026-01-01T00:00:00Z', { attachments: [att('a')] }),
+        note('n2', '2026-01-02T00:00:00Z'),
+        note('n3', '2026-01-03T00:00:00Z', {
+          attachments: [att('b'), att('c')],
+        }),
+      ],
+    };
+    expect(collectAttachments(response).map((a) => a.title)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('returns empty for responses without attachments', () => {
+    expect(collectAttachments({ answer: 'text' })).toEqual([]);
+  });
+});
+
+describe('mapAttachments', () => {
+  const externalize = (a: AttachmentAnswer): AttachmentAnswer => ({
+    contentType: a.contentType,
+    url: `case/attachments/${a.title}`,
+    title: a.title,
+  });
+
+  it('rewrites fileData (single and array) preserving shape', () => {
+    const single = mapAttachments(
+      { fileData: { contentType: 'image/png', dataUrl: 'x', title: 'f1' } },
+      externalize
+    );
+    expect(single.fileData).toMatchObject({ url: 'case/attachments/f1' });
+    expect(Array.isArray(single.fileData)).toBe(false);
+
+    const multi = mapAttachments(
+      {
+        fileData: [
+          { contentType: 'image/png', dataUrl: 'x', title: 'f1' },
+          { contentType: 'image/png', dataUrl: 'y', title: 'f2' },
+        ],
+      },
+      externalize
+    );
+    expect((multi.fileData as AttachmentAnswer[]).map((a) => a.url)).toEqual([
+      'case/attachments/f1',
+      'case/attachments/f2',
+    ]);
+  });
+
+  it('rewrites notes[].attachments without touching note bodies', () => {
+    const response: FieldResponse = {
+      notes: [
+        note('n1', '2026-01-01T00:00:00Z', {
+          attachments: [{ contentType: 'image/png', dataUrl: 'x', title: 'a' }],
+        }),
+        note('n2', '2026-01-02T00:00:00Z'),
+      ],
+    };
+    const mapped = mapAttachments(response, externalize);
+    expect(mapped.notes?.[0].attachments?.[0].url).toBe('case/attachments/a');
+    expect(mapped.notes?.[0].markdown).toBe('note n1');
+    expect(mapped.notes?.[1]).toBe(response.notes?.[1]);
+  });
+
+  it('returns the same reference when there is nothing to map', () => {
+    const response: FieldResponse = { answer: 'plain text' };
+    expect(mapAttachments(response, externalize)).toBe(response);
+  });
+
+  it('round-trips unchanged with an identity mapper', () => {
+    const response: FieldResponse = {
+      notes: [
+        note('n1', '2026-01-01T00:00:00Z', {
+          attachments: [{ contentType: 'image/png', dataUrl: 'x' }],
+        }),
+      ],
+    };
+    expect(mapAttachments(response, (a) => a)).toEqual(response);
+  });
+});

--- a/packages/core/src/lib/functions/notes.ts
+++ b/packages/core/src/lib/functions/notes.ts
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------
+// Notes helpers — GUID-keyed merge and attachment traversal
+// ---------------------------------------------------------------------------
+
+import type {
+  AttachmentAnswer,
+  FieldResponse,
+  NoteEntry,
+} from '../types.js';
+
+/** Timestamp used for conflict resolution: last edit wins, else creation. */
+function noteMergeStamp(note: NoteEntry): string {
+  return note.updatedAt ?? note.createdAt;
+}
+
+/**
+ * Merge two `notes[]` arrays as a **set keyed by `id`**.
+ *
+ * - Entries present on only one side are kept (concurrent adds union cleanly
+ *   because every entry carries its own GUID).
+ * - Same-id conflicts resolve last-writer-wins on `updatedAt ?? createdAt`.
+ * - Output is sorted by `createdAt` (ties broken by id for determinism).
+ *
+ * Hosts with CRDT bindings call this when both sides changed the field
+ * instead of letting the whole array be last-writer-wins.
+ */
+export function mergeNotes(
+  a: NoteEntry[] | undefined,
+  b: NoteEntry[] | undefined
+): NoteEntry[] {
+  const byId = new Map<string, NoteEntry>();
+  for (const note of a ?? []) {
+    byId.set(note.id, note);
+  }
+  for (const note of b ?? []) {
+    const existing = byId.get(note.id);
+    if (!existing || noteMergeStamp(note) >= noteMergeStamp(existing)) {
+      byId.set(note.id, note);
+    }
+  }
+  return [...byId.values()].sort(
+    (x, y) =>
+      x.createdAt.localeCompare(y.createdAt) || x.id.localeCompare(y.id)
+  );
+}
+
+/**
+ * Every attachment in a response, whatever the field type — covers `fileData`
+ * (file fields) and `notes[].attachments` (notes fields). Use this instead of
+ * hardcoding `fileData` in externalize/rehydrate pipelines.
+ */
+export function collectAttachments(
+  response: FieldResponse
+): AttachmentAnswer[] {
+  const result: AttachmentAnswer[] = [];
+  if (response.fileData) {
+    result.push(
+      ...(Array.isArray(response.fileData)
+        ? response.fileData
+        : [response.fileData])
+    );
+  }
+  for (const note of response.notes ?? []) {
+    if (note.attachments) result.push(...note.attachments);
+  }
+  return result;
+}
+
+/**
+ * Rewrite every attachment in a response via a mapper, returning a new
+ * response (used by externalize/rehydrate pipelines). Responses without
+ * attachments are returned unchanged (same reference).
+ */
+export function mapAttachments(
+  response: FieldResponse,
+  fn: (attachment: AttachmentAnswer) => AttachmentAnswer
+): FieldResponse {
+  let changed = false;
+  const next: FieldResponse = { ...response };
+
+  if (response.fileData) {
+    next.fileData = Array.isArray(response.fileData)
+      ? response.fileData.map(fn)
+      : fn(response.fileData);
+    changed = true;
+  }
+
+  if (response.notes?.some((note) => note.attachments?.length)) {
+    next.notes = response.notes.map((note) =>
+      note.attachments?.length
+        ? { ...note, attachments: note.attachments.map(fn) }
+        : note
+    );
+    changed = true;
+  }
+
+  return changed ? next : response;
+}

--- a/packages/core/src/lib/functions/notes.ts
+++ b/packages/core/src/lib/functions/notes.ts
@@ -14,6 +14,33 @@ function noteMergeStamp(note: NoteEntry): string {
 }
 
 /**
+ * Merge two GUID-keyed entry arrays as a set: union by `id`, same-id
+ * conflicts resolve last-writer-wins on `stamp`, output sorted by `sortKey`
+ * (ties broken by id for determinism). Shared by notes and activity logs.
+ */
+export function mergeById<T extends { id: string }>(
+  a: T[] | undefined,
+  b: T[] | undefined,
+  stamp: (entry: T) => string,
+  sortKey: (entry: T) => string
+): T[] {
+  const byId = new Map<string, T>();
+  for (const entry of a ?? []) {
+    byId.set(entry.id, entry);
+  }
+  for (const entry of b ?? []) {
+    const existing = byId.get(entry.id);
+    if (!existing || stamp(entry) >= stamp(existing)) {
+      byId.set(entry.id, entry);
+    }
+  }
+  return [...byId.values()].sort(
+    (x, y) =>
+      sortKey(x).localeCompare(sortKey(y)) || x.id.localeCompare(y.id)
+  );
+}
+
+/**
  * Merge two `notes[]` arrays as a **set keyed by `id`**.
  *
  * - Entries present on only one side are kept (concurrent adds union cleanly
@@ -28,20 +55,7 @@ export function mergeNotes(
   a: NoteEntry[] | undefined,
   b: NoteEntry[] | undefined
 ): NoteEntry[] {
-  const byId = new Map<string, NoteEntry>();
-  for (const note of a ?? []) {
-    byId.set(note.id, note);
-  }
-  for (const note of b ?? []) {
-    const existing = byId.get(note.id);
-    if (!existing || noteMergeStamp(note) >= noteMergeStamp(existing)) {
-      byId.set(note.id, note);
-    }
-  }
-  return [...byId.values()].sort(
-    (x, y) =>
-      x.createdAt.localeCompare(y.createdAt) || x.id.localeCompare(y.id)
-  );
+  return mergeById(a, b, noteMergeStamp, (note) => note.createdAt);
 }
 
 /**

--- a/packages/core/src/lib/logic/conditions.ts
+++ b/packages/core/src/lib/logic/conditions.ts
@@ -1003,6 +1003,10 @@ function getExpressionFieldValue(
     return files.length;
   }
 
+  if (definition.fieldType === 'notes') {
+    return response.notes?.length ?? 0;
+  }
+
   if (
     definition.fieldType === 'check' ||
     definition.fieldType === 'multiselectdropdown'
@@ -1098,6 +1102,11 @@ function getActualValue(
         ? null
         : files.map((f) => f.title ?? f.url ?? '');
     }
+
+    case 'notes':
+      return response.notes && response.notes.length > 0
+        ? response.notes.map((n) => n.id)
+        : null;
 
     default:
       return null;

--- a/packages/core/src/lib/logic/validate.ts
+++ b/packages/core/src/lib/logic/validate.ts
@@ -194,7 +194,13 @@ export function validateField(
 // ---------------------------------------------------------------------------
 
 /** Field types that don't accept user input — skip validation. */
-const NON_INPUT_TYPES = new Set(['section', 'expression', 'html', 'image']);
+const NON_INPUT_TYPES = new Set([
+  'section',
+  'expression',
+  'html',
+  'image',
+  'activity',
+]);
 
 /**
  * Check whether a field response is effectively empty.

--- a/packages/core/src/lib/logic/validate.ts
+++ b/packages/core/src/lib/logic/validate.ts
@@ -242,6 +242,9 @@ function isResponseEmpty(response: FieldResponse | undefined): boolean {
     if (files.length > 0) return false;
   }
 
+  // notes — required means at least one entry
+  if (response.notes && response.notes.length > 0) return false;
+
   // signatureData
   if (response.signatureData && response.signatureData.trim() !== '')
     return false;

--- a/packages/core/src/lib/notes-field.spec.ts
+++ b/packages/core/src/lib/notes-field.spec.ts
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------
+// Notes field — schema, registry, validation, and response extraction tests
+// ---------------------------------------------------------------------------
+
+import {
+  formDefinitionSchema,
+  normalizeFormDefinition,
+  noteEntrySchema,
+  type FormDefinition,
+  type NoteEntry,
+} from './types.js';
+import { getFieldTypeMeta } from './registry.js';
+import { normalizeDefinition } from './functions/normalize.js';
+import { hydrateResponse } from './functions/hydrate-response.js';
+import { extractResponseValue } from './functions/normalize-responses.js';
+import { validateField } from './logic/validate.js';
+
+const makeNote = (overrides: Partial<NoteEntry> = {}): NoteEntry => ({
+  id: crypto.randomUUID(),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  markdown: 'Hello *world*',
+  ...overrides,
+});
+
+const notesForm: FormDefinition = {
+  id: 'notes-form',
+  pages: [
+    {
+      id: 'p1',
+      fields: [
+        {
+          id: 'case-notes',
+          fieldType: 'notes',
+          question: 'Case notes',
+          allowAttachments: true,
+          accept: 'image/*,.pdf',
+          maxFileSize: 1024,
+          maxAttachments: 3,
+          maxNotes: 10,
+          sortOrder: 'oldest',
+          entryLabel: 'Letter',
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+describe('notes field definition schema', () => {
+  it('round-trips a notes field through the form schema', () => {
+    const result = formDefinitionSchema.safeParse(notesForm);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const field = result.data.pages[0].fields?.[0];
+      expect(field).toMatchObject({
+        fieldType: 'notes',
+        entryLabel: 'Letter',
+        sortOrder: 'oldest',
+        allowAttachments: true,
+      });
+    }
+  });
+
+  it('rejects unknown properties on a notes field', () => {
+    const bad = structuredClone(notesForm) as Record<string, unknown>;
+    (
+      (bad['pages'] as Record<string, unknown>[])[0][
+        'fields'
+      ] as Record<string, unknown>[]
+    )[0]['bogus'] = true;
+    expect(formDefinitionSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('normalizeFormDefinition keeps notes props and strips irrelevant ones', () => {
+    const raw = {
+      id: 'f',
+      pages: [
+        {
+          id: 'p1',
+          fields: [
+            {
+              id: 'n1',
+              fieldType: 'notes',
+              entryLabel: 'Comment',
+              options: [{ id: 'x', value: 'y' }], // not a notes prop
+            },
+          ],
+        },
+      ],
+    };
+    const normalized = normalizeFormDefinition(raw);
+    const field = (
+      (normalized['pages'] as Record<string, unknown>[])[0][
+        'fields'
+      ] as Record<string, unknown>[]
+    )[0];
+    expect(field['entryLabel']).toBe('Comment');
+    expect(field['options']).toBeUndefined();
+  });
+
+  it('validates NoteEntry shape (id, createdAt, markdown required)', () => {
+    expect(noteEntrySchema.safeParse(makeNote()).success).toBe(true);
+    expect(
+      noteEntrySchema.safeParse({ id: 'a', markdown: 'no createdAt' }).success
+    ).toBe(false);
+    expect(
+      noteEntrySchema.safeParse(
+        makeNote({
+          attachments: [{ contentType: 'image/png', dataUrl: 'data:...' }],
+        })
+      ).success
+    ).toBe(true);
+  });
+});
+
+describe('notes field registry metadata', () => {
+  it('is registered with notes answerType and default props', () => {
+    const meta = getFieldTypeMeta('notes');
+    expect(meta).toBeDefined();
+    expect(meta?.label).toBe('Notes');
+    expect(meta?.answerType).toBe('notes');
+    expect(meta?.defaultProps).toMatchObject({
+      entryLabel: 'Note',
+      sortOrder: 'newest',
+    });
+  });
+});
+
+describe('notes field validation', () => {
+  const normalized = normalizeDefinition(notesForm.pages);
+
+  it('required notes field with no entries is an error', () => {
+    const errors = validateField('case-notes', normalized, {});
+    expect(errors).toMatchObject([{ fieldId: 'case-notes', rule: 'required' }]);
+  });
+
+  it('required is satisfied by at least one entry', () => {
+    const errors = validateField('case-notes', normalized, {
+      'case-notes': { notes: [makeNote()] },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('empty notes array counts as unanswered', () => {
+    const errors = validateField('case-notes', normalized, {
+      'case-notes': { notes: [] },
+    });
+    expect(errors).toMatchObject([{ fieldId: 'case-notes', rule: 'required' }]);
+  });
+});
+
+describe('notes field response extraction', () => {
+  it('extractResponseValue returns the notes array', () => {
+    const notes = [makeNote()];
+    expect(extractResponseValue({ notes })).toBe(notes);
+    expect(extractResponseValue({ notes: [] })).toBeUndefined();
+  });
+
+  it('hydrateResponse carries NoteEntry[] as the answer', () => {
+    const normalized = normalizeDefinition(notesForm.pages);
+    const notes = [makeNote({ author: 'Dr. Demo' })];
+    const envelope = hydrateResponse(normalized, {
+      'case-notes': { notes },
+    });
+    const item = envelope.items.find((i) => i.id === 'case-notes');
+    expect(item?.answer).toBe(notes);
+  });
+});

--- a/packages/core/src/lib/registry.spec.ts
+++ b/packages/core/src/lib/registry.spec.ts
@@ -13,8 +13,8 @@ describe('field type registry', () => {
     resetFieldTypeRegistry();
   });
 
-  it('should have all 23 built-in types registered by default', () => {
-    expect(getRegisteredFieldTypes()).toHaveLength(23);
+  it('should have all 24 built-in types registered by default', () => {
+    expect(getRegisteredFieldTypes()).toHaveLength(24);
     for (const ft of FIELD_TYPES) {
       expect(getFieldTypeMeta(ft)).toBeDefined();
     }
@@ -36,7 +36,7 @@ describe('field type registry', () => {
 
     expect(getFieldTypeMeta('vitals')).toBeDefined();
     expect(getFieldTypeMeta('vitals')!.label).toBe('Vitals Field');
-    expect(getRegisteredFieldTypes()).toHaveLength(24);
+    expect(getRegisteredFieldTypes()).toHaveLength(25);
   });
 
   it('should allow overriding a built-in field type', () => {
@@ -50,7 +50,7 @@ describe('field type registry', () => {
     });
 
     expect(getFieldTypeMeta('text')!.label).toBe('Custom Text');
-    expect(getRegisteredFieldTypes()).toHaveLength(23);
+    expect(getRegisteredFieldTypes()).toHaveLength(24);
   });
 
   it('should reset to defaults', () => {
@@ -62,10 +62,10 @@ describe('field type registry', () => {
       hasMatrix: false,
       defaultProps: {},
     });
-    expect(getRegisteredFieldTypes()).toHaveLength(24);
+    expect(getRegisteredFieldTypes()).toHaveLength(25);
 
     resetFieldTypeRegistry();
-    expect(getRegisteredFieldTypes()).toHaveLength(23);
+    expect(getRegisteredFieldTypes()).toHaveLength(24);
     expect(getFieldTypeMeta('custom')).toBeUndefined();
   });
 

--- a/packages/core/src/lib/registry.spec.ts
+++ b/packages/core/src/lib/registry.spec.ts
@@ -13,8 +13,8 @@ describe('field type registry', () => {
     resetFieldTypeRegistry();
   });
 
-  it('should have all 22 built-in types registered by default', () => {
-    expect(getRegisteredFieldTypes()).toHaveLength(22);
+  it('should have all 23 built-in types registered by default', () => {
+    expect(getRegisteredFieldTypes()).toHaveLength(23);
     for (const ft of FIELD_TYPES) {
       expect(getFieldTypeMeta(ft)).toBeDefined();
     }
@@ -36,7 +36,7 @@ describe('field type registry', () => {
 
     expect(getFieldTypeMeta('vitals')).toBeDefined();
     expect(getFieldTypeMeta('vitals')!.label).toBe('Vitals Field');
-    expect(getRegisteredFieldTypes()).toHaveLength(23);
+    expect(getRegisteredFieldTypes()).toHaveLength(24);
   });
 
   it('should allow overriding a built-in field type', () => {
@@ -50,7 +50,7 @@ describe('field type registry', () => {
     });
 
     expect(getFieldTypeMeta('text')!.label).toBe('Custom Text');
-    expect(getRegisteredFieldTypes()).toHaveLength(22);
+    expect(getRegisteredFieldTypes()).toHaveLength(23);
   });
 
   it('should reset to defaults', () => {
@@ -62,10 +62,10 @@ describe('field type registry', () => {
       hasMatrix: false,
       defaultProps: {},
     });
-    expect(getRegisteredFieldTypes()).toHaveLength(23);
+    expect(getRegisteredFieldTypes()).toHaveLength(24);
 
     resetFieldTypeRegistry();
-    expect(getRegisteredFieldTypes()).toHaveLength(22);
+    expect(getRegisteredFieldTypes()).toHaveLength(23);
     expect(getFieldTypeMeta('custom')).toBeUndefined();
   });
 

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -285,6 +285,15 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     defaultProps: { width: 'full' },
     placeholder: { question: 'Upload a file' },
   },
+  notes: {
+    label: 'Notes',
+    category: 'rich',
+    answerType: 'notes',
+    hasOptions: false,
+    hasMatrix: false,
+    defaultProps: { entryLabel: 'Note', sortOrder: 'newest', width: 'full' },
+    placeholder: { question: 'Enter your question...' },
+  },
   display: {
     label: 'Display',
     category: 'rich',

--- a/packages/core/src/lib/registry.ts
+++ b/packages/core/src/lib/registry.ts
@@ -294,6 +294,15 @@ const BUILT_IN_FIELD_TYPES: Record<FieldType, FieldTypeMeta> = {
     defaultProps: { entryLabel: 'Note', sortOrder: 'newest', width: 'full' },
     placeholder: { question: 'Enter your question...' },
   },
+  activity: {
+    label: 'Activity',
+    category: 'rich',
+    answerType: 'display',
+    hasOptions: false,
+    hasMatrix: false,
+    defaultProps: { width: 'full' },
+    placeholder: { question: 'Activity' },
+  },
   display: {
     label: 'Display',
     category: 'rich',

--- a/packages/core/src/lib/stores/form-store.spec.ts
+++ b/packages/core/src/lib/stores/form-store.spec.ts
@@ -170,6 +170,144 @@ describe('createFormStore', () => {
         expect(store.getState().responses).toEqual({});
       });
     });
+
+    describe('extensions', () => {
+      it('registers, reads, and updates typed namespaced state', () => {
+        const initial = { rows: ['doc-1'], loading: false };
+        expect(
+          store.getState().registerExtension('documents', 'q1', initial)
+        ).toBe(true);
+        expect(
+          store.getState().registerExtension('documents', 'q1', initial)
+        ).toBe(false);
+
+        store
+          .getState()
+          .updateExtension<typeof initial>('documents', 'q1', (state) => ({
+            ...state!,
+            loading: true,
+          }));
+
+        expect(
+          store.getState().getExtension<typeof initial>('documents', 'q1')
+        ).toEqual({ rows: ['doc-1'], loading: true });
+        expect(store.getState().getExtension('other', 'q1')).toBeUndefined();
+      });
+
+      it('isolates extensions between form store instances', () => {
+        const secondStore = createFormStore(form([field('q1')]));
+        store.getState().registerExtension('documents', 'q1', { value: 1 });
+        secondStore
+          .getState()
+          .registerExtension('documents', 'q1', { value: 2 });
+
+        expect(
+          store.getState().getExtension<{ value: number }>('documents', 'q1')
+        ).toEqual({ value: 1 });
+        expect(
+          secondStore
+            .getState()
+            .getExtension<{ value: number }>('documents', 'q1')
+        ).toEqual({ value: 2 });
+      });
+
+      it('disposes extensions on definition reload', () => {
+        const onDispose = vi.fn();
+        store
+          .getState()
+          .registerExtension('documents', 'q1', { value: 1 }, { onDispose });
+
+        store.getState().loadDefinition(form([field('q2')]));
+
+        expect(onDispose).toHaveBeenCalledOnce();
+        expect(store.getState().extensions).toEqual({});
+      });
+
+      it('disposes extensions for removed fields and descendants', () => {
+        store = createFormStore(
+          form([
+            field('s1', 'section', {
+              fields: [field('c1')],
+            } as Partial<FieldDefinition>),
+            field('q2'),
+          ])
+        );
+        const sectionDispose = vi.fn();
+        const childDispose = vi.fn();
+        store
+          .getState()
+          .registerExtension(
+            'documents',
+            's1',
+            {},
+            { onDispose: sectionDispose }
+          );
+        store
+          .getState()
+          .registerExtension(
+            'documents',
+            'c1',
+            {},
+            { onDispose: childDispose }
+          );
+        store.getState().registerExtension('documents', 'q2', { value: 2 });
+
+        expect(store.getState().removeField('s1')).toBe(true);
+
+        expect(sectionDispose).toHaveBeenCalledOnce();
+        expect(childDispose).toHaveBeenCalledOnce();
+        expect(store.getState().getExtension('documents', 'q2')).toEqual({
+          value: 2,
+        });
+      });
+
+      it('disposes an extension when its field is renamed', () => {
+        const onDispose = vi.fn();
+        store
+          .getState()
+          .registerExtension('documents', 'q1', {}, { onDispose });
+
+        expect(store.getState().updateField('q1', { id: 'q1-renamed' })).toBe(
+          true
+        );
+
+        expect(onDispose).toHaveBeenCalledOnce();
+        expect(
+          store.getState().getExtension('documents', 'q1')
+        ).toBeUndefined();
+      });
+
+      it('disposes an extension when a field changes type', () => {
+        const onDispose = vi.fn();
+        store
+          .getState()
+          .registerExtension('documents', 'q1', {}, { onDispose });
+
+        expect(store.getState().updateField('q1', { fieldType: 'radio' })).toBe(
+          true
+        );
+
+        expect(onDispose).toHaveBeenCalledOnce();
+        expect(
+          store.getState().getExtension('documents', 'q1')
+        ).toBeUndefined();
+      });
+
+      it('clears and disposes entries, then rejects registration after dispose', () => {
+        const onDispose = vi.fn();
+        store
+          .getState()
+          .registerExtension('documents', 'q1', {}, { onDispose });
+        store.getState().dispose();
+
+        expect(onDispose).toHaveBeenCalledOnce();
+        expect(store.getState().disposed).toBe(true);
+        expect(store.getState().extensions).toEqual({});
+        expect(store.getState().registerExtension('documents', 'q1', {})).toBe(
+          false
+        );
+      });
+    });
   });
 
   describe('validation and hydration', () => {

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -91,6 +91,8 @@ export interface FormState {
   readonly normalized: NormalizedDefinition;
   /** Current responses keyed by field ID. */
   readonly responses: FieldResponseMap;
+  /** Host-supplied identity of the current user (stamps notes authorship). */
+  readonly identity?: { name: string };
   /** Field IDs that have been explicitly edited by the user (not auto-calculated). */
   readonly userEditedFields: ReadonlySet<string>;
   /** Core-managed custom-field runtime state; excluded from response export. */
@@ -109,6 +111,8 @@ export interface FormState {
   setFormDescription: (description: string | undefined) => void;
   /** Enable or disable dangerously embedded JS for this form. */
   setDangerouslyAllowJS: (enabled: boolean) => void;
+  /** Set the host-supplied identity of the current user. */
+  setIdentity: (identity: { name: string } | undefined) => void;
   /** Set (or replace) a single field's response. */
   setResponse: (fieldId: string, response: FieldResponse) => void;
   /** Remove a single field's response. */
@@ -539,6 +543,7 @@ export function createFormStore(
     dangerouslyAllowJS: (initial?.dangerouslyAllowJS ?? false) && _hostAllowsJS,
     normalized: initial ? normalizeDefinition(initial.pages) : EMPTY_NORMALIZED,
     responses: {},
+    identity: undefined,
     userEditedFields: new Set<string>(),
     extensions: {},
     disposed: false,
@@ -573,6 +578,8 @@ export function createFormStore(
 
     setDangerouslyAllowJS: (enabled) =>
       set({ dangerouslyAllowJS: enabled && _hostAllowsJS }),
+
+    setIdentity: (identity) => set({ identity }),
 
     setResponse: (fieldId, response) =>
       set((state) => {

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -62,6 +62,16 @@ export interface AddFieldOptions {
   patch?: Record<string, unknown>;
 }
 
+/** Lifecycle options for a core-managed custom-field extension. */
+export interface FormExtensionOptions {
+  readonly onDispose?: () => void;
+}
+
+/** Namespaced custom-field runtime state owned by the form store. */
+export type FormExtensionState = Readonly<
+  Record<string, Readonly<Record<string, unknown>>>
+>;
+
 /** The full form state — data + actions + selectors. */
 export interface FormState {
   // --- Data ---
@@ -83,6 +93,10 @@ export interface FormState {
   readonly responses: FieldResponseMap;
   /** Field IDs that have been explicitly edited by the user (not auto-calculated). */
   readonly userEditedFields: ReadonlySet<string>;
+  /** Core-managed custom-field runtime state; excluded from response export. */
+  readonly extensions: FormExtensionState;
+  /** True after `dispose()` has been called. */
+  readonly disposed: boolean;
 
   // --- Lifecycle Actions ---
   /** Load a form definition (tree), normalizing it into the flat index. */
@@ -101,6 +115,33 @@ export interface FormState {
   clearResponse: (fieldId: string) => void;
   /** Clear all responses. */
   resetResponses: () => void;
+  /** Register extension state for a namespace and field ID. */
+  registerExtension: <T>(
+    namespace: string,
+    fieldId: string,
+    initialState: T,
+    options?: FormExtensionOptions
+  ) => boolean;
+  /** Read extension state with a caller-provided type. */
+  getExtension: <T>(namespace: string, fieldId: string) => T | undefined;
+  /** Replace extension state. Creates the entry when it does not exist. */
+  setExtension: <T>(namespace: string, fieldId: string, state: T) => void;
+  /** Update extension state immutably. */
+  updateExtension: <T>(
+    namespace: string,
+    fieldId: string,
+    updater: (state: T | undefined) => T
+  ) => void;
+  /** Clear one extension and invoke its disposer. */
+  clearExtension: (namespace: string, fieldId: string) => void;
+  /** Clear extensions belonging to the supplied field IDs. */
+  clearExtensionsForFields: (fieldIds: readonly string[]) => void;
+  /** Clear every extension registered under a namespace. */
+  clearExtensionsForNamespace: (namespace: string) => void;
+  /** Clear every extension in the form store. */
+  clearExtensions: () => void;
+  /** Dispose all extension state and prevent future extension registration. */
+  dispose: () => void;
 
   // --- Builder Actions ---
   /** Add a new field. Returns the generated field ID, or `null` if the type is unknown. */
@@ -420,6 +461,53 @@ function createTemporaryFormId(): string {
   return id;
 }
 
+function extensionKey(namespace: string, fieldId: string): string {
+  return `${namespace}\u0000${fieldId}`;
+}
+
+function hasExtension(
+  extensions: FormExtensionState,
+  namespace: string,
+  fieldId: string
+): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    extensions[namespace] ?? {},
+    fieldId
+  );
+}
+
+function withoutExtensionFields(
+  extensions: FormExtensionState,
+  fieldIds: ReadonlySet<string>
+): FormExtensionState {
+  const next: Record<string, Record<string, unknown>> = {};
+  for (const [namespace, entries] of Object.entries(extensions)) {
+    const remaining = Object.fromEntries(
+      Object.entries(entries).filter(([fieldId]) => !fieldIds.has(fieldId))
+    );
+    if (Object.keys(remaining).length > 0) next[namespace] = remaining;
+  }
+  return next;
+}
+
+function withoutExtension(
+  extensions: FormExtensionState,
+  namespace: string,
+  fieldId: string
+): FormExtensionState {
+  const entries = extensions[namespace];
+  if (!entries || !hasExtension(extensions, namespace, fieldId))
+    return extensions;
+  const remaining = { ...entries };
+  delete remaining[fieldId];
+  if (Object.keys(remaining).length === 0) {
+    const next = { ...extensions };
+    delete next[namespace];
+    return next;
+  }
+  return { ...extensions, [namespace]: remaining };
+}
+
 export function createFormStore(
   initial?: FormDefinition,
   hostAllowsJS = false
@@ -427,6 +515,19 @@ export function createFormStore(
   const initialFormId = initial?.id?.trim() || createTemporaryFormId();
   // Sealed at creation time — cannot be overridden by store mutations.
   const _hostAllowsJS = hostAllowsJS;
+  const extensionDisposers = new Map<string, () => void>();
+
+  const disposeExtension = (namespace: string, fieldId: string): void => {
+    const key = extensionKey(namespace, fieldId);
+    const disposer = extensionDisposers.get(key);
+    extensionDisposers.delete(key);
+    disposer?.();
+  };
+
+  const disposeAllExtensions = (): void => {
+    for (const disposer of extensionDisposers.values()) disposer();
+    extensionDisposers.clear();
+  };
 
   const store = createStore<FormState>()((set, get) => ({
     // --- Data ---
@@ -439,20 +540,26 @@ export function createFormStore(
     normalized: initial ? normalizeDefinition(initial.pages) : EMPTY_NORMALIZED,
     responses: {},
     userEditedFields: new Set<string>(),
+    extensions: {},
+    disposed: false,
 
     // --- Actions ---
     loadDefinition: (definition) =>
-      set({
-        formId: definition.id,
-        formTitle: definition.title,
-        formDescription: definition.description,
-        formSourceData: definition._sourceData,
-        dangerouslyAllowJS:
-          (definition.dangerouslyAllowJS ?? false) && _hostAllowsJS,
-        normalized: normalizeDefinition(definition.pages),
-        responses: {},
-        userEditedFields: new Set<string>(),
-      }),
+      (() => {
+        disposeAllExtensions();
+        set({
+          formId: definition.id,
+          formTitle: definition.title,
+          formDescription: definition.description,
+          formSourceData: definition._sourceData,
+          dangerouslyAllowJS:
+            (definition.dangerouslyAllowJS ?? false) && _hostAllowsJS,
+          normalized: normalizeDefinition(definition.pages),
+          responses: {},
+          userEditedFields: new Set<string>(),
+          extensions: {},
+        });
+      })(),
 
     setFormId: (id) => {
       const nextId = id.trim();
@@ -505,6 +612,99 @@ export function createFormStore(
 
     resetResponses: () =>
       set({ responses: {}, userEditedFields: new Set<string>() }),
+
+    registerExtension: (namespace, fieldId, initialState, options) => {
+      if (get().disposed) return false;
+      if (hasExtension(get().extensions, namespace, fieldId)) return false;
+      if (options?.onDispose) {
+        extensionDisposers.set(
+          extensionKey(namespace, fieldId),
+          options.onDispose
+        );
+      }
+      set((state) => ({
+        extensions: {
+          ...state.extensions,
+          [namespace]: {
+            ...(state.extensions[namespace] ?? {}),
+            [fieldId]: initialState,
+          },
+        },
+      }));
+      return true;
+    },
+
+    getExtension: <T>(namespace: string, fieldId: string): T | undefined =>
+      get().extensions[namespace]?.[fieldId] as T | undefined,
+
+    setExtension: (namespace, fieldId, state) => {
+      if (get().disposed) return;
+      set((current) => ({
+        extensions: {
+          ...current.extensions,
+          [namespace]: {
+            ...(current.extensions[namespace] ?? {}),
+            [fieldId]: state,
+          },
+        },
+      }));
+    },
+
+    updateExtension: <T>(
+      namespace: string,
+      fieldId: string,
+      updater: (state: T | undefined) => T
+    ) => {
+      if (get().disposed) return;
+      const current = get().extensions[namespace]?.[fieldId] as T | undefined;
+      set((state) => ({
+        extensions: {
+          ...state.extensions,
+          [namespace]: {
+            ...(state.extensions[namespace] ?? {}),
+            [fieldId]: updater(current),
+          },
+        },
+      }));
+    },
+
+    clearExtension: (namespace, fieldId) => {
+      disposeExtension(namespace, fieldId);
+      set((state) => ({
+        extensions: withoutExtension(state.extensions, namespace, fieldId),
+      }));
+    },
+
+    clearExtensionsForFields: (fieldIds) => {
+      const ids = new Set(fieldIds);
+      for (const namespace of Object.keys(get().extensions)) {
+        for (const fieldId of ids) disposeExtension(namespace, fieldId);
+      }
+      set((state) => ({
+        extensions: withoutExtensionFields(state.extensions, ids),
+      }));
+    },
+
+    clearExtensionsForNamespace: (namespace) => {
+      for (const fieldId of Object.keys(get().extensions[namespace] ?? {}))
+        disposeExtension(namespace, fieldId);
+      set((state) => {
+        if (!state.extensions[namespace]) return state;
+        const extensions = { ...state.extensions };
+        delete extensions[namespace];
+        return { extensions };
+      });
+    },
+
+    clearExtensions: () => {
+      disposeAllExtensions();
+      set({ extensions: {} });
+    },
+
+    dispose: () => {
+      disposeAllExtensions();
+      set({ extensions: {}, disposed: true });
+    },
 
     // --- Builder Actions ---
     addField: (fieldType, options) => {
@@ -625,6 +825,10 @@ export function createFormStore(
 
       const newId = patch['id'] as string | undefined;
       const isRename = newId !== undefined && newId !== fieldId;
+      const nextFieldType = patch['fieldType'] as FieldType | undefined;
+      const isTypeChange =
+        nextFieldType !== undefined &&
+        nextFieldType !== node.definition.fieldType;
 
       if (isRename) {
         if (normalized.byId[newId!]) return false;
@@ -672,6 +876,7 @@ export function createFormStore(
           }
         }
 
+        get().clearExtensionsForFields([fieldId]);
         set({ normalized: { byId, pages } });
         return true;
       }
@@ -687,6 +892,7 @@ export function createFormStore(
           } as FieldDefinition)
       );
       if (!result) return false;
+      if (isTypeChange) get().clearExtensionsForFields([fieldId]);
       set({ normalized: result });
       return true;
     },
@@ -723,6 +929,7 @@ export function createFormStore(
         });
       }
 
+      get().clearExtensionsForFields([...toRemove]);
       set({ normalized: { byId, pages } });
       return true;
     },
@@ -767,6 +974,7 @@ export function createFormStore(
         if (!toRemove.has(id)) byId[id] = n;
       }
       const pages = normalized.pages.filter((p) => p.id !== pageId);
+      get().clearExtensionsForFields([...toRemove]);
       set({ normalized: { byId, pages } });
       return true;
     },

--- a/packages/core/src/lib/stores/form-store.ts
+++ b/packages/core/src/lib/stores/form-store.ts
@@ -31,6 +31,7 @@ import {
   hydrateDefinition,
 } from '../functions/normalize.js';
 import { hydrateResponse } from '../functions/hydrate-response.js';
+import { recordActivity } from '../functions/activity.js';
 import { resolveEffect } from '../logic/resolve.js';
 import {
   evaluateJsExpression,
@@ -589,7 +590,10 @@ export function createFormStore(
         const nextEdited = new Set(state.userEditedFields);
         nextEdited.add(fieldId);
         if (!state.dangerouslyAllowJS)
-          return { responses: updated, userEditedFields: nextEdited };
+          return {
+            responses: recordActivity(state, fieldId, updated),
+            userEditedFields: nextEdited,
+          };
         // Apply calculations for all fields that have a calculation string
         const calcResponses = { ...updated };
         for (const [calcId, node] of Object.entries(state.normalized.byId)) {
@@ -607,7 +611,10 @@ export function createFormStore(
             calcResponses[calcId] = { answer: String(result) };
           }
         }
-        return { responses: calcResponses, userEditedFields: nextEdited };
+        return {
+          responses: recordActivity(state, fieldId, calcResponses),
+          userEditedFields: nextEdited,
+        };
       }),
 
     clearResponse: (fieldId) =>

--- a/packages/core/src/lib/types.spec.ts
+++ b/packages/core/src/lib/types.spec.ts
@@ -21,7 +21,7 @@ describe('schema types', () => {
     expect(FIELD_TYPES).toContain('display');
     expect(FIELD_TYPES).toContain('file');
     expect(FIELD_TYPES).toContain('openchoice');
-    expect(FIELD_TYPES).toHaveLength(22);
+    expect(FIELD_TYPES).toHaveLength(23);
   });
 
   it('should allow constructing a valid FormDefinition', () => {

--- a/packages/core/src/lib/types.spec.ts
+++ b/packages/core/src/lib/types.spec.ts
@@ -21,7 +21,7 @@ describe('schema types', () => {
     expect(FIELD_TYPES).toContain('display');
     expect(FIELD_TYPES).toContain('file');
     expect(FIELD_TYPES).toContain('openchoice');
-    expect(FIELD_TYPES).toHaveLength(23);
+    expect(FIELD_TYPES).toHaveLength(24);
   });
 
   it('should allow constructing a valid FormDefinition', () => {

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -25,6 +25,7 @@ export const FIELD_TYPES = [
   'signature',
   'diagram',
   'file',
+  'notes',
   'openchoice',
   'display',
   'section',
@@ -285,6 +286,7 @@ export type FieldCategory =
  * - `multitext`      - per-option text (`field.options[].answer`)
  * - `matrix`         - row -> column mapping (`field.selected: Record`)
  * - `media`          - binary/base64 data
+ * - `notes`          - array of note entries (`field.notes: NoteEntry[]`)
  * - `display`        - no answer (presentational only)
  * - `container`      - no own answer (children hold answers)
  * - `none`           - unsupported / no answer
@@ -296,6 +298,7 @@ export type AnswerType =
   | 'multitext'
   | 'matrix'
   | 'media'
+  | 'notes'
   | 'display'
   | 'container'
   | 'none';
@@ -688,6 +691,24 @@ export interface FileFieldDefinition extends BaseFieldDefinition {
   maxFiles?: number;
 }
 
+export interface NotesFieldDefinition extends BaseFieldDefinition {
+  fieldType: 'notes';
+  /** Allow file/image attachments per note. Default false. */
+  allowAttachments?: boolean;
+  /** Accept string for the attachment input (same semantics as FileFieldDefinition). */
+  accept?: string;
+  /** Maximum allowed attachment size in bytes (optional). */
+  maxFileSize?: number;
+  /** Maximum number of attachments per note (optional). */
+  maxAttachments?: number;
+  /** Maximum number of note entries (optional). */
+  maxNotes?: number;
+  /** Display order of the entry list. Default 'newest'. */
+  sortOrder?: 'newest' | 'oldest';
+  /** Label for one entry, e.g. "Note", "Letter", "Comment". Default "Note". */
+  entryLabel?: string;
+}
+
 export interface OpenChoiceFieldDefinition extends BaseFieldDefinition {
   fieldType: 'openchoice';
   /** Predefined selectable options. */
@@ -773,6 +794,7 @@ export type FieldDefinition =
   // Rich
   | ImageFieldDefinition
   | FileFieldDefinition
+  | NotesFieldDefinition
   | HtmlFieldDefinition
   | SignatureFieldDefinition
   | DiagramFieldDefinition
@@ -839,6 +861,15 @@ const FIELD_TYPE_PROPERTIES: Record<FieldType, readonly string[]> = {
   signature: ['padPlaceholder'],
   diagram: ['imageUri', 'padPlaceholder'],
   file: ['accept', 'maxFileSize', 'maxFiles'],
+  notes: [
+    'allowAttachments',
+    'accept',
+    'maxFileSize',
+    'maxAttachments',
+    'maxNotes',
+    'sortOrder',
+    'entryLabel',
+  ],
   openchoice: ['options', 'maxCustomOptions', 'otherLabel', 'optionLayout'],
   display: ['content'],
   // Organization category
@@ -1118,6 +1149,18 @@ const fileFieldSchema = z.strictObject({
   maxFiles: z.optional(z.number()),
 });
 
+const notesFieldSchema = z.strictObject({
+  ...baseFieldProps,
+  fieldType: z.literal('notes'),
+  allowAttachments: z.optional(z.boolean()),
+  accept: z.optional(z.string()),
+  maxFileSize: z.optional(z.number()),
+  maxAttachments: z.optional(z.number()),
+  maxNotes: z.optional(z.number()),
+  sortOrder: z.optional(z.enum(['newest', 'oldest'])),
+  entryLabel: z.optional(z.string()),
+});
+
 const openChoiceFieldSchema = z.strictObject({
   ...baseFieldProps,
   fieldType: z.literal('openchoice'),
@@ -1191,6 +1234,7 @@ const builtInFieldDefinitionSchema = z.discriminatedUnion('fieldType', [
   // Rich
   imageFieldSchema,
   fileFieldSchema,
+  notesFieldSchema,
   htmlFieldSchema,
   signatureFieldSchema,
   diagramFieldSchema,
@@ -1280,6 +1324,8 @@ export interface FieldResponse {
   markupImage?: string;
   /** File/attachment(s) uploaded by user (file field). Supports single or multiple files. */
   fileData?: AttachmentAnswer | AttachmentAnswer[];
+  /** Note entries (notes field). A set keyed by `NoteEntry.id`, not a positional array. */
+  notes?: NoteEntry[];
   /** Set to true when the response was filled programmatically by an AI agent. */
   _ai?: boolean;
 }
@@ -1471,6 +1517,35 @@ export type AttachmentAnswer = {
   size?: number;
 };
 
+/** Zod schema for AttachmentAnswer. */
+export const attachmentAnswerSchema = z.object({
+  contentType: z.string(),
+  dataUrl: z.optional(z.string()),
+  url: z.optional(z.string()),
+  title: z.optional(z.string()),
+  size: z.optional(z.number()),
+});
+
+/**
+ * One entry in a notes field. Every entry carries a stable GUID so `notes[]`
+ * merges as a set keyed by `id` (see `mergeNotes`), not a positional array.
+ */
+export const noteEntrySchema = z.object({
+  /** GUID (crypto.randomUUID()), stable across edits. */
+  id: z.string(),
+  /** ISO 8601 creation timestamp. */
+  createdAt: z.string(),
+  /** ISO 8601 timestamp of the last edit (absent until first edit). */
+  updatedAt: z.optional(z.string()),
+  /** Host-supplied display name of the author. */
+  author: z.optional(z.string()),
+  /** The note body, raw markdown. */
+  markdown: z.string(),
+  /** Attachments on this note (reuses the file-field attachment shape). */
+  attachments: z.optional(z.array(attachmentAnswerSchema)),
+});
+export type NoteEntry = z.infer<typeof noteEntrySchema>;
+
 /** All possible answer value shapes in a submission payload. */
 export type AnswerValue =
   | string
@@ -1482,6 +1557,7 @@ export type AnswerValue =
   | RankedAnswer[]
   | ResponseItem[]
   | AttachmentAnswer
+  | NoteEntry[]
   | Record<string, SelectedOption | SelectedOption[]>;
 
 /** A single item in the submission payload - one per answerable field. */

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -26,6 +26,7 @@ export const FIELD_TYPES = [
   'diagram',
   'file',
   'notes',
+  'activity',
   'openchoice',
   'display',
   'section',
@@ -709,6 +710,15 @@ export interface NotesFieldDefinition extends BaseFieldDefinition {
   entryLabel?: string;
 }
 
+/**
+ * Read-only, append-only log of response changes over time. Rendered by the
+ * `activity` field; entries live under the reserved `_activity` response key
+ * and are GUID-keyed so the log union-merges exactly like notes.
+ */
+export interface ActivityFieldDefinition extends BaseFieldDefinition {
+  fieldType: 'activity';
+}
+
 export interface OpenChoiceFieldDefinition extends BaseFieldDefinition {
   fieldType: 'openchoice';
   /** Predefined selectable options. */
@@ -795,6 +805,7 @@ export type FieldDefinition =
   | ImageFieldDefinition
   | FileFieldDefinition
   | NotesFieldDefinition
+  | ActivityFieldDefinition
   | HtmlFieldDefinition
   | SignatureFieldDefinition
   | DiagramFieldDefinition
@@ -870,6 +881,7 @@ const FIELD_TYPE_PROPERTIES: Record<FieldType, readonly string[]> = {
     'sortOrder',
     'entryLabel',
   ],
+  activity: [],
   openchoice: ['options', 'maxCustomOptions', 'otherLabel', 'optionLayout'],
   display: ['content'],
   // Organization category
@@ -1161,6 +1173,11 @@ const notesFieldSchema = z.strictObject({
   entryLabel: z.optional(z.string()),
 });
 
+const activityFieldSchema = z.strictObject({
+  ...baseFieldProps,
+  fieldType: z.literal('activity'),
+});
+
 const openChoiceFieldSchema = z.strictObject({
   ...baseFieldProps,
   fieldType: z.literal('openchoice'),
@@ -1235,6 +1252,7 @@ const builtInFieldDefinitionSchema = z.discriminatedUnion('fieldType', [
   imageFieldSchema,
   fileFieldSchema,
   notesFieldSchema,
+  activityFieldSchema,
   htmlFieldSchema,
   signatureFieldSchema,
   diagramFieldSchema,
@@ -1326,6 +1344,8 @@ export interface FieldResponse {
   fileData?: AttachmentAnswer | AttachmentAnswer[];
   /** Note entries (notes field). A set keyed by `NoteEntry.id`, not a positional array. */
   notes?: NoteEntry[];
+  /** Append-only response change log (reserved `_activity` key; activity field). */
+  activity?: ActivityEntry[];
   /** Set to true when the response was filled programmatically by an AI agent. */
   _ai?: boolean;
 }
@@ -1545,6 +1565,28 @@ export const noteEntrySchema = z.object({
   attachments: z.optional(z.array(attachmentAnswerSchema)),
 });
 export type NoteEntry = z.infer<typeof noteEntrySchema>;
+
+/**
+ * One entry in the append-only response change log (activity page type).
+ * GUID-keyed so concurrent logs union-merge exactly like notes.
+ */
+export const activityEntrySchema = z.object({
+  /** GUID (crypto.randomUUID()). */
+  id: z.string(),
+  /** ISO 8601 timestamp of the change. */
+  at: z.string(),
+  /** From renderer identity, when present. */
+  author: z.optional(z.string()),
+  /** Which response changed. */
+  fieldId: z.string(),
+  /** Field label at time of change. */
+  question: z.optional(z.string()),
+  /** Display form of the previous value. */
+  from: z.optional(z.string()),
+  /** Display form of the new value. */
+  to: z.optional(z.string()),
+});
+export type ActivityEntry = z.infer<typeof activityEntrySchema>;
 
 /** All possible answer value shapes in a submission payload. */
 export type AnswerValue =

--- a/packages/document-list-field/eslint.config.mjs
+++ b/packages/document-list-field/eslint.config.mjs
@@ -1,0 +1,8 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    ignores: ['**/out-tsc'],
+  },
+];

--- a/packages/document-list-field/package.json
+++ b/packages/document-list-field/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@esheet/document-list-field",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mieweb/eSheet"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite build",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "typecheck": "tsc --build --emitDeclarationOnly"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@esheet/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@esheet/core": "workspace:*",
+    "@esheet/fields": "workspace:*",
+    "@mieweb/datavis": "1.6.0",
+    "@mieweb/ui": "0.7.1",
+    "ag-grid-community": "^35.1.0",
+    "ag-grid-react": "^35.1.0",
+    "datavis-ace": "4.1.0",
+    "lucide-react": "^1.31.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  }
+}

--- a/packages/document-list-field/package.json
+++ b/packages/document-list-field/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@esheet/core": "workspace:*",
     "@esheet/fields": "workspace:*",
+    "@kerebron/editor": "^0.8.10",
+    "@kerebron/editor-kits": "^0.8.10",
     "@mieweb/datavis": "1.6.0",
     "@mieweb/ui": "0.7.1",
     "ag-grid-community": "^35.1.0",

--- a/packages/document-list-field/src/DocumentListField.tsx
+++ b/packages/document-list-field/src/DocumentListField.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -11,21 +12,52 @@ import {
   DocumentListGrid,
   useDocumentListFieldHost,
   useDocumentListFieldRuntime,
+  type DocumentListColumn,
 } from './DocumentListGrid.js';
-import { normalizeDocumentRows, parseDocumentListAnswer } from './data.js';
+import {
+  DOCUMENT_LIST_COLUMNS,
+  documentListValueFromRows,
+  normalizeDocumentRows,
+  parseDocumentListAnswer,
+} from './data.js';
 import {
   getDocumentListRuntimeState,
   type DocumentListRuntimeState,
 } from './document-list-runtime.js';
 import {
-  DocumentListComposeModal,
+  DocumentListComposePanel,
   DocumentListDetailRow,
-  DocumentListUploadModal,
+  DocumentListUploadPanel,
 } from './DocumentListWorkflows.js';
-import type { DocumentListDefinition, DocumentListDocument } from './types.js';
+import type {
+  DocumentListDefinition,
+  DocumentListDocument,
+  DocumentListWorkflow,
+} from './types.js';
 
 const subscribeToNothing = (): (() => void) => () => {};
 const getEmptyRuntimeState = (): DocumentListRuntimeState | null => null;
+
+/** A field offers every workflow unless its definition names a subset. */
+function offers(
+  definition: DocumentListDefinition,
+  workflow: DocumentListWorkflow
+): boolean {
+  return !definition.workflows || definition.workflows.includes(workflow);
+}
+
+/** The named columns in the order the definition gives them, or all of them. */
+function columnsOf(
+  definition: DocumentListDefinition
+): readonly DocumentListColumn[] | undefined {
+  if (!definition.columns) return undefined;
+  return definition.columns.flatMap((name) => {
+    const column = DOCUMENT_LIST_COLUMNS.find(
+      (candidate) => candidate.field === name
+    );
+    return column ? [column] : [];
+  });
+}
 
 function runtimeRows(
   state: {
@@ -44,6 +76,7 @@ export function DocumentListField({
   field,
   form,
   response,
+  onResponse,
 }: FieldComponentProps): React.JSX.Element {
   const definition = field.definition as DocumentListDefinition;
   const host = useDocumentListFieldHost();
@@ -55,7 +88,16 @@ export function DocumentListField({
         : normalizeDocumentRows(definition.documents),
     [definition.documents, response?.answer]
   );
-  useDocumentListFieldRuntime(field.definition.id, initialRows);
+  const publishRows = useCallback(
+    (rows: readonly DocumentListDocument[]) => {
+      onResponse?.({
+        ...response,
+        answer: JSON.stringify(documentListValueFromRows(rows)),
+      });
+    },
+    [onResponse, response]
+  );
+  useDocumentListFieldRuntime(field.definition.id, initialRows, publishRows);
   const runtimeState = useSyncExternalStore(
     formStore?.subscribe ?? subscribeToNothing,
     () =>
@@ -88,6 +130,9 @@ export function DocumentListField({
     typeof definition.question === 'string' && definition.question.trim()
       ? definition.question
       : 'Documents';
+  const noun = definition.noun?.trim() || undefined;
+  const columns = columnsOf(definition);
+  const columnFields = columns?.map((column) => column.field);
   const formInstanceId = form?.getState().instanceId ?? 'document-list-form';
   const inputPrefix = `${formInstanceId}-${field.definition.id}`;
   const gridDetailRowsExpanded = host?.detailRowsExpanded ?? detailRowsExpanded;
@@ -96,16 +141,18 @@ export function DocumentListField({
     (runtimeState
       ? () => setDetailRowsExpanded((expanded) => !expanded)
       : undefined);
-  const handleCompose = runtimeState
-    ? host?.onCompose
-      ? () => void host.onCompose?.(runtimeState)
-      : () => setComposeOpen(true)
-    : undefined;
-  const handleUpload = runtimeState
-    ? host?.onUpload
-      ? () => void host.onUpload?.(runtimeState)
-      : () => setUploadOpen(true)
-    : undefined;
+  const handleCompose =
+    runtimeState && offers(definition, 'compose')
+      ? host?.onCompose
+        ? () => void host.onCompose?.(runtimeState)
+        : () => setComposeOpen(true)
+      : undefined;
+  const handleUpload =
+    runtimeState && offers(definition, 'upload')
+      ? host?.onUpload
+        ? () => void host.onUpload?.(runtimeState)
+        : () => setUploadOpen(true)
+      : undefined;
   const detailRenderer = host?.renderDetailRow
     ? host.renderDetailRow
     : runtimeState
@@ -115,10 +162,17 @@ export function DocumentListField({
     : undefined;
 
   return (
-    <section className="document-list-field" aria-label={title}>
+    <section
+      className={`document-list-field${
+        composeOpen || uploadOpen ? ' document-list-field--workflow-open' : ''
+      }`}
+      aria-label={title}
+    >
       <DocumentListGrid
         rows={rows}
         title={title}
+        noun={noun}
+        columns={columns}
         titleActions={host?.titleActions}
         renderActions={host?.renderActions}
         getRowCapabilities={host?.getRowCapabilities}
@@ -134,20 +188,27 @@ export function DocumentListField({
         }
         error={runtimeState?.error ?? host?.error}
       />
-      {runtimeState && !host?.onCompose && (
-        <DocumentListComposeModal
-          open={composeOpen}
+      {runtimeState && !host?.onCompose && composeOpen && (
+        <DocumentListComposePanel
+          open
           onOpenChange={setComposeOpen}
           runtime={runtimeState}
           inputPrefix={inputPrefix}
+          noun={noun}
+          fields={columnFields}
+          docTypes={definition.docTypes}
+          defaultInline={definition.inline}
         />
       )}
-      {runtimeState && !host?.onUpload && (
-        <DocumentListUploadModal
-          open={uploadOpen}
+      {runtimeState && !host?.onUpload && uploadOpen && (
+        <DocumentListUploadPanel
+          open
           onOpenChange={setUploadOpen}
           runtime={runtimeState}
           inputPrefix={inputPrefix}
+          noun={noun}
+          accept={definition.accept}
+          maxFileSize={definition.maxFileSize}
         />
       )}
     </section>

--- a/packages/document-list-field/src/DocumentListField.tsx
+++ b/packages/document-list-field/src/DocumentListField.tsx
@@ -1,11 +1,33 @@
-import { useMemo } from 'react';
+import { useContext, useEffect, useMemo, useSyncExternalStore } from 'react';
 import type { FieldComponentProps } from '@esheet/core';
+import { FormStoreContext } from '@esheet/fields';
 import {
   DocumentListGrid,
   useDocumentListFieldHost,
+  useDocumentListFieldRuntime,
 } from './DocumentListGrid.js';
 import { normalizeDocumentRows, parseDocumentListAnswer } from './data.js';
-import type { DocumentListDefinition } from './types.js';
+import {
+  getDocumentListRuntimeState,
+  type DocumentListRuntimeState,
+} from './document-list-runtime.js';
+import type { DocumentListDefinition, DocumentListDocument } from './types.js';
+
+const subscribeToNothing = (): (() => void) => () => {};
+const getEmptyRuntimeState = (): DocumentListRuntimeState | null => null;
+
+function runtimeRows(
+  state: {
+    readonly documentIds: readonly string[];
+    readonly documents: Readonly<Record<string, DocumentListDocument>>;
+  } | null
+): DocumentListDocument[] | null {
+  if (!state) return null;
+  return state.documentIds.flatMap((documentId) => {
+    const document = state.documents[documentId];
+    return document ? [document] : [];
+  });
+}
 
 export function DocumentListField({
   field,
@@ -13,13 +35,40 @@ export function DocumentListField({
 }: FieldComponentProps): React.JSX.Element {
   const definition = field.definition as DocumentListDefinition;
   const host = useDocumentListFieldHost();
-  const rows = useMemo(
+  const formStore = useContext(FormStoreContext);
+  const initialRows = useMemo(
     () =>
       response?.answer
         ? parseDocumentListAnswer(response.answer)
         : normalizeDocumentRows(definition.documents),
     [definition.documents, response?.answer]
   );
+  useDocumentListFieldRuntime(field.definition.id, initialRows);
+  const runtimeState = useSyncExternalStore(
+    formStore?.subscribe ?? subscribeToNothing,
+    () =>
+      formStore
+        ? getDocumentListRuntimeState(formStore, field.definition.id) ?? null
+        : null,
+    getEmptyRuntimeState
+  );
+  const rows = useMemo(
+    () => runtimeRows(runtimeState) ?? initialRows,
+    [initialRows, runtimeState]
+  );
+
+  useEffect(() => {
+    if (!formStore) return;
+    const runtimeState = getDocumentListRuntimeState(
+      formStore,
+      field.definition.id
+    );
+    if (!runtimeState) return;
+    runtimeState.hydrateSnapshot({ documents: initialRows });
+    runtimeState.start();
+    void runtimeState.refresh().catch(() => undefined);
+  }, [field.definition.id, formStore, initialRows]);
+
   const title =
     typeof definition.question === 'string' && definition.question.trim()
       ? definition.question
@@ -27,7 +76,25 @@ export function DocumentListField({
 
   return (
     <section className="document-list-field" aria-label={title}>
-      <DocumentListGrid rows={rows} title={title} {...(host ?? {})} />
+      <DocumentListGrid
+        rows={rows}
+        title={title}
+        {...(host ?? {})}
+        onCompose={
+          host?.onCompose && runtimeState
+            ? () => void host.onCompose?.(runtimeState)
+            : undefined
+        }
+        onUpload={
+          host?.onUpload && runtimeState
+            ? () => void host.onUpload?.(runtimeState)
+            : undefined
+        }
+        loading={
+          host?.loading === true || runtimeState?.syncStatus === 'loading'
+        }
+        error={runtimeState?.error ?? host?.error}
+      />
     </section>
   );
 }

--- a/packages/document-list-field/src/DocumentListField.tsx
+++ b/packages/document-list-field/src/DocumentListField.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import type { FieldComponentProps } from '@esheet/core';
+import {
+  DocumentListGrid,
+  useDocumentListFieldHost,
+} from './DocumentListGrid.js';
+import { normalizeDocumentRows, parseDocumentListAnswer } from './data.js';
+import type { DocumentListDefinition } from './types.js';
+
+export function DocumentListField({
+  field,
+  response,
+}: FieldComponentProps): React.JSX.Element {
+  const definition = field.definition as DocumentListDefinition;
+  const host = useDocumentListFieldHost();
+  const rows = useMemo(
+    () =>
+      response?.answer
+        ? parseDocumentListAnswer(response.answer)
+        : normalizeDocumentRows(definition.documents),
+    [definition.documents, response?.answer]
+  );
+  const title =
+    typeof definition.question === 'string' && definition.question.trim()
+      ? definition.question
+      : 'Documents';
+
+  return (
+    <section className="document-list-field" aria-label={title}>
+      <DocumentListGrid rows={rows} title={title} {...(host ?? {})} />
+    </section>
+  );
+}

--- a/packages/document-list-field/src/DocumentListField.tsx
+++ b/packages/document-list-field/src/DocumentListField.tsx
@@ -1,4 +1,10 @@
-import { useContext, useEffect, useMemo, useSyncExternalStore } from 'react';
+import {
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import type { FieldComponentProps } from '@esheet/core';
 import { FormStoreContext } from '@esheet/fields';
 import {
@@ -11,6 +17,11 @@ import {
   getDocumentListRuntimeState,
   type DocumentListRuntimeState,
 } from './document-list-runtime.js';
+import {
+  DocumentListComposeModal,
+  DocumentListDetailRow,
+  DocumentListUploadModal,
+} from './DocumentListWorkflows.js';
 import type { DocumentListDefinition, DocumentListDocument } from './types.js';
 
 const subscribeToNothing = (): (() => void) => () => {};
@@ -31,6 +42,7 @@ function runtimeRows(
 
 export function DocumentListField({
   field,
+  form,
   response,
 }: FieldComponentProps): React.JSX.Element {
   const definition = field.definition as DocumentListDefinition;
@@ -56,6 +68,9 @@ export function DocumentListField({
     () => runtimeRows(runtimeState) ?? initialRows,
     [initialRows, runtimeState]
   );
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [detailRowsExpanded, setDetailRowsExpanded] = useState(false);
 
   useEffect(() => {
     if (!formStore) return;
@@ -73,28 +88,68 @@ export function DocumentListField({
     typeof definition.question === 'string' && definition.question.trim()
       ? definition.question
       : 'Documents';
+  const formInstanceId = form?.getState().instanceId ?? 'document-list-form';
+  const inputPrefix = `${formInstanceId}-${field.definition.id}`;
+  const gridDetailRowsExpanded = host?.detailRowsExpanded ?? detailRowsExpanded;
+  const handleToggleDetails =
+    host?.onToggleDetails ??
+    (runtimeState
+      ? () => setDetailRowsExpanded((expanded) => !expanded)
+      : undefined);
+  const handleCompose = runtimeState
+    ? host?.onCompose
+      ? () => void host.onCompose?.(runtimeState)
+      : () => setComposeOpen(true)
+    : undefined;
+  const handleUpload = runtimeState
+    ? host?.onUpload
+      ? () => void host.onUpload?.(runtimeState)
+      : () => setUploadOpen(true)
+    : undefined;
+  const detailRenderer = host?.renderDetailRow
+    ? host.renderDetailRow
+    : runtimeState
+    ? (row: DocumentListDocument) => (
+        <DocumentListDetailRow document={row} runtime={runtimeState} />
+      )
+    : undefined;
 
   return (
     <section className="document-list-field" aria-label={title}>
       <DocumentListGrid
         rows={rows}
         title={title}
-        {...(host ?? {})}
-        onCompose={
-          host?.onCompose && runtimeState
-            ? () => void host.onCompose?.(runtimeState)
-            : undefined
-        }
-        onUpload={
-          host?.onUpload && runtimeState
-            ? () => void host.onUpload?.(runtimeState)
-            : undefined
-        }
+        titleActions={host?.titleActions}
+        renderActions={host?.renderActions}
+        getRowCapabilities={host?.getRowCapabilities}
+        onRowClick={host?.onRowClick}
+        onRowDoubleClick={host?.onRowDoubleClick}
+        renderDetailRow={detailRenderer}
+        detailRowsExpanded={gridDetailRowsExpanded}
+        onToggleDetails={handleToggleDetails}
+        onCompose={handleCompose}
+        onUpload={handleUpload}
         loading={
           host?.loading === true || runtimeState?.syncStatus === 'loading'
         }
         error={runtimeState?.error ?? host?.error}
       />
+      {runtimeState && !host?.onCompose && (
+        <DocumentListComposeModal
+          open={composeOpen}
+          onOpenChange={setComposeOpen}
+          runtime={runtimeState}
+          inputPrefix={inputPrefix}
+        />
+      )}
+      {runtimeState && !host?.onUpload && (
+        <DocumentListUploadModal
+          open={uploadOpen}
+          onOpenChange={setUploadOpen}
+          runtime={runtimeState}
+          inputPrefix={inputPrefix}
+        />
+      )}
     </section>
   );
 }

--- a/packages/document-list-field/src/DocumentListFieldProvider.spec.tsx
+++ b/packages/document-list-field/src/DocumentListFieldProvider.spec.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import {
+  DocumentListFieldProvider,
+  useDocumentListFieldHost,
+} from './DocumentListGrid.js';
+
+function HostProbe(): React.JSX.Element {
+  const host = useDocumentListFieldHost();
+  return <output>{host?.detailRowsExpanded ? 'expanded' : 'collapsed'}</output>;
+}
+
+describe('DocumentListFieldProvider', () => {
+  it('makes host controls available without changing the field value', () => {
+    render(
+      <DocumentListFieldProvider host={{ detailRowsExpanded: true }}>
+        <HostProbe />
+      </DocumentListFieldProvider>
+    );
+
+    expect(screen.getByText('expanded')).toBeTruthy();
+  });
+
+  it('returns no host when the field is not wrapped', () => {
+    render(<HostProbe />);
+
+    expect(screen.getByText('collapsed')).toBeTruthy();
+  });
+});

--- a/packages/document-list-field/src/DocumentListFieldProvider.spec.tsx
+++ b/packages/document-list-field/src/DocumentListFieldProvider.spec.tsx
@@ -1,15 +1,42 @@
 import { render, screen } from '@testing-library/react';
+import { createFormStore } from '@esheet/core';
+import { FormStoreContext } from '@esheet/fields';
 import {
   DocumentListFieldProvider,
   useDocumentListFieldHost,
+  useDocumentListFieldRuntime,
 } from './DocumentListGrid.js';
+import type { DocumentListDocument } from './types.js';
 
 function HostProbe(): React.JSX.Element {
   const host = useDocumentListFieldHost();
   return <output>{host?.detailRowsExpanded ? 'expanded' : 'collapsed'}</output>;
 }
 
+const document: DocumentListDocument = {
+  id: 'doc-1',
+  date: '2026-08-18',
+  title: 'Letter',
+  subject: 'Subject',
+  docType: 'Letter',
+  docId: '42',
+  source: 'WebChart',
+  file: '42.pdf',
+};
+
+const runtimeStores: unknown[] = [];
+
+function RuntimeProbe({ fieldId }: { fieldId: string }): React.JSX.Element {
+  const store = useDocumentListFieldRuntime(fieldId, [document]);
+  if (store) runtimeStores.push(store);
+  return <output>{store?.documentIds.join(',') ?? 'missing'}</output>;
+}
+
 describe('DocumentListFieldProvider', () => {
+  beforeEach(() => {
+    runtimeStores.length = 0;
+  });
+
   it('makes host controls available without changing the field value', () => {
     render(
       <DocumentListFieldProvider host={{ detailRowsExpanded: true }}>
@@ -24,5 +51,60 @@ describe('DocumentListFieldProvider', () => {
     render(<HostProbe />);
 
     expect(screen.getByText('collapsed')).toBeTruthy();
+  });
+
+  it('registers one extension per field in the core form store', () => {
+    const formStore = createFormStore();
+    const { unmount } = render(
+      <FormStoreContext.Provider value={formStore}>
+        <DocumentListFieldProvider host={{}}>
+          <RuntimeProbe fieldId="documents" />
+          <RuntimeProbe fieldId="documents" />
+        </DocumentListFieldProvider>
+      </FormStoreContext.Provider>
+    );
+
+    expect(screen.getAllByText('doc-1')).toHaveLength(2);
+    expect(runtimeStores[0]).toBe(runtimeStores[1]);
+    expect(
+      formStore.getState().getExtension('documents', 'documents')
+    ).toBeUndefined();
+    expect(
+      formStore
+        .getState()
+        .getExtension('@esheet/document-list-field', 'documents')
+    ).toBe(runtimeStores[0]);
+    unmount();
+  });
+
+  it('isolates extension state between core form stores', () => {
+    const firstFormStore = createFormStore();
+    const secondFormStore = createFormStore();
+    render(
+      <>
+        <FormStoreContext.Provider value={firstFormStore}>
+          <DocumentListFieldProvider host={{}}>
+            <RuntimeProbe fieldId="documents" />
+          </DocumentListFieldProvider>
+        </FormStoreContext.Provider>
+        <FormStoreContext.Provider value={secondFormStore}>
+          <DocumentListFieldProvider host={{}}>
+            <RuntimeProbe fieldId="documents" />
+          </DocumentListFieldProvider>
+        </FormStoreContext.Provider>
+      </>
+    );
+
+    expect(screen.getAllByText('doc-1')).toHaveLength(2);
+    expect(
+      firstFormStore
+        .getState()
+        .getExtension('@esheet/document-list-field', 'documents')
+    ).toBeTruthy();
+    expect(
+      secondFormStore
+        .getState()
+        .getExtension('@esheet/document-list-field', 'documents')
+    ).toBeTruthy();
   });
 });

--- a/packages/document-list-field/src/DocumentListGrid.spec.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.spec.tsx
@@ -20,7 +20,7 @@ vi.mock('@mieweb/ui/datavis', () => ({
   },
   DataVisNitroGrid: (props: Record<string, unknown>) => {
     captured.props = props;
-    return null;
+    return (props.titleActions as ReactNode) ?? null;
   },
 }));
 
@@ -152,6 +152,9 @@ describe('DocumentListGrid host integration', () => {
         screen.getByRole('button', { name: 'Toggle all document details' })
       ).toBeTruthy()
     );
+    expect(
+      (captured.props as { titleActions: ReactNode }).titleActions
+    ).toBeTruthy();
 
     const detailButton = screen.getByRole('button', {
       name: 'Toggle all document details',

--- a/packages/document-list-field/src/DocumentListGrid.spec.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.spec.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import type { FieldComponentProps } from '@esheet/core';
+import { createFormStore, type FieldComponentProps } from '@esheet/core';
+import { FormStoreContext } from '@esheet/fields';
 import { DocumentListField } from './DocumentListField.js';
-import { DocumentListGrid } from './DocumentListGrid.js';
+import {
+  DocumentListFieldProvider,
+  DocumentListGrid,
+} from './DocumentListGrid.js';
 import type { DocumentListDocument } from './types.js';
 
 const captured = {
@@ -186,6 +190,57 @@ describe('DocumentListGrid host integration', () => {
           .getAttribute('aria-pressed')
       ).toBe('true')
     );
+  });
+
+  it('uses package workflow defaults with a repository-only runtime', async () => {
+    const formStore = createFormStore();
+    const customDetail = vi.fn(() => <div>Custom detail</div>);
+    const repository = {
+      load: vi.fn(async () => ({ documents: [row] })),
+      save: vi.fn(
+        async (_context: unknown, document: DocumentListDocument) => document
+      ),
+      remove: vi.fn(async () => undefined),
+      loadContent: vi.fn(async () => ({ text: 'Loaded content' })),
+    };
+    const field = {
+      definition: { id: 'documents', question: 'Documents' },
+    } as unknown as FieldComponentProps['field'];
+    const fieldProps = {
+      field,
+      form: formStore,
+      response: undefined,
+    } as unknown as FieldComponentProps;
+
+    render(
+      <FormStoreContext.Provider value={formStore}>
+        <DocumentListFieldProvider
+          host={{ renderDetailRow: customDetail }}
+          runtime={{ repository }}
+        >
+          <DocumentListField {...fieldProps} />
+        </DocumentListFieldProvider>
+      </FormStoreContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Compose document' })
+      ).toBeTruthy()
+    );
+    expect(
+      screen.getByRole('button', { name: 'Upload document' })
+    ).toBeTruthy();
+
+    const props = captured.props as {
+      renderDetailRow: (tableRow: {
+        data: Record<string, unknown>;
+      }) => ReactNode;
+    };
+    expect(props.renderDetailRow({ data: tableData })).toEqual(
+      <div>Custom detail</div>
+    );
+    expect(customDetail).toHaveBeenCalledWith(row);
   });
 
   it('publishes an empty source for malformed field responses', async () => {

--- a/packages/document-list-field/src/DocumentListGrid.spec.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.spec.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { DocumentListGrid } from './DocumentListGrid.js';
+import type { DocumentListDocument } from './types.js';
+
+const captured = {
+  props: null as Record<string, unknown> | null,
+};
+
+vi.mock('@mieweb/ui/datavis', () => ({
+  DataVisNitroContext: {
+    Provider: ({ children }: { children: ReactNode }) => children,
+  },
+  DataVisNitroGrid: (props: Record<string, unknown>) => {
+    captured.props = props;
+    return null;
+  },
+}));
+
+vi.mock('datavis-ace', () => {
+  class Source {
+    cache: Record<string, unknown> = {};
+
+    constructor(public readonly options: unknown) {}
+  }
+
+  class ComputedView {
+    source: Source;
+
+    constructor(source: Source) {
+      this.source = source;
+    }
+
+    clearCache(): void {}
+
+    getData(): void {}
+  }
+
+  return { ComputedView, Source };
+});
+
+const row: DocumentListDocument = {
+  id: 'doc-1',
+  date: '2026-08-18',
+  title: 'Letter',
+  subject: 'Subject',
+  docType: 'Letter',
+  docId: '42',
+  source: 'WebChart',
+  file: '42.pdf',
+};
+const tableData: Record<string, unknown> = { ...row };
+
+describe('DocumentListGrid host integration', () => {
+  beforeEach(() => {
+    captured.props = null;
+  });
+
+  it('adds the Actions column and renders host actions for a stable row', async () => {
+    const actionRenderer = vi.fn(() => <button type="button">View</button>);
+
+    render(<DocumentListGrid rows={[row]} renderActions={actionRenderer} />);
+
+    await waitFor(() => expect(captured.props).not.toBeNull());
+
+    const props = captured.props as {
+      columns: readonly { field: string }[];
+      formatCell: (
+        value: unknown,
+        data: Record<string, unknown>,
+        column: { field: string }
+      ) => ReactNode;
+    };
+    expect(props.columns.map((column) => column.field)).toContain('_actions');
+    expect(
+      props.formatCell(undefined, tableData, { field: '_actions' })
+    ).toBeTruthy();
+    expect(actionRenderer).toHaveBeenCalledWith(
+      row,
+      expect.objectContaining({ canView: true, canDelete: true })
+    );
+  });
+
+  it('maps DataVis row events and detail rows to document summaries', async () => {
+    const onRowClick = vi.fn();
+    const onRowDoubleClick = vi.fn();
+    const renderDetailRow = vi.fn(() => <div>Detail</div>);
+
+    render(
+      <DocumentListGrid
+        rows={[row]}
+        onRowClick={onRowClick}
+        onRowDoubleClick={onRowDoubleClick}
+        renderDetailRow={renderDetailRow}
+      />
+    );
+
+    await waitFor(() => expect(captured.props).not.toBeNull());
+
+    const props = captured.props as {
+      onRowClick: (
+        tableRow: { data: Record<string, unknown> },
+        event: unknown
+      ) => void;
+      onRowDoubleClick: (
+        tableRow: { data: Record<string, unknown> },
+        event: unknown
+      ) => void;
+      renderDetailRow: (tableRow: {
+        data: Record<string, unknown>;
+      }) => ReactNode;
+    };
+    const event = {};
+    props.onRowClick({ data: tableData }, event);
+    props.onRowDoubleClick({ data: tableData }, event);
+    props.renderDetailRow({ data: tableData });
+
+    expect(onRowClick).toHaveBeenCalledWith(row, event);
+    expect(onRowDoubleClick).toHaveBeenCalledWith(row, event);
+    expect(renderDetailRow).toHaveBeenCalledWith(row);
+  });
+
+  it('renders standard toolbar controls and dispatches host callbacks', async () => {
+    const onToggleDetails = vi.fn();
+    const onCompose = vi.fn();
+    const onUpload = vi.fn();
+
+    const { rerender } = render(
+      <DocumentListGrid
+        rows={[row]}
+        detailRowsExpanded={false}
+        onToggleDetails={onToggleDetails}
+        onCompose={onCompose}
+        onUpload={onUpload}
+        titleActions={<button type="button">Custom action</button>}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Toggle all document details' })
+      ).toBeTruthy()
+    );
+
+    const detailButton = screen.getByRole('button', {
+      name: 'Toggle all document details',
+    });
+    expect(detailButton.getAttribute('aria-pressed')).toBe('false');
+    expect(
+      screen.getByRole('button', { name: 'Compose document' })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Upload document' })
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Custom action' })).toBeTruthy();
+
+    fireEvent.click(detailButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Compose document' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Upload document' }));
+
+    expect(onToggleDetails).toHaveBeenCalledOnce();
+    expect(onCompose).toHaveBeenCalledOnce();
+    expect(onUpload).toHaveBeenCalledOnce();
+
+    rerender(
+      <DocumentListGrid
+        rows={[row]}
+        detailRowsExpanded
+        onToggleDetails={onToggleDetails}
+        onCompose={onCompose}
+        onUpload={onUpload}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole('button', { name: 'Toggle all document details' })
+          .getAttribute('aria-pressed')
+      ).toBe('true')
+    );
+  });
+});

--- a/packages/document-list-field/src/DocumentListGrid.spec.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.spec.tsx
@@ -1,11 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import type { FieldComponentProps } from '@esheet/core';
+import { DocumentListField } from './DocumentListField.js';
 import { DocumentListGrid } from './DocumentListGrid.js';
 import type { DocumentListDocument } from './types.js';
 
 const captured = {
   props: null as Record<string, unknown> | null,
 };
+const sourceKeys: string[] = [];
 
 vi.mock('@mieweb/ui/datavis', () => ({
   DataVisNitroContext: {
@@ -21,7 +24,10 @@ vi.mock('datavis-ace', () => {
   class Source {
     cache: Record<string, unknown> = {};
 
-    constructor(public readonly options: unknown) {}
+    constructor(public readonly options: unknown) {
+      const varName = (options as { varName?: unknown }).varName;
+      if (typeof varName === 'string') sourceKeys.push(varName);
+    }
   }
 
   class ComputedView {
@@ -54,6 +60,7 @@ const tableData: Record<string, unknown> = { ...row };
 describe('DocumentListGrid host integration', () => {
   beforeEach(() => {
     captured.props = null;
+    sourceKeys.length = 0;
   });
 
   it('adds the Actions column and renders host actions for a stable row', async () => {
@@ -179,5 +186,70 @@ describe('DocumentListGrid host integration', () => {
           .getAttribute('aria-pressed')
       ).toBe('true')
     );
+  });
+
+  it('publishes an empty source for malformed field responses', async () => {
+    const field = {
+      definition: {
+        question: 'Documents',
+        documents: [row],
+      },
+    } as unknown as FieldComponentProps['field'];
+    const props = {
+      field,
+      response: { answer: '{invalid' },
+    } as unknown as FieldComponentProps;
+
+    render(<DocumentListField {...props} />);
+
+    await waitFor(() => expect(sourceKeys).toHaveLength(1));
+    const sourceKey = sourceKeys[0];
+    expect(
+      (window as unknown as Record<string, { data: unknown[] }>)[sourceKey].data
+    ).toEqual([]);
+  });
+
+  it('replaces published rows when the response becomes empty', async () => {
+    const { rerender, unmount } = render(<DocumentListGrid rows={[row]} />);
+
+    await waitFor(() => expect(sourceKeys).toHaveLength(1));
+    const sourceKey = sourceKeys[0];
+    const sources = window as unknown as Record<
+      string,
+      { data: DocumentListDocument[] }
+    >;
+
+    expect(sources[sourceKey].data).toEqual([row]);
+
+    rerender(<DocumentListGrid rows={[]} />);
+
+    await waitFor(() => expect(sources[sourceKey].data).toEqual([]));
+    unmount();
+    expect(sources[sourceKey]).toBeUndefined();
+  });
+
+  it('uses independent source keys for multiple field instances', async () => {
+    const secondRow = { ...row, id: 'doc-2', title: 'Second letter' };
+
+    const { unmount } = render(
+      <>
+        <DocumentListGrid rows={[row]} />
+        <DocumentListGrid rows={[secondRow]} />
+      </>
+    );
+
+    await waitFor(() => expect(sourceKeys).toHaveLength(2));
+    expect(new Set(sourceKeys).size).toBe(2);
+
+    const sources = window as unknown as Record<
+      string,
+      { data: DocumentListDocument[] }
+    >;
+    expect(sources[sourceKeys[0]].data).toEqual([row]);
+    expect(sources[sourceKeys[1]].data).toEqual([secondRow]);
+
+    unmount();
+    expect(sources[sourceKeys[0]]).toBeUndefined();
+    expect(sources[sourceKeys[1]]).toBeUndefined();
   });
 });

--- a/packages/document-list-field/src/DocumentListGrid.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.tsx
@@ -1,0 +1,351 @@
+import {
+  createContext,
+  useEffect,
+  useContext,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ComponentType,
+  type ContextType,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import { Button } from '@mieweb/ui';
+import { DataVisNitroContext, DataVisNitroGrid } from '@mieweb/ui/datavis';
+import { ComputedView, Source } from 'datavis-ace';
+import { LayoutList, SquarePen, Upload } from 'lucide-react';
+import {
+  createLocalSourcePayload,
+  DOCUMENT_LIST_ACTIONS_COLUMN,
+  DOCUMENT_LIST_COLUMNS,
+  normalizeDocumentRow,
+} from './data.js';
+import type { FieldProvider } from '@esheet/fields';
+import type { DocumentListDocument } from './types.js';
+
+type DataVisGridProps = Partial<ComponentProps<typeof DataVisNitroGrid>>;
+type DataVisView = ContextType<typeof DataVisNitroContext>;
+const OptionalDataVisNitroGrid =
+  DataVisNitroGrid as unknown as ComponentType<DataVisGridProps>;
+
+export type DocumentListColumn =
+  | (typeof DOCUMENT_LIST_COLUMNS)[number]
+  | typeof DOCUMENT_LIST_ACTIONS_COLUMN;
+
+export interface DocumentListRowCapabilities {
+  readonly canView: boolean;
+  readonly canCompose: boolean;
+  readonly canEdit: boolean;
+  readonly canRequestSignature: boolean;
+  readonly canDelete: boolean;
+  readonly canDownloadPdf: boolean;
+}
+
+export type DocumentListActionsRenderer = (
+  row: DocumentListDocument,
+  capabilities: DocumentListRowCapabilities
+) => ReactNode;
+
+export interface DocumentListToolbarProps {
+  detailRowsExpanded?: boolean;
+  onToggleDetails?: () => void;
+  onCompose?: () => void;
+  onUpload?: () => void;
+}
+
+export interface DocumentListGridProps extends DocumentListToolbarProps {
+  rows: readonly DocumentListDocument[];
+  title?: string;
+  columns?: readonly DocumentListColumn[];
+  titleActions?: ReactNode;
+  renderActions?: DocumentListActionsRenderer;
+  getRowCapabilities?: (
+    row: DocumentListDocument
+  ) => DocumentListRowCapabilities;
+  formatCell?: DataVisGridProps['formatCell'];
+  onRowClick?: (row: DocumentListDocument, event: MouseEvent) => void;
+  onRowDoubleClick?: (row: DocumentListDocument, event: MouseEvent) => void;
+  renderDetailRow?: (row: DocumentListDocument) => ReactNode;
+  loading?: boolean;
+  error?: ReactNode;
+  style?: DataVisGridProps['style'];
+}
+
+export type DocumentListFieldHost = Pick<
+  DocumentListGridProps,
+  | 'titleActions'
+  | 'renderActions'
+  | 'getRowCapabilities'
+  | 'onRowClick'
+  | 'onRowDoubleClick'
+  | 'renderDetailRow'
+  | 'detailRowsExpanded'
+  | 'onToggleDetails'
+  | 'onCompose'
+  | 'onUpload'
+  | 'loading'
+  | 'error'
+>;
+
+const DocumentListFieldHostContext =
+  createContext<DocumentListFieldHost | null>(null);
+
+export function DocumentListFieldProvider({
+  host,
+  children,
+}: {
+  host: DocumentListFieldHost;
+  children: ReactNode;
+}): React.JSX.Element {
+  return (
+    <DocumentListFieldHostContext.Provider value={host}>
+      {children}
+    </DocumentListFieldHostContext.Provider>
+  );
+}
+
+export function createDocumentListFieldProvider(
+  host: DocumentListFieldHost
+): FieldProvider {
+  return (children) => (
+    <DocumentListFieldProvider host={host}>
+      {children}
+    </DocumentListFieldProvider>
+  );
+}
+
+export function useDocumentListFieldHost(): DocumentListFieldHost | null {
+  return useContext(DocumentListFieldHostContext);
+}
+
+const DEFAULT_ROW_CAPABILITIES: DocumentListRowCapabilities = {
+  canView: true,
+  canCompose: true,
+  canEdit: true,
+  canRequestSignature: true,
+  canDelete: true,
+  canDownloadPdf: false,
+};
+
+interface DataVisTableRow {
+  data: Record<string, unknown>;
+}
+
+function documentFromTableRow(
+  row: DataVisTableRow
+): DocumentListDocument | null {
+  return normalizeDocumentRow(row.data);
+}
+
+let nextSourceId = 0;
+
+function createSourceKey(): string {
+  nextSourceId += 1;
+  return `__esheet_document_list_${nextSourceId}`;
+}
+
+function publishRows(
+  sourceKey: string,
+  rows: readonly DocumentListDocument[]
+): void {
+  const windowRecord = window as unknown as Record<string, unknown>;
+  windowRecord[sourceKey] = createLocalSourcePayload(rows);
+}
+
+function refreshView(view: ComputedView): void {
+  const source = view.source as unknown as { cache?: Record<string, unknown> };
+  source.cache = {};
+  view.clearCache();
+  view.getData();
+}
+
+function useDocumentListView(rows: readonly DocumentListDocument[]): {
+  sourceKey: string;
+  view: DataVisView;
+} {
+  const sourceKey = useRef<string | null>(null);
+  const viewRef = useRef<ComputedView | null>(null);
+  const [view, setView] = useState<DataVisView>(null);
+
+  if (sourceKey.current === null) sourceKey.current = createSourceKey();
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || sourceKey.current === null) return;
+
+    const key = sourceKey.current;
+    publishRows(key, rows);
+    const nextView = new ComputedView(
+      new Source({ type: 'local', varName: key })
+    );
+    viewRef.current = nextView;
+    setView(nextView as unknown as DataVisView);
+
+    return () => {
+      delete (window as unknown as Record<string, unknown>)[key];
+      viewRef.current = null;
+      setView(null);
+    };
+    // The source is intentionally created once per mounted field instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || sourceKey.current === null) return;
+
+    const key = sourceKey.current;
+    publishRows(key, rows);
+    const refreshTimer = window.setTimeout(() => {
+      if (viewRef.current) refreshView(viewRef.current);
+    }, 0);
+
+    return () => window.clearTimeout(refreshTimer);
+  }, [rows]);
+
+  return { sourceKey: sourceKey.current, view };
+}
+
+export function DocumentListGrid({
+  rows,
+  title = 'Documents',
+  columns = DOCUMENT_LIST_COLUMNS,
+  titleActions,
+  renderActions,
+  getRowCapabilities,
+  formatCell,
+  onRowClick,
+  onRowDoubleClick,
+  renderDetailRow,
+  detailRowsExpanded,
+  onToggleDetails,
+  onCompose,
+  onUpload,
+  loading = false,
+  error,
+  style,
+}: DocumentListGridProps): React.JSX.Element {
+  const { view } = useDocumentListView(rows);
+  const gridColumns = renderActions
+    ? columns.some(
+        (column) => column.field === DOCUMENT_LIST_ACTIONS_COLUMN.field
+      )
+      ? columns
+      : [...columns, DOCUMENT_LIST_ACTIONS_COLUMN]
+    : columns;
+  const gridFormatCell: DataVisGridProps['formatCell'] =
+    formatCell || renderActions
+      ? (value, row, column) => {
+          const document = normalizeDocumentRow(row);
+          if (
+            column.field === DOCUMENT_LIST_ACTIONS_COLUMN.field &&
+            document &&
+            renderActions
+          ) {
+            return renderActions(
+              document,
+              getRowCapabilities?.(document) ?? DEFAULT_ROW_CAPABILITIES
+            );
+          }
+          return formatCell?.(value, row, column);
+        }
+      : undefined;
+  const gridOnRowClick: DataVisGridProps['onRowClick'] = onRowClick
+    ? (row, event) => {
+        const document = documentFromTableRow(row);
+        if (document) onRowClick(document, event);
+      }
+    : undefined;
+  const gridOnRowDoubleClick: DataVisGridProps['onRowDoubleClick'] =
+    onRowDoubleClick
+      ? (row, event) => {
+          const document = documentFromTableRow(row);
+          if (document) onRowDoubleClick(document, event);
+        }
+      : undefined;
+  const gridRenderDetailRow: DataVisGridProps['renderDetailRow'] =
+    renderDetailRow
+      ? (row) => {
+          const document = documentFromTableRow(row);
+          return document ? renderDetailRow(document) : null;
+        }
+      : undefined;
+
+  if (!view) {
+    return (
+      <div
+        className="document-list-grid document-list-grid--loading"
+        role="status"
+      >
+        Loading documents…
+      </div>
+    );
+  }
+
+  return (
+    <DataVisNitroContext.Provider value={view}>
+      <div className="document-list-grid">
+        {loading && (
+          <div className="document-list-grid__status" role="status">
+            Loading documents…
+          </div>
+        )}
+        {error && (
+          <div className="document-list-grid__error" role="alert">
+            {error}
+          </div>
+        )}
+        {(titleActions || onToggleDetails || onCompose || onUpload) && (
+          <div className="document-list-grid__title-actions">
+            {onToggleDetails && (
+              <Button
+                type="button"
+                variant={detailRowsExpanded ? 'primary' : 'ghost'}
+                size="sm"
+                onClick={onToggleDetails}
+                aria-label="Toggle all document details"
+                aria-pressed={detailRowsExpanded ?? false}
+                leftIcon={<LayoutList size={16} aria-hidden="true" />}
+              >
+                Detail
+              </Button>
+            )}
+            {onCompose && (
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                onClick={onCompose}
+                aria-label="Compose document"
+                leftIcon={<SquarePen size={16} aria-hidden="true" />}
+              >
+                Compose
+              </Button>
+            )}
+            {onUpload && (
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                onClick={onUpload}
+                aria-label="Upload document"
+                leftIcon={<Upload size={16} aria-hidden="true" />}
+              >
+                Upload
+              </Button>
+            )}
+            {titleActions}
+          </div>
+        )}
+        <OptionalDataVisNitroGrid
+          title={title}
+          columns={gridColumns as DataVisGridProps['columns']}
+          formatCell={gridFormatCell}
+          onRowClick={gridOnRowClick}
+          onRowDoubleClick={gridOnRowDoubleClick}
+          renderDetailRow={gridRenderDetailRow}
+          detailRowsExpanded={detailRowsExpanded}
+          style={{ width: '100%', ...style }}
+        />
+      </div>
+    </DataVisNitroContext.Provider>
+  );
+}

--- a/packages/document-list-field/src/DocumentListGrid.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useEffect,
   useContext,
+  useMemo,
   useRef,
   useState,
   type ComponentProps,
@@ -21,6 +22,12 @@ import {
   normalizeDocumentRow,
 } from './data.js';
 import type { FieldProvider } from '@esheet/fields';
+import { FormStoreContext } from '@esheet/fields';
+import {
+  createDocumentListRuntimeExtension,
+  type DocumentListRepository,
+  type DocumentListRuntimeState,
+} from './document-list-runtime.js';
 import type { DocumentListDocument } from './types.js';
 
 type DataVisGridProps = Partial<ComponentProps<typeof DataVisNitroGrid>>;
@@ -45,6 +52,20 @@ export type DocumentListActionsRenderer = (
   row: DocumentListDocument,
   capabilities: DocumentListRowCapabilities
 ) => ReactNode;
+
+export type DocumentListFieldAction = (
+  runtime: DocumentListRuntimeState
+) => void | Promise<void>;
+
+export interface DocumentListFieldRuntimeOptions {
+  readonly formInstanceId?: string;
+  readonly repository?: DocumentListRepository;
+}
+
+interface DocumentListRuntimeContextValue {
+  readonly options: DocumentListFieldRuntimeOptions;
+  readonly registerField: (fieldId: string) => void;
+}
 
 export interface DocumentListToolbarProps {
   detailRowsExpanded?: boolean;
@@ -81,34 +102,64 @@ export type DocumentListFieldHost = Pick<
   | 'renderDetailRow'
   | 'detailRowsExpanded'
   | 'onToggleDetails'
-  | 'onCompose'
-  | 'onUpload'
   | 'loading'
   | 'error'
->;
+> & {
+  readonly onCompose?: DocumentListFieldAction;
+  readonly onUpload?: DocumentListFieldAction;
+};
 
 const DocumentListFieldHostContext =
   createContext<DocumentListFieldHost | null>(null);
 
+const DocumentListRuntimeContext =
+  createContext<DocumentListRuntimeContextValue | null>(null);
+
+export interface DocumentListFieldProviderProps {
+  readonly host: DocumentListFieldHost;
+  readonly runtime?: DocumentListFieldRuntimeOptions;
+  readonly children: ReactNode;
+}
+
 export function DocumentListFieldProvider({
   host,
   children,
-}: {
-  host: DocumentListFieldHost;
-  children: ReactNode;
-}): React.JSX.Element {
+  runtime,
+}: DocumentListFieldProviderProps): React.JSX.Element {
+  const formStore = useContext(FormStoreContext);
+  const fieldIdsRef = useRef(new Set<string>());
+  const runtimeContext = useMemo<DocumentListRuntimeContextValue>(
+    () => ({
+      options: runtime ?? {},
+      registerField: (fieldId) => fieldIdsRef.current.add(fieldId),
+    }),
+    [runtime]
+  );
+
+  useEffect(
+    () => () => {
+      if (!formStore) return;
+      formStore.getState().clearExtensionsForFields([...fieldIdsRef.current]);
+      fieldIdsRef.current.clear();
+    },
+    [formStore]
+  );
+
   return (
     <DocumentListFieldHostContext.Provider value={host}>
-      {children}
+      <DocumentListRuntimeContext.Provider value={runtimeContext}>
+        {children}
+      </DocumentListRuntimeContext.Provider>
     </DocumentListFieldHostContext.Provider>
   );
 }
 
 export function createDocumentListFieldProvider(
-  host: DocumentListFieldHost
+  host: DocumentListFieldHost,
+  runtime?: DocumentListFieldRuntimeOptions
 ): FieldProvider {
   return (children) => (
-    <DocumentListFieldProvider host={host}>
+    <DocumentListFieldProvider host={host} runtime={runtime}>
       {children}
     </DocumentListFieldProvider>
   );
@@ -116,6 +167,30 @@ export function createDocumentListFieldProvider(
 
 export function useDocumentListFieldHost(): DocumentListFieldHost | null {
   return useContext(DocumentListFieldHostContext);
+}
+
+export function useDocumentListFieldRuntime(
+  fieldId: string,
+  initialDocuments?: readonly DocumentListDocument[]
+): DocumentListRuntimeState | null {
+  const formStore = useContext(FormStoreContext);
+  const runtime = useContext(DocumentListRuntimeContext);
+  runtime?.registerField(fieldId);
+  return useMemo(() => {
+    if (!formStore) return null;
+    const formInstanceId =
+      formStore.getState().instanceId ??
+      runtime?.options.formInstanceId ??
+      'document-list-provider';
+    return (
+      createDocumentListRuntimeExtension({
+        formStore,
+        context: { formInstanceId, fieldId },
+        repository: runtime?.options.repository,
+        initialDocuments,
+      }) ?? null
+    );
+  }, [fieldId, formStore, initialDocuments, runtime]);
 }
 
 const DEFAULT_ROW_CAPABILITIES: DocumentListRowCapabilities = {

--- a/packages/document-list-field/src/DocumentListGrid.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.tsx
@@ -343,6 +343,52 @@ export function DocumentListGrid({
           return document ? renderDetailRow(document) : null;
         }
       : undefined;
+  const gridTitleActions =
+    titleActions || onToggleDetails || onCompose || onUpload ? (
+      <div className="document-list-grid__title-actions">
+        {onToggleDetails && (
+          <Button
+            type="button"
+            variant={detailRowsExpanded ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={onToggleDetails}
+            aria-label="Toggle all document details"
+            aria-pressed={detailRowsExpanded ?? false}
+            title="Detail"
+            leftIcon={<LayoutList size={16} aria-hidden="true" />}
+          >
+            <span className="document-list-grid__action-label">Detail</span>
+          </Button>
+        )}
+        {onCompose && (
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            onClick={onCompose}
+            aria-label="Compose document"
+            title="Compose"
+            leftIcon={<SquarePen size={16} aria-hidden="true" />}
+          >
+            <span className="document-list-grid__action-label">Compose</span>
+          </Button>
+        )}
+        {onUpload && (
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            onClick={onUpload}
+            aria-label="Upload document"
+            title="Upload"
+            leftIcon={<Upload size={16} aria-hidden="true" />}
+          >
+            <span className="document-list-grid__action-label">Upload</span>
+          </Button>
+        )}
+        {titleActions}
+      </div>
+    ) : undefined;
 
   if (!view) {
     return (
@@ -368,50 +414,9 @@ export function DocumentListGrid({
             {error}
           </div>
         )}
-        {(titleActions || onToggleDetails || onCompose || onUpload) && (
-          <div className="document-list-grid__title-actions">
-            {onToggleDetails && (
-              <Button
-                type="button"
-                variant={detailRowsExpanded ? 'primary' : 'ghost'}
-                size="sm"
-                onClick={onToggleDetails}
-                aria-label="Toggle all document details"
-                aria-pressed={detailRowsExpanded ?? false}
-                leftIcon={<LayoutList size={16} aria-hidden="true" />}
-              >
-                Detail
-              </Button>
-            )}
-            {onCompose && (
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                onClick={onCompose}
-                aria-label="Compose document"
-                leftIcon={<SquarePen size={16} aria-hidden="true" />}
-              >
-                Compose
-              </Button>
-            )}
-            {onUpload && (
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                onClick={onUpload}
-                aria-label="Upload document"
-                leftIcon={<Upload size={16} aria-hidden="true" />}
-              >
-                Upload
-              </Button>
-            )}
-            {titleActions}
-          </div>
-        )}
         <OptionalDataVisNitroGrid
           title={title}
+          titleActions={gridTitleActions}
           columns={gridColumns as DataVisGridProps['columns']}
           formatCell={gridFormatCell}
           onRowClick={gridOnRowClick}

--- a/packages/document-list-field/src/DocumentListGrid.tsx
+++ b/packages/document-list-field/src/DocumentListGrid.tsx
@@ -19,6 +19,7 @@ import {
   createLocalSourcePayload,
   DOCUMENT_LIST_ACTIONS_COLUMN,
   DOCUMENT_LIST_COLUMNS,
+  DOCUMENT_LIST_DEFAULT_NOUN,
   normalizeDocumentRow,
 } from './data.js';
 import type { FieldProvider } from '@esheet/fields';
@@ -77,6 +78,8 @@ export interface DocumentListToolbarProps {
 export interface DocumentListGridProps extends DocumentListToolbarProps {
   rows: readonly DocumentListDocument[];
   title?: string;
+  /** What one row is called, lowercase; defaults to `document`. */
+  noun?: string;
   columns?: readonly DocumentListColumn[];
   titleActions?: ReactNode;
   renderActions?: DocumentListActionsRenderer;
@@ -171,10 +174,13 @@ export function useDocumentListFieldHost(): DocumentListFieldHost | null {
 
 export function useDocumentListFieldRuntime(
   fieldId: string,
-  initialDocuments?: readonly DocumentListDocument[]
+  initialDocuments?: readonly DocumentListDocument[],
+  onDocumentsChange?: (documents: readonly DocumentListDocument[]) => void
 ): DocumentListRuntimeState | null {
   const formStore = useContext(FormStoreContext);
   const runtime = useContext(DocumentListRuntimeContext);
+  const onDocumentsChangeRef = useRef(onDocumentsChange);
+  onDocumentsChangeRef.current = onDocumentsChange;
   runtime?.registerField(fieldId);
   return useMemo(() => {
     if (!formStore) return null;
@@ -188,6 +194,10 @@ export function useDocumentListFieldRuntime(
         context: { formInstanceId, fieldId },
         repository: runtime?.options.repository,
         initialDocuments,
+        // The extension outlives any one render, so the callback stays behind
+        // a ref rather than being captured at creation.
+        onDocumentsChange: (documents) =>
+          onDocumentsChangeRef.current?.(documents),
       }) ?? null
     );
   }, [fieldId, formStore, initialDocuments, runtime]);
@@ -282,6 +292,7 @@ function useDocumentListView(rows: readonly DocumentListDocument[]): {
 export function DocumentListGrid({
   rows,
   title = 'Documents',
+  noun = DOCUMENT_LIST_DEFAULT_NOUN,
   columns = DOCUMENT_LIST_COLUMNS,
   titleActions,
   renderActions,
@@ -366,7 +377,7 @@ export function DocumentListGrid({
             variant="link"
             size="sm"
             onClick={onCompose}
-            aria-label="Compose document"
+            aria-label={`Compose ${noun}`}
             title="Compose"
             leftIcon={<SquarePen size={16} aria-hidden="true" />}
           >
@@ -379,7 +390,7 @@ export function DocumentListGrid({
             variant="link"
             size="sm"
             onClick={onUpload}
-            aria-label="Upload document"
+            aria-label={`Upload ${noun}`}
             title="Upload"
             leftIcon={<Upload size={16} aria-hidden="true" />}
           >

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -10,6 +10,41 @@ import {
   DocumentListUploadModal,
 } from './DocumentListWorkflows.js';
 
+vi.mock('@kerebron/editor', () => ({
+  CoreEditor: {
+    create: ({ element }: { element: HTMLElement }) => {
+      const eventTarget = new EventTarget();
+      const editor = {
+        addEventListener: eventTarget.addEventListener.bind(eventTarget),
+        removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+        view: { setProps: vi.fn() },
+        loadDocument: vi.fn(async (_mediaType: string, content: Uint8Array) => {
+          const nextValue = new TextDecoder().decode(content);
+          editorValue = nextValue;
+          editorInput.value = nextValue;
+        }),
+        saveDocument: vi.fn(async () => new TextEncoder().encode(editorValue)),
+        destroy: vi.fn(),
+      };
+      let editorValue = '';
+      const editorInput = globalThis.document.createElement('textarea');
+      editorInput.setAttribute('aria-label', 'Note');
+      const updateValue = (): void => {
+        editorValue = editorInput.value;
+        eventTarget.dispatchEvent(new Event('changed'));
+      };
+      editorInput.addEventListener('input', updateValue);
+      editorInput.addEventListener('change', updateValue);
+      element.appendChild(editorInput);
+      return editor;
+    },
+  },
+}));
+
+vi.mock('@kerebron/editor-kits/AdvancedEditorKit', () => ({
+  AdvancedEditorKit: class AdvancedEditorKit {},
+}));
+
 vi.mock('@mieweb/ui', () => {
   const Button = ({
     children,
@@ -96,11 +131,11 @@ function createRuntime(
 }
 
 describe('document list workflow modals', () => {
-  it('submits editable compose metadata and transient text content', async () => {
+  it('submits editable compose metadata and markdown content', async () => {
     const runtime = createRuntime();
     const onOpenChange = vi.fn();
 
-    render(
+    const documentView = render(
       <DocumentListComposeModal
         open
         onOpenChange={onOpenChange}
@@ -118,7 +153,11 @@ describe('document list workflow modals', () => {
     fireEvent.change(screen.getByLabelText('Document type'), {
       target: { value: 'Clinical note' },
     });
-    fireEvent.change(screen.getByLabelText('Note'), {
+    const noteEditor = documentView.container.querySelector(
+      '.document-list-compose-editor textarea'
+    );
+    expect(noteEditor).toBeTruthy();
+    fireEvent.change(noteEditor as HTMLTextAreaElement, {
       target: { value: 'Follow-up completed.' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
@@ -134,13 +173,13 @@ describe('document list workflow modals', () => {
         subject: 'Follow-up visit',
         docType: 'Clinical note',
         docId: savedDocument.id,
-        file: `${savedDocument.id}.txt`,
+        file: `${savedDocument.id}.md`,
       })
     );
     expect(content).toEqual(
       expect.objectContaining({
         content: 'Follow-up completed.',
-        contentType: 'text/plain',
+        contentType: 'text/x-markdown',
       })
     );
     expect(onOpenChange).toHaveBeenCalledWith(false);

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -12,8 +12,56 @@ import {
 
 vi.mock('@kerebron/editor', () => ({
   CoreEditor: {
-    create: ({ element }: { element: HTMLElement }) => {
+    create: ({
+      element,
+      readOnly = false,
+    }: {
+      element: HTMLElement;
+      readOnly?: boolean;
+    }) => {
       const eventTarget = new EventTarget();
+      let editorValue = '';
+      const editorInput = readOnly
+        ? null
+        : globalThis.document.createElement('textarea');
+      if (editorInput) {
+        editorInput.setAttribute('aria-label', 'Note');
+      }
+      const renderMarkdown = (markdown: string): void => {
+        const proseMirror = globalThis.document.createElement('div');
+        proseMirror.className = 'kb-editor ProseMirror';
+        let list: HTMLUListElement | null = null;
+
+        for (const line of markdown.split(/\r?\n/)) {
+          const heading = /^(#{1,6})\s+(.+)$/.exec(line);
+          const listItem = /^\s*[-*]\s+(.+)$/.exec(line);
+          if (heading) {
+            list = null;
+            const headingElement = globalThis.document.createElement(
+              `h${heading[1].length}`
+            );
+            headingElement.textContent = heading[2];
+            proseMirror.appendChild(headingElement);
+          } else if (listItem) {
+            if (!list) {
+              list = globalThis.document.createElement('ul');
+              proseMirror.appendChild(list);
+            }
+            const listElement = globalThis.document.createElement('li');
+            listElement.textContent = listItem[1];
+            list.appendChild(listElement);
+          } else if (line.trim()) {
+            list = null;
+            const paragraph = globalThis.document.createElement('p');
+            paragraph.textContent = line;
+            proseMirror.appendChild(paragraph);
+          } else {
+            list = null;
+          }
+        }
+
+        element.replaceChildren(proseMirror);
+      };
       const editor = {
         addEventListener: eventTarget.addEventListener.bind(eventTarget),
         removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
@@ -21,21 +69,25 @@ vi.mock('@kerebron/editor', () => ({
         loadDocument: vi.fn(async (_mediaType: string, content: Uint8Array) => {
           const nextValue = new TextDecoder().decode(content);
           editorValue = nextValue;
-          editorInput.value = nextValue;
+          if (editorInput) {
+            editorInput.value = nextValue;
+          } else {
+            renderMarkdown(nextValue);
+          }
         }),
         saveDocument: vi.fn(async () => new TextEncoder().encode(editorValue)),
         destroy: vi.fn(),
       };
-      let editorValue = '';
-      const editorInput = globalThis.document.createElement('textarea');
-      editorInput.setAttribute('aria-label', 'Note');
       const updateValue = (): void => {
+        if (!editorInput) return;
         editorValue = editorInput.value;
         eventTarget.dispatchEvent(new Event('changed'));
       };
-      editorInput.addEventListener('input', updateValue);
-      editorInput.addEventListener('change', updateValue);
-      element.appendChild(editorInput);
+      if (editorInput) {
+        editorInput.addEventListener('input', updateValue);
+        editorInput.addEventListener('change', updateValue);
+        element.appendChild(editorInput);
+      }
       return editor;
     },
   },
@@ -317,6 +369,33 @@ describe('document list detail row', () => {
 
     expect(await screen.findByText('Loaded note')).toBeTruthy();
     expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('renders markdown content with Kerebron formatting', async () => {
+    const content: DocumentListContent = {
+      text: '# Visit note\n\n- First item\n- Second item',
+      contentType: 'text/x-markdown',
+      size: 42,
+    };
+    const runtime = createRuntime(async () => content);
+
+    const detailView = render(
+      <DocumentListDetailRow document={document} runtime={runtime} />
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Visit note' })
+    ).toBeTruthy();
+    expect(detailView.container.querySelector('ul')).toBeTruthy();
+    expect(detailView.container.querySelector('li')?.textContent).toBe(
+      'First item'
+    );
+    const preview = detailView.container.querySelector(
+      '.document-list-detail__preview'
+    );
+    expect(preview).toBeTruthy();
+    expect(preview?.textContent).not.toContain('# Visit note');
+    expect(preview?.textContent).not.toContain('- First item');
   });
 
   it('renders image references and metadata fallback content', async () => {

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -5,10 +5,11 @@ import type {
   DocumentListRuntimeState,
 } from './document-list-runtime.js';
 import {
-  DocumentListComposeModal,
+  DocumentListComposePanel,
   DocumentListDetailRow,
-  DocumentListUploadModal,
+  DocumentListUploadPanel,
 } from './DocumentListWorkflows.js';
+import type { DocumentListDocument } from './types.js';
 
 vi.mock('@kerebron/editor', () => ({
   CoreEditor: {
@@ -185,13 +186,13 @@ function createRuntime(
   } as unknown as DocumentListRuntimeState;
 }
 
-describe('document list workflow modals', () => {
+describe('document list workflow panels', () => {
   it('submits editable compose metadata and markdown content', async () => {
     const runtime = createRuntime();
     const onOpenChange = vi.fn();
 
     const documentView = render(
-      <DocumentListComposeModal
+      <DocumentListComposePanel
         open
         onOpenChange={onOpenChange}
         runtime={runtime}
@@ -240,8 +241,71 @@ describe('document list workflow modals', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('follows Mieweb UI dark mode changes without remounting', async () => {
-    const root = globalThis.document.documentElement;
+  it('keeps an inline document type on the row instead of storing content', async () => {
+    const runtime = createRuntime();
+
+    const documentView = render(
+      <DocumentListComposePanel
+        open
+        onOpenChange={vi.fn()}
+        runtime={runtime}
+        inputPrefix="form-1-notes"
+        docTypes={[
+          { id: 'progress-note', label: 'Progress note', inline: true },
+          { id: 'referral' },
+        ]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Called employer' },
+    });
+    fireEvent.change(screen.getByLabelText('Subject'), {
+      target: { value: 'Lisa Ryan' },
+    });
+    const noteEditor = documentView.container.querySelector(
+      '.document-list-compose-editor textarea'
+    );
+    fireEvent.change(noteEditor as HTMLTextAreaElement, {
+      target: { value: 'Employer confirmed return date.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+
+    await waitFor(() => expect(runtime.saveDocument).toHaveBeenCalledOnce());
+    const [savedDocument, content] = (
+      runtime.saveDocument as ReturnType<typeof vi.fn>
+    ).mock.calls[0] as [DocumentListDocument, DocumentListContentInput?];
+
+    expect(savedDocument.docType).toBe('progress-note');
+    expect(savedDocument.body).toBe('Employer confirmed return date.');
+    expect(content).toBeUndefined();
+  });
+
+  it('asks only for the columns the list shows', async () => {
+    const runtime = createRuntime();
+
+    render(
+      <DocumentListComposePanel
+        open
+        onOpenChange={vi.fn()}
+        runtime={runtime}
+        inputPrefix="form-1-notes"
+        fields={['date', 'title', 'source']}
+      />
+    );
+
+    expect(screen.queryByLabelText('Subject')).toBeNull();
+    expect(screen.queryByLabelText('Document type')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Called employer' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+
+    await waitFor(() => expect(runtime.saveDocument).toHaveBeenCalledOnce());
+  });
+
+  it('follows Mieweb UI dark mode changes without remounting', async () => {    const root = globalThis.document.documentElement;
     const initialClassName = root.className;
     const initialTheme = root.getAttribute('data-theme');
     root.classList.remove('dark');
@@ -249,7 +313,7 @@ describe('document list workflow modals', () => {
 
     try {
       const documentView = render(
-        <DocumentListComposeModal
+        <DocumentListComposePanel
           open
           onOpenChange={vi.fn()}
           runtime={createRuntime()}
@@ -289,7 +353,7 @@ describe('document list workflow modals', () => {
     }
   });
 
-  it('validates compose fields and keeps storage errors in the modal', async () => {
+  it('validates compose fields and keeps storage errors in the panel', async () => {
     const runtime = createRuntime();
     const saveError = new Error('storage unavailable');
     runtime.saveDocument = vi.fn(async () => {
@@ -297,7 +361,7 @@ describe('document list workflow modals', () => {
     });
 
     render(
-      <DocumentListComposeModal
+      <DocumentListComposePanel
         open
         onOpenChange={vi.fn()}
         runtime={runtime}
@@ -307,7 +371,7 @@ describe('document list workflow modals', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
     expect(screen.getByRole('alert').textContent).toContain(
-      'Title, subject, and document type are required.'
+      'Title, Subject and Document type are required.'
     );
     expect(runtime.saveDocument).not.toHaveBeenCalled();
 
@@ -333,7 +397,7 @@ describe('document list workflow modals', () => {
     });
 
     render(
-      <DocumentListUploadModal
+      <DocumentListUploadPanel
         open
         onOpenChange={onOpenChange}
         runtime={runtime}
@@ -375,7 +439,7 @@ describe('document list workflow modals', () => {
     const runtime = createRuntime();
     const onOpenChange = vi.fn();
     const { rerender } = render(
-      <DocumentListUploadModal
+      <DocumentListUploadPanel
         open
         onOpenChange={onOpenChange}
         runtime={runtime}
@@ -395,7 +459,7 @@ describe('document list workflow modals', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
     rerender(
-      <DocumentListUploadModal
+      <DocumentListUploadPanel
         open
         onOpenChange={onOpenChange}
         runtime={runtime}

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -185,6 +185,55 @@ describe('document list workflow modals', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('follows Mieweb UI dark mode changes without remounting', async () => {
+    const root = globalThis.document.documentElement;
+    const initialClassName = root.className;
+    const initialTheme = root.getAttribute('data-theme');
+    root.classList.remove('dark');
+    root.removeAttribute('data-theme');
+
+    try {
+      const documentView = render(
+        <DocumentListComposeModal
+          open
+          onOpenChange={vi.fn()}
+          runtime={createRuntime()}
+          inputPrefix="form-1-documents"
+        />
+      );
+      const editor = documentView.container.querySelector(
+        '.document-list-compose-editor'
+      );
+
+      expect(editor).toBeTruthy();
+      expect(editor?.classList.contains('kb-component--dark')).toBe(false);
+
+      root.classList.add('dark');
+      await waitFor(() =>
+        expect(editor?.classList.contains('kb-component--dark')).toBe(true)
+      );
+
+      root.classList.remove('dark');
+      root.dataset.theme = 'dark';
+      await waitFor(() =>
+        expect(editor?.classList.contains('kb-component--dark')).toBe(true)
+      );
+
+      root.removeAttribute('data-theme');
+      await waitFor(() =>
+        expect(editor?.classList.contains('kb-component--dark')).toBe(false)
+      );
+      documentView.unmount();
+    } finally {
+      root.className = initialClassName;
+      if (initialTheme === null) {
+        root.removeAttribute('data-theme');
+      } else {
+        root.setAttribute('data-theme', initialTheme);
+      }
+    }
+  });
+
   it('validates compose fields and keeps storage errors in the modal', async () => {
     const runtime = createRuntime();
     const saveError = new Error('storage unavailable');

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -1,0 +1,328 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type {
+  DocumentListContent,
+  DocumentListContentInput,
+  DocumentListRuntimeState,
+} from './document-list-runtime.js';
+import {
+  DocumentListComposeModal,
+  DocumentListDetailRow,
+  DocumentListUploadModal,
+} from './DocumentListWorkflows.js';
+
+vi.mock('@mieweb/ui', () => {
+  const Button = ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  );
+  const Input = ({
+    label,
+    error,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    label?: string;
+    error?: string;
+  }) => (
+    <label>
+      {label}
+      <input {...props} />
+      {error && <span>{error}</span>}
+    </label>
+  );
+  const Textarea = ({
+    label,
+    ...props
+  }: React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    label?: string;
+  }) => (
+    <label>
+      {label}
+      <textarea {...props} />
+    </label>
+  );
+  const Modal = ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div role="dialog">{children}</div> : null);
+  const ModalHeader = ({ children }: { children: React.ReactNode }) => (
+    <header>{children}</header>
+  );
+  const ModalTitle = ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  );
+  const ModalClose = () => null;
+  const ModalBody = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  const ModalFooter = ({ children }: { children: React.ReactNode }) => (
+    <footer>{children}</footer>
+  );
+  return {
+    Button,
+    Input,
+    Modal,
+    ModalBody,
+    ModalClose,
+    ModalFooter,
+    ModalHeader,
+    ModalTitle,
+    Textarea,
+  };
+});
+
+const document = {
+  id: 'doc-1',
+  date: '2026-08-18',
+  title: 'Letter',
+  subject: 'Subject',
+  docType: 'Letter',
+  docId: '42',
+  source: 'WebChart',
+  file: '42.pdf',
+} as const;
+
+function createRuntime(
+  loadContent: DocumentListRuntimeState['loadContent'] = async () => undefined
+): DocumentListRuntimeState {
+  return {
+    saveDocument: vi.fn(async (savedDocument) => savedDocument),
+    loadContent,
+  } as unknown as DocumentListRuntimeState;
+}
+
+describe('document list workflow modals', () => {
+  it('submits editable compose metadata and transient text content', async () => {
+    const runtime = createRuntime();
+    const onOpenChange = vi.fn();
+
+    render(
+      <DocumentListComposeModal
+        open
+        onOpenChange={onOpenChange}
+        runtime={runtime}
+        inputPrefix="form-1-documents"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Visit note' },
+    });
+    fireEvent.change(screen.getByLabelText('Subject'), {
+      target: { value: 'Follow-up visit' },
+    });
+    fireEvent.change(screen.getByLabelText('Document type'), {
+      target: { value: 'Clinical note' },
+    });
+    fireEvent.change(screen.getByLabelText('Note'), {
+      target: { value: 'Follow-up completed.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+
+    await waitFor(() => expect(runtime.saveDocument).toHaveBeenCalledOnce());
+    const [savedDocument, content] = (
+      runtime.saveDocument as ReturnType<typeof vi.fn>
+    ).mock.calls[0] as [typeof document, DocumentListContentInput];
+
+    expect(savedDocument).toEqual(
+      expect.objectContaining({
+        title: 'Visit note',
+        subject: 'Follow-up visit',
+        docType: 'Clinical note',
+        docId: savedDocument.id,
+        file: `${savedDocument.id}.txt`,
+      })
+    );
+    expect(content).toEqual(
+      expect.objectContaining({
+        content: 'Follow-up completed.',
+        contentType: 'text/plain',
+      })
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('validates compose fields and keeps storage errors in the modal', async () => {
+    const runtime = createRuntime();
+    const saveError = new Error('storage unavailable');
+    runtime.saveDocument = vi.fn(async () => {
+      throw saveError;
+    });
+
+    render(
+      <DocumentListComposeModal
+        open
+        onOpenChange={vi.fn()}
+        runtime={runtime}
+        inputPrefix="form-1-documents"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+    expect(screen.getByRole('alert').textContent).toContain(
+      'Title, subject, and document type are required.'
+    );
+    expect(runtime.saveDocument).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Visit note' },
+    });
+    fireEvent.change(screen.getByLabelText('Subject'), {
+      target: { value: 'Follow-up visit' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain(
+        'storage unavailable'
+      )
+    );
+  });
+
+  it('derives upload metadata from the original file and forwards the renamed file', async () => {
+    const runtime = createRuntime();
+    const onOpenChange = vi.fn();
+    const file = new File(['image data'], 'original.png', {
+      type: 'image/png',
+    });
+
+    render(
+      <DocumentListUploadModal
+        open
+        onOpenChange={onOpenChange}
+        runtime={runtime}
+        inputPrefix="form-1-documents"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Choose a file'), {
+      target: { files: [file] },
+    });
+    fireEvent.change(screen.getByLabelText('Stored filename'), {
+      target: { value: 'renamed-image.png' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save document' }));
+
+    await waitFor(() => expect(runtime.saveDocument).toHaveBeenCalledOnce());
+    const [savedDocument, content] = (
+      runtime.saveDocument as ReturnType<typeof vi.fn>
+    ).mock.calls[0] as [typeof document, DocumentListContentInput];
+
+    expect(savedDocument).toEqual(
+      expect.objectContaining({
+        title: 'original.png',
+        docType: 'image/png',
+        file: 'renamed-image.png',
+      })
+    );
+    expect(content).toEqual(
+      expect.objectContaining({
+        content: file,
+        contentType: 'image/png',
+        size: file.size,
+      })
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('resets upload form state when cancelled', () => {
+    const runtime = createRuntime();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <DocumentListUploadModal
+        open
+        onOpenChange={onOpenChange}
+        runtime={runtime}
+        inputPrefix="form-1-documents"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Choose a file'), {
+      target: {
+        files: [new File(['draft'], 'draft.pdf', { type: 'application/pdf' })],
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Stored filename'), {
+      target: { value: 'draft.pdf' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    rerender(
+      <DocumentListUploadModal
+        open
+        onOpenChange={onOpenChange}
+        runtime={runtime}
+        inputPrefix="form-1-documents"
+      />
+    );
+    expect(
+      (screen.getByLabelText('Stored filename') as HTMLInputElement).value
+    ).toBe('');
+  });
+});
+
+describe('document list detail row', () => {
+  it('renders loaded text content inline', async () => {
+    const content: DocumentListContent = {
+      text: 'Loaded note',
+      contentType: 'text/plain',
+      size: 11,
+    };
+    const runtime = createRuntime(async () => content);
+
+    render(<DocumentListDetailRow document={document} runtime={runtime} />);
+
+    expect(await screen.findByText('Loaded note')).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('renders image references and metadata fallback content', async () => {
+    const imageRuntime = createRuntime(async () => ({
+      reference: 'https://example.test/document.png',
+      contentType: 'image/png',
+      size: 12,
+    }));
+    const imageView = render(
+      <DocumentListDetailRow document={document} runtime={imageRuntime} />
+    );
+
+    expect(
+      (await screen.findByRole('img', { name: document.title })).getAttribute(
+        'src'
+      )
+    ).toBe('https://example.test/document.png');
+    imageView.unmount();
+
+    const fallbackRuntime = createRuntime(async () => ({
+      reference: 'document.pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+    }));
+    render(
+      <DocumentListDetailRow document={document} runtime={fallbackRuntime} />
+    );
+
+    expect(await screen.findByText('document.pdf')).toBeTruthy();
+    expect(screen.getByText('application/pdf')).toBeTruthy();
+    expect(screen.getByText('2048 bytes')).toBeTruthy();
+  });
+
+  it('falls back to metadata when content loading fails', async () => {
+    const runtime = createRuntime(async () => {
+      throw new Error('content unavailable');
+    });
+
+    render(<DocumentListDetailRow document={document} runtime={runtime} />);
+
+    expect(
+      await screen.findByText(
+        'Could not load document content: content unavailable'
+      )
+    ).toBeTruthy();
+    expect(screen.getByText(document.file)).toBeTruthy();
+  });
+});

--- a/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.spec.tsx
@@ -97,7 +97,8 @@ vi.mock('@kerebron/editor-kits/AdvancedEditorKit', () => ({
   AdvancedEditorKit: class AdvancedEditorKit {},
 }));
 
-vi.mock('@mieweb/ui', () => {
+vi.mock('@mieweb/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mieweb/ui')>();
   const Button = ({
     children,
     ...props
@@ -150,6 +151,8 @@ vi.mock('@mieweb/ui', () => {
     <footer>{children}</footer>
   );
   return {
+    // The detail preview renders markdown with the real MarkdownRenderer.
+    MarkdownRenderer: actual.MarkdownRenderer,
     Button,
     Input,
     Modal,
@@ -420,7 +423,7 @@ describe('document list detail row', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 
-  it('renders markdown content with Kerebron formatting', async () => {
+  it('renders markdown content as formatted preview', async () => {
     const content: DocumentListContent = {
       text: '# Visit note\n\n- First item\n- Second item',
       contentType: 'text/x-markdown',

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -701,6 +701,46 @@ function ContentMetadata({
   );
 }
 
+function DocumentListMarkdownPreview({
+  content,
+}: {
+  readonly content: string;
+}): React.JSX.Element {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const mount = document.createElement('div');
+    host.appendChild(mount);
+    const editor = CoreEditor.create({
+      element: mount,
+      uri: 'file:///document-list-detail.md',
+      assetLoad: composeAssetLoad,
+      editorKits: [new AdvancedEditorKit()],
+      readOnly: true,
+    });
+
+    void editor
+      .loadDocument(COMPOSE_CONTENT_TYPE, new TextEncoder().encode(content))
+      .catch(() => undefined);
+
+    return () => {
+      editor.destroy();
+      host.replaceChildren();
+    };
+  }, [content]);
+
+  return (
+    <div
+      ref={hostRef}
+      className="kb-component document-list-detail__preview"
+      aria-label="Document content"
+    />
+  );
+}
+
 export function DocumentListDetailRow({
   document,
   runtime,
@@ -737,6 +777,8 @@ export function DocumentListDetailRow({
     content?.reference &&
       content.contentType?.toLowerCase().startsWith('image/')
   );
+  const isMarkdown =
+    content?.contentType === COMPOSE_CONTENT_TYPE && content.text != null;
 
   return (
     <div className="document-list-detail">
@@ -765,9 +807,13 @@ export function DocumentListDetailRow({
           Could not load document content: {error}
         </p>
       )}
-      {!loading && content?.text != null && (
-        <div className="document-list-detail__text">{content.text}</div>
-      )}
+      {!loading &&
+        content?.text != null &&
+        (isMarkdown ? (
+          <DocumentListMarkdownPreview content={content.text} />
+        ) : (
+          <div className="document-list-detail__text">{content.text}</div>
+        ))}
       {!loading && isImage && (
         <img
           className="document-list-detail__image"

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -6,20 +6,12 @@ import {
   useState,
   type ChangeEvent,
   type FormEvent,
+  type ReactNode,
 } from 'react';
 import { CoreEditor, type AssetLoad } from '@kerebron/editor';
 import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
-import {
-  Button,
-  Input,
-  MarkdownRenderer,
-  Modal,
-  ModalBody,
-  ModalClose,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-} from '@mieweb/ui';
+import { Button, Input, MarkdownRenderer } from '@mieweb/ui';
+import { X } from 'lucide-react';
 import '@kerebron/editor/assets/index.css';
 import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
 import '@mieweb/ui/markdown.css';
@@ -28,9 +20,13 @@ import type {
   DocumentListContentInput,
   DocumentListRuntimeState,
 } from './document-list-runtime.js';
-import type { DocumentListDocument } from './types.js';
+import { DOCUMENT_LIST_DEFAULT_NOUN, DOCUMENT_LIST_MARKDOWN_TYPE } from './data.js';
+import type {
+  DocumentListDocTypeOption,
+  DocumentListDocument,
+} from './types.js';
 
-const COMPOSE_CONTENT_TYPE = 'text/x-markdown';
+const COMPOSE_CONTENT_TYPE = DOCUMENT_LIST_MARKDOWN_TYPE;
 
 function useIsDark(): boolean {
   const [isDark, setIsDark] = useState(() => {
@@ -225,11 +221,35 @@ if (
   document.head.appendChild(style);
 }
 
-export interface DocumentListWorkflowModalProps {
+export interface DocumentListWorkflowPanelProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
   readonly runtime: DocumentListRuntimeState;
   readonly inputPrefix: string;
+  /** What one row is called, lowercase; defaults to `document`. */
+  readonly noun?: string;
+  /** Column field names the list shows; the compose form asks for those. */
+  readonly fields?: readonly string[];
+  /** Types the field offers; the compose form falls back to free text. */
+  readonly docTypes?: readonly DocumentListDocTypeOption[];
+  /** Compose inline unless the chosen `docType` says otherwise. */
+  readonly defaultInline?: boolean;
+  /** `accept` for the upload file input. */
+  readonly accept?: string;
+  /** Largest upload accepted, in bytes. */
+  readonly maxFileSize?: number;
+}
+
+/** Compose asks for the columns the list shows, and always for the title. */
+function asks(fields: readonly string[] | undefined, name: string): boolean {
+  return !fields || name === 'title' || fields.includes(name);
+}
+
+function requiredMessage(labels: readonly string[]): string {
+  if (labels.length === 1) return `${labels[0]} is required.`;
+  return `${labels.slice(0, -1).join(', ')} and ${
+    labels[labels.length - 1]
+  } are required.`;
 }
 
 function today(): string {
@@ -417,24 +437,90 @@ const DocumentListComposeEditor = forwardRef<
   );
 });
 
-export function DocumentListComposeModal({
+/**
+ * The workflow forms float over the list they belong to rather than dimming the
+ * page, so the row being added stays in its own context.
+ */
+function DocumentListWorkflowPanel({
+  onClose,
+  title,
+  children,
+}: {
+  readonly onClose: () => void;
+  readonly title: string;
+  readonly children: ReactNode;
+}): React.JSX.Element {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onCloseRef.current();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    panelRef.current
+      ?.querySelector<HTMLElement>('input, select, textarea')
+      ?.focus();
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return (
+    <div
+      ref={panelRef}
+      className="document-list-workflow-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div className="document-list-workflow-panel__header">
+        <h3 className="document-list-workflow-panel__title">{title}</h3>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          aria-label="Close"
+          title="Close"
+        >
+          <X size={16} aria-hidden="true" />
+        </Button>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function DocumentListComposePanel({
   open,
   onOpenChange,
   runtime,
   inputPrefix,
-}: DocumentListWorkflowModalProps): React.JSX.Element {
+  noun = DOCUMENT_LIST_DEFAULT_NOUN,
+  fields,
+  docTypes,
+  defaultInline,
+}: DocumentListWorkflowPanelProps): React.JSX.Element | null {
+  const defaultDocType = docTypes?.[0]?.id ?? 'Note';
   const [title, setTitle] = useState('');
   const [subject, setSubject] = useState('');
-  const [docType, setDocType] = useState('Note');
+  const [docType, setDocType] = useState(defaultDocType);
   const [note, setNote] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const editorRef = useRef<DocumentListComposeEditorHandle>(null);
+  const asksSubject = asks(fields, 'subject');
+  const asksDocType = asks(fields, 'docType');
+  const requiredLabels = [
+    'Title',
+    ...(asksSubject ? ['Subject'] : []),
+    ...(asksDocType ? ['Document type'] : []),
+  ];
 
   const reset = (): void => {
     setTitle('');
     setSubject('');
-    setDocType('Note');
+    setDocType(defaultDocType);
     setNote('');
     resetFormState(setError, setSaving);
   };
@@ -449,8 +535,12 @@ export function DocumentListComposeModal({
     const trimmedTitle = title.trim();
     const trimmedSubject = subject.trim();
     const trimmedDocType = docType.trim();
-    if (!trimmedTitle || !trimmedSubject || !trimmedDocType) {
-      setError('Title, subject, and document type are required.');
+    if (
+      !trimmedTitle ||
+      (asksSubject && !trimmedSubject) ||
+      (asksDocType && !trimmedDocType)
+    ) {
+      setError(requiredMessage(requiredLabels));
       return;
     }
 
@@ -461,11 +551,10 @@ export function DocumentListComposeModal({
         ? await editorRef.current.getContent()
         : note;
       const id = createDocumentId();
-      const content: DocumentListContentInput = {
-        content: composedNote,
-        contentType: COMPOSE_CONTENT_TYPE,
-        size: contentSize(composedNote),
-      };
+      const inline =
+        docTypes?.find((option) => option.id === trimmedDocType)?.inline ??
+        defaultInline ??
+        false;
       const document: DocumentListDocument = {
         id,
         date: today(),
@@ -475,8 +564,20 @@ export function DocumentListComposeModal({
         docId: id,
         source: 'Compose',
         file: `${id}.md`,
+        ...(inline ? { body: composedNote } : {}),
       };
-      await runtime.saveDocument(document, content);
+      // An inline type keeps its prose on the row, so there is nothing for
+      // the repository to store.
+      await runtime.saveDocument(
+        document,
+        inline
+          ? undefined
+          : {
+              content: composedNote,
+              contentType: COMPOSE_CONTENT_TYPE,
+              size: contentSize(composedNote),
+            }
+      );
       reset();
       onOpenChange(false);
     } catch (saveError) {
@@ -487,18 +588,19 @@ export function DocumentListComposeModal({
     }
   };
 
+  if (!open) return null;
+
   return (
-    <Modal
-      open={open}
-      onOpenChange={handleOpenChange}
-      aria-label="Compose document"
+    <DocumentListWorkflowPanel
+      title={`Compose ${noun}`}
+      onClose={() => handleOpenChange(false)}
     >
-      <ModalHeader>
-        <ModalTitle>Compose document</ModalTitle>
-        <ModalClose />
-      </ModalHeader>
-      <form onSubmit={handleSubmit} noValidate>
-        <ModalBody className="document-list-workflow__body">
+      <form
+        className="document-list-workflow-panel__form"
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <div className="document-list-workflow-panel__body">
           <Input
             id={inputId(inputPrefix, 'compose-title')}
             label="Title"
@@ -507,23 +609,48 @@ export function DocumentListComposeModal({
             disabled={saving}
             required
           />
-          <Input
-            id={inputId(inputPrefix, 'compose-subject')}
-            label="Subject"
-            value={subject}
-            onChange={(event) => setSubject(event.target.value)}
-            disabled={saving}
-            required
-          />
-          <Input
-            id={inputId(inputPrefix, 'compose-type')}
-            label="Document type"
-            value={docType}
-            onChange={(event) => setDocType(event.target.value)}
-            disabled={saving}
-            required
-          />
-          <div className="document-list-workflow__field">
+          {asksSubject && (
+            <Input
+              id={inputId(inputPrefix, 'compose-subject')}
+              label="Subject"
+              value={subject}
+              onChange={(event) => setSubject(event.target.value)}
+              disabled={saving}
+              required
+            />
+          )}
+          {asksDocType &&
+            (docTypes?.length ? (
+              <div className="document-list-workflow__field">
+                <label htmlFor={inputId(inputPrefix, 'compose-type')}>
+                  Document type
+                </label>
+                <select
+                  id={inputId(inputPrefix, 'compose-type')}
+                  className="document-list-workflow__select"
+                  value={docType}
+                  onChange={(event) => setDocType(event.target.value)}
+                  disabled={saving}
+                  required
+                >
+                  {docTypes.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label ?? option.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <Input
+                id={inputId(inputPrefix, 'compose-type')}
+                label="Document type"
+                value={docType}
+                onChange={(event) => setDocType(event.target.value)}
+                disabled={saving}
+                required
+              />
+            ))}
+          <div className="document-list-workflow__field document-list-workflow__field--grow">
             <label
               id={inputId(inputPrefix, 'compose-note-label')}
               htmlFor={inputId(inputPrefix, 'compose-note')}
@@ -545,8 +672,8 @@ export function DocumentListComposeModal({
               {error}
             </p>
           )}
-        </ModalBody>
-        <ModalFooter>
+        </div>
+        <div className="document-list-workflow-panel__footer">
           <Button
             type="button"
             variant="outline"
@@ -557,20 +684,23 @@ export function DocumentListComposeModal({
             Cancel
           </Button>
           <Button type="submit" variant="primary" size="sm" disabled={saving}>
-            {saving ? 'Saving…' : 'Save document'}
+            {saving ? 'Saving…' : `Save ${noun}`}
           </Button>
-        </ModalFooter>
+        </div>
       </form>
-    </Modal>
+    </DocumentListWorkflowPanel>
   );
 }
 
-export function DocumentListUploadModal({
+export function DocumentListUploadPanel({
   open,
   onOpenChange,
   runtime,
   inputPrefix,
-}: DocumentListWorkflowModalProps): React.JSX.Element {
+  noun = DOCUMENT_LIST_DEFAULT_NOUN,
+  accept,
+  maxFileSize,
+}: DocumentListWorkflowPanelProps): React.JSX.Element | null {
   const [file, setFile] = useState<File | null>(null);
   const [storedName, setStoredName] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -599,6 +729,10 @@ export function DocumentListUploadModal({
     const trimmedStoredName = storedName.trim();
     if (!file || !trimmedStoredName) {
       setError('Choose a file and enter a stored filename.');
+      return;
+    }
+    if (maxFileSize != null && file.size > maxFileSize) {
+      setError(`File is larger than the ${maxFileSize} byte limit.`);
       return;
     }
 
@@ -634,22 +768,24 @@ export function DocumentListUploadModal({
     }
   };
 
+  if (!open) return null;
+
   return (
-    <Modal
-      open={open}
-      onOpenChange={handleOpenChange}
-      aria-label="Upload document"
+    <DocumentListWorkflowPanel
+      title={`Upload ${noun}`}
+      onClose={() => handleOpenChange(false)}
     >
-      <ModalHeader>
-        <ModalTitle>Upload document</ModalTitle>
-        <ModalClose />
-      </ModalHeader>
-      <form onSubmit={handleSubmit} noValidate>
-        <ModalBody className="document-list-workflow__body">
+      <form
+        className="document-list-workflow-panel__form"
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <div className="document-list-workflow-panel__body">
           <Input
             id={inputId(inputPrefix, 'upload-file')}
             label="Choose a file"
             type="file"
+            accept={accept}
             onChange={handleFileChange}
             disabled={saving}
           />
@@ -672,8 +808,8 @@ export function DocumentListUploadModal({
               {error}
             </p>
           )}
-        </ModalBody>
-        <ModalFooter>
+        </div>
+        <div className="document-list-workflow-panel__footer">
           <Button
             type="button"
             variant="outline"
@@ -684,11 +820,11 @@ export function DocumentListUploadModal({
             Cancel
           </Button>
           <Button type="submit" variant="primary" size="sm" disabled={saving}>
-            {saving ? 'Saving…' : 'Save document'}
+            {saving ? 'Saving…' : `Save ${noun}`}
           </Button>
-        </ModalFooter>
+        </div>
       </form>
-    </Modal>
+    </DocumentListWorkflowPanel>
   );
 }
 

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -1,4 +1,14 @@
-import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
+import { CoreEditor, type AssetLoad } from '@kerebron/editor';
+import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
 import {
   Button,
   Input,
@@ -8,14 +18,83 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
-  Textarea,
 } from '@mieweb/ui';
+import '@kerebron/editor/assets/index-light.css';
+import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
 import type {
   DocumentListContent,
   DocumentListContentInput,
   DocumentListRuntimeState,
 } from './document-list-runtime.js';
 import type { DocumentListDocument } from './types.js';
+
+const COMPOSE_CONTENT_TYPE = 'text/x-markdown';
+
+let composeAssetLoad: AssetLoad | undefined;
+
+export function configureDocumentListComposeEditor(options: {
+  assetLoad: AssetLoad;
+}): void {
+  composeAssetLoad = options.assetLoad;
+}
+
+const COMPOSE_EDITOR_STYLES = `
+  .document-list-compose-editor .ProseMirror {
+    min-height: 160px;
+    outline: none;
+    padding: 8px 12px;
+  }
+
+  .document-list-compose-editor .ProseMirror h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin: 0.67em 0;
+  }
+
+  .document-list-compose-editor .ProseMirror h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin: 0.75em 0;
+  }
+
+  .document-list-compose-editor .ProseMirror h3 {
+    font-size: 1.17em;
+    font-weight: bold;
+    margin: 0.83em 0;
+  }
+
+  .document-list-compose-editor .ProseMirror ul {
+    list-style: disc;
+    padding-left: 1.5em;
+  }
+
+  .document-list-compose-editor .ProseMirror ol {
+    list-style: decimal;
+    padding-left: 1.5em;
+  }
+
+  .document-list-compose-editor .ProseMirror blockquote {
+    border-left: 3px solid #ccc;
+    color: #666;
+    margin-left: 0;
+    padding-left: 1em;
+  }
+
+  .document-list-compose-editor .kb-custom-menu__editor {
+    max-height: 300px;
+    overflow-y: auto;
+  }
+`;
+
+if (
+  typeof document !== 'undefined' &&
+  !document.getElementById('document-list-compose-editor-styles')
+) {
+  const style = document.createElement('style');
+  style.id = 'document-list-compose-editor-styles';
+  style.textContent = COMPOSE_EDITOR_STYLES;
+  document.head.appendChild(style);
+}
 
 export interface DocumentListWorkflowModalProps {
   readonly open: boolean;
@@ -52,6 +131,160 @@ function resetFormState(
   setSaving(false);
 }
 
+interface DocumentListComposeEditorProps {
+  readonly ariaLabel: string;
+  readonly disabled: boolean;
+  readonly id: string;
+  readonly labelledBy: string;
+  readonly onChange: (value: string) => void;
+  readonly value: string;
+}
+
+interface DocumentListComposeEditorHandle {
+  readonly getContent: () => Promise<string>;
+}
+
+const DocumentListComposeEditor = forwardRef<
+  DocumentListComposeEditorHandle,
+  DocumentListComposeEditorProps
+>(function DocumentListComposeEditor(
+  { ariaLabel, disabled, id, labelledBy, onChange, value },
+  ref
+): React.JSX.Element {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<CoreEditor | null>(null);
+  const onChangeRef = useRef(onChange);
+  const valueRef = useRef(value);
+  const readyPromiseRef = useRef<Promise<void> | null>(null);
+  const isLoadingRef = useRef(false);
+  const disabledRef = useRef(disabled);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (value === valueRef.current) return;
+    valueRef.current = value;
+    if (!editor) return;
+
+    isLoadingRef.current = true;
+    void editor
+      .loadDocument(COMPOSE_CONTENT_TYPE, new TextEncoder().encode(value))
+      .catch(() => undefined)
+      .finally(() => {
+        if (editorRef.current === editor) isLoadingRef.current = false;
+      });
+  }, [value]);
+
+  useEffect(() => {
+    disabledRef.current = disabled;
+    editorRef.current?.view.setProps({
+      editable: () => !disabledRef.current,
+    });
+  }, [disabled]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const mount = document.createElement('div');
+    host.appendChild(mount);
+    const editor = CoreEditor.create({
+      element: mount,
+      uri: 'file:///document.md',
+      assetLoad: composeAssetLoad,
+      editorKits: [new AdvancedEditorKit()],
+      readOnly: disabledRef.current,
+    });
+    editorRef.current = editor;
+    editor.view.setProps({
+      editable: () => !disabledRef.current,
+      attributes: { 'aria-label': ariaLabel },
+    });
+
+    let destroyed = false;
+    let listening = false;
+    const handleChanged = (): void => {
+      if (isLoadingRef.current) return;
+      void editor
+        .saveDocument(COMPOSE_CONTENT_TYPE)
+        .then((content) => {
+          if (destroyed) return;
+          const nextValue = new TextDecoder().decode(content);
+          valueRef.current = nextValue;
+          onChangeRef.current(nextValue);
+        })
+        .catch(() => undefined);
+    };
+
+    const loadInitialContent = async (): Promise<void> => {
+      if (valueRef.current) {
+        isLoadingRef.current = true;
+        try {
+          await editor.loadDocument(
+            COMPOSE_CONTENT_TYPE,
+            new TextEncoder().encode(valueRef.current)
+          );
+        } catch {
+          // Keep the empty editor available when initial content cannot load.
+        } finally {
+          isLoadingRef.current = false;
+        }
+      }
+      if (destroyed) return;
+      editor.addEventListener('changed', handleChanged);
+      listening = true;
+    };
+
+    readyPromiseRef.current = loadInitialContent();
+
+    return () => {
+      destroyed = true;
+      if (listening) editor.removeEventListener('changed', handleChanged);
+      editor.destroy();
+      editorRef.current = null;
+      readyPromiseRef.current = null;
+      host.replaceChildren();
+    };
+    // The editor is intentionally created once for the modal instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getContent: async (): Promise<string> => {
+        await readyPromiseRef.current;
+        const editor = editorRef.current;
+        if (!editor) return valueRef.current;
+        const content = await editor.saveDocument(COMPOSE_CONTENT_TYPE);
+        const nextValue = new TextDecoder().decode(content);
+        valueRef.current = nextValue;
+        return nextValue;
+      },
+    }),
+    []
+  );
+
+  return (
+    <div
+      ref={hostRef}
+      id={id}
+      className="kb-component document-list-compose-editor"
+      aria-labelledby={labelledBy}
+      aria-label="Document note editor"
+      aria-disabled={disabled || undefined}
+      style={{
+        isolation: 'isolate',
+        opacity: disabled ? 0.65 : undefined,
+        pointerEvents: disabled ? 'none' : undefined,
+      }}
+    />
+  );
+});
+
 export function DocumentListComposeModal({
   open,
   onOpenChange,
@@ -64,6 +297,7 @@ export function DocumentListComposeModal({
   const [note, setNote] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const editorRef = useRef<DocumentListComposeEditorHandle>(null);
 
   const reset = (): void => {
     setTitle('');
@@ -88,26 +322,28 @@ export function DocumentListComposeModal({
       return;
     }
 
-    const id = createDocumentId();
-    const content: DocumentListContentInput = {
-      content: note,
-      contentType: 'text/plain',
-      size: contentSize(note),
-    };
-    const document: DocumentListDocument = {
-      id,
-      date: today(),
-      title: trimmedTitle,
-      subject: trimmedSubject,
-      docType: trimmedDocType,
-      docId: id,
-      source: 'Compose',
-      file: `${id}.txt`,
-    };
-
     setSaving(true);
     setError(null);
     try {
+      const composedNote = editorRef.current
+        ? await editorRef.current.getContent()
+        : note;
+      const id = createDocumentId();
+      const content: DocumentListContentInput = {
+        content: composedNote,
+        contentType: COMPOSE_CONTENT_TYPE,
+        size: contentSize(composedNote),
+      };
+      const document: DocumentListDocument = {
+        id,
+        date: today(),
+        title: trimmedTitle,
+        subject: trimmedSubject,
+        docType: trimmedDocType,
+        docId: id,
+        source: 'Compose',
+        file: `${id}.md`,
+      };
       await runtime.saveDocument(document, content);
       reset();
       onOpenChange(false);
@@ -155,14 +391,23 @@ export function DocumentListComposeModal({
             disabled={saving}
             required
           />
-          <Textarea
-            id={inputId(inputPrefix, 'compose-note')}
-            label="Note"
-            value={note}
-            onChange={(event) => setNote(event.target.value)}
-            disabled={saving}
-            rows={7}
-          />
+          <div className="document-list-workflow__field">
+            <label
+              id={inputId(inputPrefix, 'compose-note-label')}
+              htmlFor={inputId(inputPrefix, 'compose-note')}
+            >
+              Note
+            </label>
+            <DocumentListComposeEditor
+              ref={editorRef}
+              id={inputId(inputPrefix, 'compose-note')}
+              ariaLabel="Note"
+              labelledBy={inputId(inputPrefix, 'compose-note-label')}
+              value={note}
+              onChange={setNote}
+              disabled={saving}
+            />
+          </div>
           {error && (
             <p className="document-list-workflow__error" role="alert">
               {error}

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -1,0 +1,439 @@
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Textarea,
+} from '@mieweb/ui';
+import type {
+  DocumentListContent,
+  DocumentListContentInput,
+  DocumentListRuntimeState,
+} from './document-list-runtime.js';
+import type { DocumentListDocument } from './types.js';
+
+export interface DocumentListWorkflowModalProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly runtime: DocumentListRuntimeState;
+  readonly inputPrefix: string;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function createDocumentId(): string {
+  const randomUuid = globalThis.crypto?.randomUUID?.();
+  return (
+    randomUuid ??
+    `document-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+function contentSize(content: string | Blob): number {
+  return typeof content === 'string' ? new Blob([content]).size : content.size;
+}
+
+function inputId(prefix: string, purpose: string): string {
+  return `${prefix}-${purpose}`;
+}
+
+function resetFormState(
+  setError: (value: string | null) => void,
+  setSaving: (value: boolean) => void
+): void {
+  setError(null);
+  setSaving(false);
+}
+
+export function DocumentListComposeModal({
+  open,
+  onOpenChange,
+  runtime,
+  inputPrefix,
+}: DocumentListWorkflowModalProps): React.JSX.Element {
+  const [title, setTitle] = useState('');
+  const [subject, setSubject] = useState('');
+  const [docType, setDocType] = useState('Note');
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const reset = (): void => {
+    setTitle('');
+    setSubject('');
+    setDocType('Note');
+    setNote('');
+    resetFormState(setError, setSaving);
+  };
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && !saving) reset();
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTitle = title.trim();
+    const trimmedSubject = subject.trim();
+    const trimmedDocType = docType.trim();
+    if (!trimmedTitle || !trimmedSubject || !trimmedDocType) {
+      setError('Title, subject, and document type are required.');
+      return;
+    }
+
+    const id = createDocumentId();
+    const content: DocumentListContentInput = {
+      content: note,
+      contentType: 'text/plain',
+      size: contentSize(note),
+    };
+    const document: DocumentListDocument = {
+      id,
+      date: today(),
+      title: trimmedTitle,
+      subject: trimmedSubject,
+      docType: trimmedDocType,
+      docId: id,
+      source: 'Compose',
+      file: `${id}.txt`,
+    };
+
+    setSaving(true);
+    setError(null);
+    try {
+      await runtime.saveDocument(document, content);
+      reset();
+      onOpenChange(false);
+    } catch (saveError) {
+      setSaving(false);
+      setError(
+        saveError instanceof Error ? saveError.message : String(saveError)
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={handleOpenChange}
+      aria-label="Compose document"
+    >
+      <ModalHeader>
+        <ModalTitle>Compose document</ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <form onSubmit={handleSubmit} noValidate>
+        <ModalBody className="document-list-workflow__body">
+          <Input
+            id={inputId(inputPrefix, 'compose-title')}
+            label="Title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            disabled={saving}
+            required
+          />
+          <Input
+            id={inputId(inputPrefix, 'compose-subject')}
+            label="Subject"
+            value={subject}
+            onChange={(event) => setSubject(event.target.value)}
+            disabled={saving}
+            required
+          />
+          <Input
+            id={inputId(inputPrefix, 'compose-type')}
+            label="Document type"
+            value={docType}
+            onChange={(event) => setDocType(event.target.value)}
+            disabled={saving}
+            required
+          />
+          <Textarea
+            id={inputId(inputPrefix, 'compose-note')}
+            label="Note"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            disabled={saving}
+            rows={7}
+          />
+          {error && (
+            <p className="document-list-workflow__error" role="alert">
+              {error}
+            </p>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="sm" disabled={saving}>
+            {saving ? 'Saving…' : 'Save document'}
+          </Button>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+}
+
+export function DocumentListUploadModal({
+  open,
+  onOpenChange,
+  runtime,
+  inputPrefix,
+}: DocumentListWorkflowModalProps): React.JSX.Element {
+  const [file, setFile] = useState<File | null>(null);
+  const [storedName, setStoredName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const reset = (): void => {
+    setFile(null);
+    setStoredName('');
+    resetFormState(setError, setSaving);
+  };
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && !saving) reset();
+    onOpenChange(nextOpen);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const selectedFile = event.target.files?.[0] ?? null;
+    setFile(selectedFile);
+    setStoredName(selectedFile?.name ?? '');
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedStoredName = storedName.trim();
+    if (!file || !trimmedStoredName) {
+      setError('Choose a file and enter a stored filename.');
+      return;
+    }
+
+    const id = createDocumentId();
+    const contentType = file.type || 'application/octet-stream';
+    const content: DocumentListContentInput = {
+      content: file,
+      contentType,
+      size: file.size,
+    };
+    const document: DocumentListDocument = {
+      id,
+      date: today(),
+      title: file.name,
+      subject: 'Uploaded document',
+      docType: contentType,
+      docId: id,
+      source: 'Upload',
+      file: trimmedStoredName,
+    };
+
+    setSaving(true);
+    setError(null);
+    try {
+      await runtime.saveDocument(document, content);
+      reset();
+      onOpenChange(false);
+    } catch (saveError) {
+      setSaving(false);
+      setError(
+        saveError instanceof Error ? saveError.message : String(saveError)
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={handleOpenChange}
+      aria-label="Upload document"
+    >
+      <ModalHeader>
+        <ModalTitle>Upload document</ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <form onSubmit={handleSubmit} noValidate>
+        <ModalBody className="document-list-workflow__body">
+          <Input
+            id={inputId(inputPrefix, 'upload-file')}
+            label="Choose a file"
+            type="file"
+            onChange={handleFileChange}
+            disabled={saving}
+          />
+          {file && (
+            <p className="document-list-workflow__hint">
+              Title: {file.name} · Type:{' '}
+              {file.type || 'application/octet-stream'}
+            </p>
+          )}
+          <Input
+            id={inputId(inputPrefix, 'upload-filename')}
+            label="Stored filename"
+            value={storedName}
+            onChange={(event) => setStoredName(event.target.value)}
+            disabled={saving || !file}
+            required
+          />
+          {error && (
+            <p className="document-list-workflow__error" role="alert">
+              {error}
+            </p>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="sm" disabled={saving}>
+            {saving ? 'Saving…' : 'Save document'}
+          </Button>
+        </ModalFooter>
+      </form>
+    </Modal>
+  );
+}
+
+export interface DocumentListDetailRowProps {
+  readonly document: DocumentListDocument;
+  readonly runtime: DocumentListRuntimeState;
+}
+
+function formatSize(size: number | undefined): string {
+  return size == null ? 'Unknown' : `${size} bytes`;
+}
+
+function ContentMetadata({
+  document,
+  content,
+}: {
+  readonly document: DocumentListDocument;
+  readonly content?: DocumentListContent;
+}): React.JSX.Element {
+  return (
+    <dl className="document-list-detail__content-meta">
+      <div>
+        <dt>Content</dt>
+        <dd>
+          {content?.text != null
+            ? 'Text content'
+            : 'Unavailable or unsupported'}
+        </dd>
+      </div>
+      <div>
+        <dt>Reference</dt>
+        <dd>{content?.reference ?? document.file}</dd>
+      </div>
+      <div>
+        <dt>Type</dt>
+        <dd>{content?.contentType ?? document.docType}</dd>
+      </div>
+      <div>
+        <dt>Size</dt>
+        <dd>{formatSize(content?.size)}</dd>
+      </div>
+    </dl>
+  );
+}
+
+export function DocumentListDetailRow({
+  document,
+  runtime,
+}: DocumentListDetailRowProps): React.JSX.Element {
+  const [content, setContent] = useState<DocumentListContent | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setContent(undefined);
+    setLoading(true);
+    setError(null);
+    void runtime
+      .loadContent(document.id)
+      .then((loadedContent) => {
+        if (!active) return;
+        setContent(loadedContent);
+        setLoading(false);
+      })
+      .catch((loadError: unknown) => {
+        if (!active) return;
+        setLoading(false);
+        setError(
+          loadError instanceof Error ? loadError.message : String(loadError)
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, [document.id, runtime]);
+
+  const isImage = Boolean(
+    content?.reference &&
+      content.contentType?.toLowerCase().startsWith('image/')
+  );
+
+  return (
+    <div className="document-list-detail">
+      <strong className="document-list-detail__title">{document.title}</strong>
+      <dl className="document-list-detail__metadata">
+        <div>
+          <dt>Date</dt>
+          <dd>{document.date}</dd>
+        </div>
+        <div>
+          <dt>Subject</dt>
+          <dd>{document.subject}</dd>
+        </div>
+        <div>
+          <dt>Document type</dt>
+          <dd>{document.docType}</dd>
+        </div>
+        <div>
+          <dt>Source</dt>
+          <dd>{document.source}</dd>
+        </div>
+      </dl>
+      {loading && <p role="status">Loading document content…</p>}
+      {error && (
+        <p className="document-list-workflow__error" role="alert">
+          Could not load document content: {error}
+        </p>
+      )}
+      {!loading && content?.text != null && (
+        <div className="document-list-detail__text">{content.text}</div>
+      )}
+      {!loading && isImage && (
+        <img
+          className="document-list-detail__image"
+          src={content?.reference}
+          alt={document.title}
+        />
+      )}
+      {!loading && content?.text == null && !isImage && (
+        <ContentMetadata document={document} content={content} />
+      )}
+    </div>
+  );
+}

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -19,7 +19,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@mieweb/ui';
-import '@kerebron/editor/assets/index-light.css';
+import '@kerebron/editor/assets/index.css';
 import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
 import type {
   DocumentListContent,
@@ -29,6 +29,34 @@ import type {
 import type { DocumentListDocument } from './types.js';
 
 const COMPOSE_CONTENT_TYPE = 'text/x-markdown';
+
+function useIsDark(): boolean {
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof document === 'undefined') return false;
+    return (
+      document.documentElement.classList.contains('dark') ||
+      document.documentElement.dataset.theme === 'dark'
+    );
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const updateTheme = (): void => {
+      setIsDark(
+        root.classList.contains('dark') || root.dataset.theme === 'dark'
+      );
+    };
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    updateTheme();
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}
 
 let composeAssetLoad: AssetLoad | undefined;
 
@@ -75,9 +103,29 @@ const COMPOSE_EDITOR_STYLES = `
 
   .document-list-compose-editor .ProseMirror blockquote {
     border-left: 3px solid #ccc;
-    color: #666;
+    color: var(--kb-color-text-muted);
     margin-left: 0;
     padding-left: 1em;
+  }
+
+  .document-list-compose-editor.kb-component--dark {
+    --kb-bg: var(--kb-color-surface-elevated, #374151);
+    --kb-fg: var(--kb-color-text, #f9fafb);
+    --kb-subtle: var(--kb-color-text-muted, #9ca3af);
+    --kb-border: var(--kb-color-border, #374151);
+    --kb-hover: var(--kb-color-surface-hover, rgba(232, 234, 237, 0.08));
+    --kb-active: rgba(59, 130, 246, 0.2);
+    --kb-focus: #93c5fd;
+    --kb-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  .document-list-compose-editor.kb-component--dark .ProseMirror {
+    color: var(--kb-color-text);
+    background: var(--kb-color-surface);
+  }
+
+  .document-list-compose-editor.kb-component--dark .ProseMirror blockquote {
+    border-left-color: var(--kb-color-border);
   }
 
   .document-list-compose-editor .kb-custom-menu__editor {
@@ -151,6 +199,7 @@ const DocumentListComposeEditor = forwardRef<
   { ariaLabel, disabled, id, labelledBy, onChange, value },
   ref
 ): React.JSX.Element {
+  const isDark = useIsDark();
   const hostRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<CoreEditor | null>(null);
   const onChangeRef = useRef(onChange);
@@ -272,7 +321,9 @@ const DocumentListComposeEditor = forwardRef<
     <div
       ref={hostRef}
       id={id}
-      className="kb-component document-list-compose-editor"
+      className={`kb-component document-list-compose-editor${
+        isDark ? ' kb-component--dark' : ''
+      }`}
       aria-labelledby={labelledBy}
       aria-label="Document note editor"
       aria-disabled={disabled || undefined}

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -19,7 +19,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@mieweb/ui';
-import '@kerebron/editor/assets/index-light.css';
+import '@kerebron/editor/assets/index.css';
 import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
 import type {
   DocumentListContent,
@@ -39,10 +39,99 @@ export function configureDocumentListComposeEditor(options: {
 }
 
 const COMPOSE_EDITOR_STYLES = `
+  [data-theme='light'],
+  [data-theme='light'] .kb-component {
+    --kb-color-primary: var(--mieweb-primary-500, #27aae1);
+    --kb-color-text: var(--mieweb-foreground, #1f2937);
+    --kb-color-text-muted: var(--mieweb-muted-foreground, #6b7280);
+    --kb-color-icon: var(--mieweb-muted-foreground, #5f6368);
+    --kb-color-surface: var(--mieweb-background, #ffffff);
+    --kb-color-surface-elevated: var(--mieweb-muted, #f9fafb);
+    --kb-color-surface-hover: rgba(60, 64, 67, 0.08);
+    --kb-color-border: var(--mieweb-border, #e5e7eb);
+    --kb-color-border-strong: var(--mieweb-border, #d1d5db);
+    --kb-color-hover: rgba(60, 64, 67, 0.08);
+    --kb-color-active: rgba(60, 64, 67, 0.1);
+    --kb-menu-dropdown-bg: var(--mieweb-card, #ffffff);
+    --kb-menu-dropdown-border: var(--mieweb-border, #dadce0);
+    --kb-menu-dropdown-text: var(--mieweb-card-foreground, #3c4043);
+    --kb-menu-dropdown-hover: rgba(60, 64, 67, 0.08);
+  }
+
+  [data-theme='dark'],
+  [data-theme='dark'] .kb-component,
+  .dark,
+  .dark .kb-component {
+    --kb-color-primary: var(--mieweb-primary-500, #27aae1);
+    --kb-color-text: var(--mieweb-foreground, #fafafa);
+    --kb-color-text-muted: var(--mieweb-muted-foreground, #a1a1aa);
+    --kb-color-icon: var(--mieweb-muted-foreground, #a1a1aa);
+    --kb-color-surface: var(--mieweb-background, #171717);
+    --kb-color-surface-elevated: var(--mieweb-muted, #404040);
+    --kb-color-surface-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+    --kb-color-border: var(--mieweb-border, #404040);
+    --kb-color-border-strong: var(--mieweb-border, #404040);
+    --kb-color-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+    --kb-color-active: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 14%, transparent);
+    --kb-menu-dropdown-bg: var(--mieweb-card, #262626);
+    --kb-menu-dropdown-border: var(--mieweb-border, #404040);
+    --kb-menu-dropdown-text: var(--mieweb-card-foreground, #fafafa);
+    --kb-menu-dropdown-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+  }
+
+  [data-theme='light'] .kb-custom-menu,
+  [data-theme='dark'] .kb-custom-menu,
+  .dark .kb-custom-menu {
+    background: var(--kb-color-surface-elevated);
+    border-bottom-color: var(--kb-color-border-strong);
+    color: var(--kb-color-text);
+  }
+
+  [data-theme='light'] .kb-custom-menu .kb-menu__button,
+  [data-theme='light'] .kb-custom-menu .kb-dropdown__label,
+  [data-theme='dark'] .kb-custom-menu .kb-menu__button,
+  [data-theme='dark'] .kb-custom-menu .kb-dropdown__label,
+  .dark .kb-custom-menu .kb-menu__button,
+  .dark .kb-custom-menu .kb-dropdown__label {
+    color: var(--kb-color-icon);
+  }
+
+  [data-theme='light'] .kb-dropdown__menu,
+  [data-theme='light'] .kb-submenu__content,
+  [data-theme='light'] .kb-custom-menu__overflow-menu,
+  [data-theme='dark'] .kb-dropdown__menu,
+  [data-theme='dark'] .kb-submenu__content,
+  [data-theme='dark'] .kb-custom-menu__overflow-menu,
+  .dark .kb-dropdown__menu,
+  .dark .kb-submenu__content,
+  .dark .kb-custom-menu__overflow-menu {
+    background: var(--kb-menu-dropdown-bg) !important;
+    border-color: var(--kb-menu-dropdown-border) !important;
+    color: var(--kb-menu-dropdown-text) !important;
+  }
+
+  [data-theme='light'] .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  [data-theme='light'] .kb-custom-menu .kb-submenu__label:hover,
+  [data-theme='light'] .kb-custom-menu__overflow-item:hover,
+  [data-theme='dark'] .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  [data-theme='dark'] .kb-custom-menu .kb-submenu__label:hover,
+  [data-theme='dark'] .kb-custom-menu__overflow-item:hover,
+  .dark .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  .dark .kb-custom-menu .kb-submenu__label:hover,
+  .dark .kb-custom-menu__overflow-item:hover {
+    background: var(--kb-menu-dropdown-hover) !important;
+    color: var(--kb-menu-dropdown-text) !important;
+  }
+
   .document-list-compose-editor .ProseMirror {
     min-height: 160px;
     outline: none;
     padding: 8px 12px;
+  }
+
+  .document-list-compose-editor .kb-editor,
+  .document-list-compose-editor .ProseMirror {
+    color: var(--kb-color-text);
   }
 
   .document-list-compose-editor .ProseMirror h1 {
@@ -74,10 +163,20 @@ const COMPOSE_EDITOR_STYLES = `
   }
 
   .document-list-compose-editor .ProseMirror blockquote {
-    border-left: 3px solid #ccc;
-    color: #666;
+    border-left: 3px solid var(--kb-color-border);
+    color: var(--kb-color-text-muted);
     margin-left: 0;
     padding-left: 1em;
+  }
+
+  /* Keep overflow-menu icons inside their compact button hit areas. */
+  .document-list-compose-editor .kb-custom-menu__overflow-menu .kb-icon {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    line-height: 1;
   }
 
   .document-list-compose-editor .kb-custom-menu__editor {

--- a/packages/document-list-field/src/DocumentListWorkflows.tsx
+++ b/packages/document-list-field/src/DocumentListWorkflows.tsx
@@ -12,6 +12,7 @@ import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
 import {
   Button,
   Input,
+  MarkdownRenderer,
   Modal,
   ModalBody,
   ModalClose,
@@ -21,6 +22,7 @@ import {
 } from '@mieweb/ui';
 import '@kerebron/editor/assets/index.css';
 import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
+import '@mieweb/ui/markdown.css';
 import type {
   DocumentListContent,
   DocumentListContentInput,
@@ -737,38 +739,10 @@ function DocumentListMarkdownPreview({
 }: {
   readonly content: string;
 }): React.JSX.Element {
-  const hostRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-
-    const mount = document.createElement('div');
-    host.appendChild(mount);
-    const editor = CoreEditor.create({
-      element: mount,
-      uri: 'file:///document-list-detail.md',
-      assetLoad: composeAssetLoad,
-      editorKits: [new AdvancedEditorKit()],
-      readOnly: true,
-    });
-
-    void editor
-      .loadDocument(COMPOSE_CONTENT_TYPE, new TextEncoder().encode(content))
-      .catch(() => undefined);
-
-    return () => {
-      editor.destroy();
-      host.replaceChildren();
-    };
-  }, [content]);
-
   return (
-    <div
-      ref={hostRef}
-      className="kb-component document-list-detail__preview"
-      aria-label="Document content"
-    />
+    <div className="document-list-detail__preview" aria-label="Document content">
+      <MarkdownRenderer text={content} />
+    </div>
   );
 }
 

--- a/packages/document-list-field/src/data.spec.ts
+++ b/packages/document-list-field/src/data.spec.ts
@@ -1,0 +1,79 @@
+import {
+  createLocalSourcePayload,
+  normalizeDocumentRows,
+  parseDocumentListAnswer,
+} from './data.js';
+
+describe('document list data', () => {
+  it('normalizes projected document summaries and display fallbacks', () => {
+    expect(
+      normalizeDocumentRows([
+        {
+          id: 'doc-1',
+          date: '2026-08-18',
+          title: 'Letter',
+          subject: '',
+          docType: null,
+          docId: 42,
+          from: 'WebChart',
+          file: '42.pdf',
+        },
+        { title: 'Missing identity' },
+        { id: 'doc-2', title: 'Browser draft' },
+      ])
+    ).toEqual([
+      {
+        id: 'doc-1',
+        date: '2026-08-18',
+        title: 'Letter',
+        subject: '—',
+        docType: '—',
+        docId: '42',
+        source: 'WebChart',
+        file: '42.pdf',
+      },
+      {
+        id: 'doc-2',
+        date: '—',
+        title: 'Browser draft',
+        subject: '—',
+        docType: '—',
+        docId: '—',
+        source: '—',
+        file: 'browser',
+      },
+    ]);
+  });
+
+  it('accepts object, rows, and direct-array response shapes', () => {
+    const row = { id: 'doc-1', title: 'Letter' };
+
+    expect(
+      parseDocumentListAnswer(JSON.stringify({ documents: [row] }))
+    ).toHaveLength(1);
+    expect(
+      parseDocumentListAnswer(JSON.stringify({ rows: [row] }))
+    ).toHaveLength(1);
+    expect(parseDocumentListAnswer(JSON.stringify([row]))).toHaveLength(1);
+    expect(parseDocumentListAnswer('{invalid')).toEqual([]);
+  });
+
+  it('publishes a fresh DataVis payload without mutating rows', () => {
+    const rows = normalizeDocumentRows([{ id: 'doc-1', title: 'Letter' }]);
+    const payload = createLocalSourcePayload(rows);
+
+    expect(payload.data).toEqual(rows);
+    expect(payload.data).not.toBe(rows);
+    expect(
+      payload.typeInfo.map((entry: { field: string }) => entry.field)
+    ).toEqual([
+      'date',
+      'title',
+      'subject',
+      'docType',
+      'docId',
+      'source',
+      'file',
+    ]);
+  });
+});

--- a/packages/document-list-field/src/data.ts
+++ b/packages/document-list-field/src/data.ts
@@ -4,6 +4,12 @@ import type {
   DocumentListValue,
 } from './types.js';
 
+/** Content type of composed and inline markdown documents. */
+export const DOCUMENT_LIST_MARKDOWN_TYPE = 'text/x-markdown';
+
+/** What one row is called when a field names nothing else. */
+export const DOCUMENT_LIST_DEFAULT_NOUN = 'document';
+
 export const DOCUMENT_LIST_COLUMNS = [
   {
     field: 'date',
@@ -121,6 +127,7 @@ export function normalizeDocumentRow(
     ...(typeof input.size === 'number' && Number.isFinite(input.size)
       ? { size: input.size }
       : {}),
+    ...(typeof input.body === 'string' ? { body: input.body } : {}),
   };
 }
 

--- a/packages/document-list-field/src/data.ts
+++ b/packages/document-list-field/src/data.ts
@@ -114,6 +114,13 @@ export function normalizeDocumentRow(
     docId: displayValue(input.docId),
     source: displayValue(input.source ?? input.from ?? input.author),
     file: fileValue(input.file),
+    // Host bookkeeping: carried through untouched, absent when not recorded.
+    ...(typeof input.sha256 === 'string' && input.sha256
+      ? { sha256: input.sha256 }
+      : {}),
+    ...(typeof input.size === 'number' && Number.isFinite(input.size)
+      ? { size: input.size }
+      : {}),
   };
 }
 

--- a/packages/document-list-field/src/data.ts
+++ b/packages/document-list-field/src/data.ts
@@ -1,0 +1,163 @@
+import type {
+  DocumentListDocument,
+  DocumentListInput,
+  DocumentListValue,
+} from './types.js';
+
+export const DOCUMENT_LIST_COLUMNS = [
+  {
+    field: 'date',
+    header: 'Date',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+  },
+  {
+    field: 'title',
+    header: 'Title',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+  },
+  {
+    field: 'subject',
+    header: 'Subject',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+  },
+  {
+    field: 'docType',
+    header: 'Document Type',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+    width: 150,
+  },
+  {
+    field: 'docId',
+    header: 'Doc ID',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+    width: 90,
+  },
+  {
+    field: 'source',
+    header: 'Source',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+  },
+  {
+    field: 'file',
+    header: 'File',
+    sortable: true,
+    filterable: true,
+    resizable: true,
+    width: 120,
+  },
+] as const;
+
+export const DOCUMENT_LIST_ACTIONS_COLUMN = {
+  field: '_actions',
+  header: 'Actions',
+  sortable: false,
+  filterable: false,
+  resizable: false,
+  width: 48,
+} as const;
+
+export const DOCUMENT_LIST_TYPE_INFO = DOCUMENT_LIST_COLUMNS.map((column) => ({
+  field: column.field,
+  displayText: column.header,
+  type: 'string',
+}));
+
+const EMPTY_DISPLAY = '—';
+
+function displayValue(value: unknown): string {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return EMPTY_DISPLAY;
+}
+
+function fileValue(value: unknown): string {
+  const display = displayValue(value);
+  return display === EMPTY_DISPLAY ? 'browser' : display;
+}
+
+function stringId(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function asInput(value: unknown): DocumentListInput | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as DocumentListInput;
+}
+
+export function normalizeDocumentRow(
+  value: unknown
+): DocumentListDocument | null {
+  const input = asInput(value);
+  const id = input ? stringId(input.id) : null;
+  if (!input || !id) return null;
+
+  return {
+    id,
+    date: displayValue(input.date),
+    title: displayValue(input.title),
+    subject: displayValue(input.subject),
+    docType: displayValue(input.docType),
+    docId: displayValue(input.docId),
+    source: displayValue(input.source ?? input.from ?? input.author),
+    file: fileValue(input.file),
+  };
+}
+
+export function normalizeDocumentRows(value: unknown): DocumentListDocument[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((row) => {
+    const normalized = normalizeDocumentRow(row);
+    return normalized ? [normalized] : [];
+  });
+}
+
+export function parseDocumentListAnswer(
+  answer: string | undefined
+): DocumentListDocument[] {
+  if (!answer) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(answer);
+    if (Array.isArray(parsed)) return normalizeDocumentRows(parsed);
+    if (!parsed || typeof parsed !== 'object') return [];
+
+    const value = parsed as Partial<DocumentListValue> & {
+      rows?: unknown;
+    };
+    return normalizeDocumentRows(value.documents ?? value.rows);
+  } catch {
+    return [];
+  }
+}
+
+export function documentListValueFromRows(
+  rows: readonly DocumentListDocument[]
+): DocumentListValue {
+  return { documents: rows };
+}
+
+export function createLocalSourcePayload(
+  rows: readonly DocumentListDocument[]
+): {
+  data: DocumentListDocument[];
+  typeInfo: typeof DOCUMENT_LIST_TYPE_INFO;
+} {
+  return {
+    data: rows.map((row) => ({ ...row })),
+    typeInfo: DOCUMENT_LIST_TYPE_INFO,
+  };
+}

--- a/packages/document-list-field/src/document-list-runtime.spec.ts
+++ b/packages/document-list-field/src/document-list-runtime.spec.ts
@@ -166,6 +166,39 @@ describe('document list runtime store', () => {
     expect(store.getState().documentIds).toEqual(['doc-1', 'doc-2']);
   });
 
+  it('preserves the metadata-only repository save call shape', async () => {
+    const repository = createRepository();
+    const store = createRuntime({ repository });
+
+    await store.getState().saveDocument(documentOne);
+
+    expect(repository.save).toHaveBeenCalledWith(
+      context,
+      documentOne,
+      expect.any(AbortSignal)
+    );
+    expect(repository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards transient content to the repository save operation', async () => {
+    const repository = createRepository();
+    const store = createRuntime({ repository });
+    const content = {
+      content: 'A composed note',
+      contentType: 'text/plain',
+      size: 15,
+    };
+
+    await store.getState().saveDocument(documentOne, content);
+
+    expect(repository.save).toHaveBeenCalledWith(
+      context,
+      documentOne,
+      expect.any(AbortSignal),
+      content
+    );
+  });
+
   it('rolls back an optimistic delete when the repository fails', async () => {
     const repository = createRepository({
       remove: vi.fn(async () => {

--- a/packages/document-list-field/src/document-list-runtime.spec.ts
+++ b/packages/document-list-field/src/document-list-runtime.spec.ts
@@ -1,0 +1,219 @@
+import type { DocumentListDocument } from './types.js';
+import { createFormStore, type FormStore } from '@esheet/core';
+import type {
+  DocumentListRepository,
+  DocumentListRepositoryContext,
+  DocumentListSnapshot,
+} from './document-list-runtime.js';
+import {
+  createDocumentListRuntimeExtension,
+  getDocumentListRuntimeState,
+} from './document-list-runtime.js';
+
+const context: DocumentListRepositoryContext = {
+  formInstanceId: 'form-instance-1',
+  fieldId: 'documents',
+};
+
+const documentOne: DocumentListDocument = {
+  id: 'doc-1',
+  date: '2026-08-18',
+  title: 'Letter',
+  subject: 'Subject',
+  docType: 'Letter',
+  docId: '42',
+  source: 'WebChart',
+  file: '42.pdf',
+};
+
+const documentTwo: DocumentListDocument = {
+  ...documentOne,
+  id: 'doc-2',
+  title: 'Second letter',
+};
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (error: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function createRepository(
+  overrides: Partial<DocumentListRepository> = {}
+): DocumentListRepository {
+  return {
+    load: vi.fn(async () => ({ documents: [] })),
+    save: vi.fn(async (_context, document) => document),
+    remove: vi.fn(async () => undefined),
+    loadContent: vi.fn(async () => ({ text: 'Document content' })),
+    ...overrides,
+  };
+}
+
+function createRuntime(
+  options: {
+    context?: DocumentListRepositoryContext;
+    repository?: DocumentListRepository;
+    initialDocuments?: readonly DocumentListDocument[];
+  } = {}
+): {
+  formStore: FormStore;
+  getState: () => NonNullable<ReturnType<typeof getDocumentListRuntimeState>>;
+} {
+  const formStore = createFormStore();
+  const runtimeContext = options.context ?? context;
+  createDocumentListRuntimeExtension({
+    formStore,
+    context: runtimeContext,
+    repository: options.repository,
+    initialDocuments: options.initialDocuments,
+  });
+  return {
+    formStore,
+    getState: () => {
+      const state = getDocumentListRuntimeState(
+        formStore,
+        runtimeContext.fieldId
+      );
+      if (!state) throw new Error('Document-list extension was not registered');
+      return state;
+    },
+  };
+}
+
+describe('document list runtime store', () => {
+  it('keeps document state isolated between store instances', () => {
+    const first = createRuntime({
+      initialDocuments: [documentOne],
+    });
+    const second = createRuntime({
+      context: { ...context, formInstanceId: 'form-instance-2' },
+    });
+
+    first.getState().upsertDocument(documentTwo);
+
+    expect(first.getState().documentIds).toEqual(['doc-1', 'doc-2']);
+    expect(second.getState().documentIds).toEqual([]);
+    expect(second.getState().documents['doc-2']).toBeUndefined();
+  });
+
+  it('hydrates snapshots, refreshes, and receives subscribed snapshots', async () => {
+    let notify: ((snapshot: DocumentListSnapshot) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const repository = createRepository({
+      load: vi.fn(async () => ({
+        documents: [documentTwo],
+        revision: 'revision-2',
+      })),
+      subscribe: vi.fn((_context, onSnapshot) => {
+        notify = onSnapshot;
+        return unsubscribe;
+      }),
+    });
+    const store = createRuntime({ context, repository });
+
+    store.getState().start();
+    notify?.({ documents: [documentOne], revision: 'revision-1' });
+    expect(store.getState().documents['doc-1']).toEqual(documentOne);
+
+    await store.getState().refresh();
+
+    expect(repository.load).toHaveBeenCalledWith(
+      context,
+      expect.any(AbortSignal)
+    );
+    expect(store.getState().documentIds).toEqual(['doc-2']);
+    expect(store.getState().revision).toBe('revision-2');
+
+    store.getState().dispose();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(getDocumentListRuntimeState(store.formStore, context.fieldId)).toBe(
+      undefined
+    );
+  });
+
+  it('keeps concurrent saves independent and clears their pending state', async () => {
+    const saves = new Map<
+      string,
+      ReturnType<typeof deferred<DocumentListDocument>>
+    >();
+    const repository = createRepository({
+      save: vi.fn((_context, document) => {
+        const request = deferred<DocumentListDocument>();
+        saves.set(document.id, request);
+        return request.promise;
+      }),
+    });
+    const store = createRuntime({ context, repository });
+
+    const firstSave = store.getState().saveDocument(documentOne);
+    const secondSave = store.getState().saveDocument(documentTwo);
+    saves.get('doc-1')?.resolve(documentOne);
+    saves.get('doc-2')?.resolve(documentTwo);
+
+    await Promise.all([firstSave, secondSave]);
+
+    expect(store.getState().pendingOperations).toEqual({});
+    expect(store.getState().syncStatus).toBe('idle');
+    expect(store.getState().documentIds).toEqual(['doc-1', 'doc-2']);
+  });
+
+  it('rolls back an optimistic delete when the repository fails', async () => {
+    const repository = createRepository({
+      remove: vi.fn(async () => {
+        throw new Error('delete failed');
+      }),
+    });
+    const store = createRuntime({
+      repository,
+      initialDocuments: [documentOne],
+    });
+
+    await expect(
+      store.getState().removeDocument(documentOne.id)
+    ).rejects.toThrow('delete failed');
+
+    expect(store.getState().documents[documentOne.id]).toEqual(documentOne);
+    expect(store.getState().documentIds).toEqual([documentOne.id]);
+    expect(store.getState().pendingOperations).toEqual({});
+    expect(store.getState().syncStatus).toBe('error');
+  });
+
+  it('deduplicates content requests and caches the loaded result', async () => {
+    const contentRequest = deferred<{ text: string }>();
+    const repository = createRepository({
+      loadContent: vi.fn(() => contentRequest.promise),
+    });
+    const store = createRuntime({
+      repository,
+      initialDocuments: [documentOne],
+    });
+
+    const firstLoad = store.getState().loadContent(documentOne.id);
+    const secondLoad = store.getState().loadContent(documentOne.id);
+    expect(repository.loadContent).toHaveBeenCalledOnce();
+
+    contentRequest.resolve({ text: 'Loaded once' });
+    await expect(firstLoad).resolves.toEqual({ text: 'Loaded once' });
+    await expect(secondLoad).resolves.toEqual({ text: 'Loaded once' });
+    expect(store.getState().contents[documentOne.id]).toEqual({
+      status: 'loaded',
+      content: { text: 'Loaded once' },
+    });
+
+    await expect(store.getState().loadContent(documentOne.id)).resolves.toEqual(
+      {
+        text: 'Loaded once',
+      }
+    );
+    expect(repository.loadContent).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/document-list-field/src/document-list-runtime.spec.ts
+++ b/packages/document-list-field/src/document-list-runtime.spec.ts
@@ -63,6 +63,7 @@ function createRuntime(
     context?: DocumentListRepositoryContext;
     repository?: DocumentListRepository;
     initialDocuments?: readonly DocumentListDocument[];
+    onDocumentsChange?: (documents: readonly DocumentListDocument[]) => void;
   } = {}
 ): {
   formStore: FormStore;
@@ -75,6 +76,7 @@ function createRuntime(
     context: runtimeContext,
     repository: options.repository,
     initialDocuments: options.initialDocuments,
+    onDocumentsChange: options.onDocumentsChange,
   });
   return {
     formStore,
@@ -166,18 +168,27 @@ describe('document list runtime store', () => {
     expect(store.getState().documentIds).toEqual(['doc-1', 'doc-2']);
   });
 
-  it('preserves the metadata-only repository save call shape', async () => {
+  it('keeps a row with no content away from the repository', async () => {
     const repository = createRepository();
-    const store = createRuntime({ repository });
+    const onDocumentsChange = vi.fn();
+    const store = createRuntime({ repository, onDocumentsChange });
 
     await store.getState().saveDocument(documentOne);
 
-    expect(repository.save).toHaveBeenCalledWith(
-      context,
-      documentOne,
-      expect.any(AbortSignal)
-    );
-    expect(repository.save).toHaveBeenCalledTimes(1);
+    expect(repository.save).not.toHaveBeenCalled();
+    expect(onDocumentsChange).toHaveBeenCalledWith([documentOne]);
+  });
+
+  it('publishes the row list when a document is removed', async () => {
+    const onDocumentsChange = vi.fn();
+    const store = createRuntime({
+      initialDocuments: [documentOne, documentTwo],
+      onDocumentsChange,
+    });
+
+    await store.getState().removeDocument('doc-1');
+
+    expect(onDocumentsChange).toHaveBeenCalledWith([documentTwo]);
   });
 
   it('forwards transient content to the repository save operation', async () => {

--- a/packages/document-list-field/src/document-list-runtime.ts
+++ b/packages/document-list-field/src/document-list-runtime.ts
@@ -1,4 +1,5 @@
 import type { FormStore } from '@esheet/core';
+import { DOCUMENT_LIST_MARKDOWN_TYPE } from './data.js';
 import type { DocumentListDocument } from './types.js';
 
 export const DOCUMENT_LIST_EXTENSION_NAMESPACE = '@esheet/document-list-field';
@@ -44,7 +45,7 @@ export interface DocumentListRepository {
   ) => Promise<DocumentListDocument>;
   remove: (
     context: DocumentListRepositoryContext,
-    documentId: string,
+    document: DocumentListDocument,
     signal: AbortSignal
   ) => Promise<void>;
   loadContent: (
@@ -110,6 +111,13 @@ export interface CreateDocumentListRuntimeExtensionOptions {
   readonly context: DocumentListRepositoryContext;
   readonly repository?: DocumentListRepository;
   readonly initialDocuments?: readonly DocumentListDocument[];
+  /**
+   * Called whenever the row list changes, so the field can publish it as its
+   * answer. Rows are the field's to own; the repository only ever sees bytes.
+   */
+  readonly onDocumentsChange?: (
+    documents: readonly DocumentListDocument[]
+  ) => void;
 }
 
 interface ContentRequest {
@@ -152,6 +160,15 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/** The content of a row that carries its own body, with no repository call. */
+function inlineContent(body: string): DocumentListContent {
+  return {
+    text: body,
+    contentType: DOCUMENT_LIST_MARKDOWN_TYPE,
+    size: body.length,
+  };
+}
+
 export function getDocumentListRuntimeState(
   formStore: FormStore,
   fieldId: string
@@ -167,7 +184,7 @@ export function getDocumentListRuntimeState(
 export function createDocumentListRuntimeExtension(
   options: CreateDocumentListRuntimeExtensionOptions
 ): DocumentListRuntimeState | undefined {
-  const { formStore, context, repository } = options;
+  const { formStore, context, repository, onDocumentsChange } = options;
   const existing = getDocumentListRuntimeState(formStore, context.fieldId);
   if (existing) return existing;
 
@@ -197,6 +214,19 @@ export function createDocumentListRuntimeExtension(
         context.fieldId,
         (state) => (state ? updater(state) : current)
       );
+  };
+
+  /** Publishes the row list to the field. Never called for inbound snapshots. */
+  const notifyDocuments = (): void => {
+    if (!onDocumentsChange) return;
+    const current = getState();
+    if (!current) return;
+    onDocumentsChange(
+      current.documentIds.flatMap((documentId) => {
+        const document = current.documents[documentId];
+        return document ? [document] : [];
+      })
+    );
   };
 
   const setSnapshot = (snapshot: DocumentListSnapshot): void => {
@@ -258,13 +288,15 @@ export function createDocumentListRuntimeExtension(
           : [...current.documentIds, document.id],
         error: undefined,
       }));
+      notifyDocuments();
     },
 
     saveDocument: async (document, content) => {
       const current = getState();
       if (!current || current.disposed) return document;
       current.upsertDocument(document);
-      if (!repository) return document;
+      // No bytes, no host: an inline row's content is already in the answer.
+      if (!repository || !content) return document;
 
       const operationKey = `save:${document.id}`;
       operationControllers.get(operationKey)?.abort();
@@ -343,7 +375,9 @@ export function createDocumentListRuntimeExtension(
           error: undefined,
         };
       });
-      if (!repository) return;
+      notifyDocuments();
+      // An inline row left nothing behind for the repository to delete.
+      if (!repository || previousDocument.body != null) return;
 
       const operationKey = `delete:${documentId}`;
       operationControllers.get(operationKey)?.abort();
@@ -362,7 +396,7 @@ export function createDocumentListRuntimeExtension(
       }));
 
       try {
-        await repository.remove(context, documentId, controller.signal);
+        await repository.remove(context, previousDocument, controller.signal);
         if (!getState() || operationRequestIds.get(operationKey) !== requestId)
           return;
         updateState((next) => {
@@ -397,6 +431,7 @@ export function createDocumentListRuntimeExtension(
               error: errorMessage(error),
             };
           });
+          notifyDocuments();
         }
         throw error;
       } finally {
@@ -415,6 +450,9 @@ export function createDocumentListRuntimeExtension(
       const cached = current.contents[documentId];
       if (cached?.status === 'loaded' && cached.content)
         return Promise.resolve(cached.content);
+      // An inline row carries its own content; the repository never saw it.
+      const inline = current.documents[documentId]?.body;
+      if (inline != null) return Promise.resolve(inlineContent(inline));
       if (current.disposed || !repository) return Promise.resolve(undefined);
       const document = current.documents[documentId];
       if (!document) return Promise.resolve(undefined);

--- a/packages/document-list-field/src/document-list-runtime.ts
+++ b/packages/document-list-field/src/document-list-runtime.ts
@@ -21,6 +21,12 @@ export interface DocumentListContent {
   readonly revision?: string;
 }
 
+export interface DocumentListContentInput {
+  readonly content: string | Blob;
+  readonly contentType?: string;
+  readonly size?: number;
+}
+
 export interface DocumentListRepository {
   seed?: (
     context: DocumentListRepositoryContext,
@@ -33,7 +39,8 @@ export interface DocumentListRepository {
   save: (
     context: DocumentListRepositoryContext,
     document: DocumentListDocument,
-    signal: AbortSignal
+    signal: AbortSignal,
+    content?: DocumentListContentInput
   ) => Promise<DocumentListDocument>;
   remove: (
     context: DocumentListRepositoryContext,
@@ -88,7 +95,8 @@ export interface DocumentListRuntimeState {
   applyRemoteSnapshot: (snapshot: DocumentListSnapshot) => void;
   upsertDocument: (document: DocumentListDocument) => void;
   saveDocument: (
-    document: DocumentListDocument
+    document: DocumentListDocument,
+    content?: DocumentListContentInput
   ) => Promise<DocumentListDocument>;
   removeDocument: (documentId: string) => Promise<void>;
   loadContent: (documentId: string) => Promise<DocumentListContent | undefined>;
@@ -252,7 +260,7 @@ export function createDocumentListRuntimeExtension(
       }));
     },
 
-    saveDocument: async (document) => {
+    saveDocument: async (document, content) => {
       const current = getState();
       if (!current || current.disposed) return document;
       current.upsertDocument(document);
@@ -275,11 +283,9 @@ export function createDocumentListRuntimeExtension(
       }));
 
       try {
-        const saved = await repository.save(
-          context,
-          document,
-          controller.signal
-        );
+        const saved = content
+          ? await repository.save(context, document, controller.signal, content)
+          : await repository.save(context, document, controller.signal);
         if (!getState() || operationRequestIds.get(operationKey) !== requestId)
           return saved;
         getState()?.upsertDocument(saved);

--- a/packages/document-list-field/src/document-list-runtime.ts
+++ b/packages/document-list-field/src/document-list-runtime.ts
@@ -1,0 +1,523 @@
+import type { FormStore } from '@esheet/core';
+import type { DocumentListDocument } from './types.js';
+
+export const DOCUMENT_LIST_EXTENSION_NAMESPACE = '@esheet/document-list-field';
+
+export interface DocumentListRepositoryContext {
+  readonly formInstanceId: string;
+  readonly fieldId: string;
+}
+
+export interface DocumentListSnapshot {
+  readonly documents: readonly DocumentListDocument[];
+  readonly revision?: string;
+}
+
+export interface DocumentListContent {
+  readonly reference?: string;
+  readonly text?: string;
+  readonly contentType?: string;
+  readonly size?: number;
+  readonly revision?: string;
+}
+
+export interface DocumentListRepository {
+  seed?: (
+    context: DocumentListRepositoryContext,
+    snapshot: DocumentListSnapshot
+  ) => void;
+  load: (
+    context: DocumentListRepositoryContext,
+    signal: AbortSignal
+  ) => Promise<DocumentListSnapshot>;
+  save: (
+    context: DocumentListRepositoryContext,
+    document: DocumentListDocument,
+    signal: AbortSignal
+  ) => Promise<DocumentListDocument>;
+  remove: (
+    context: DocumentListRepositoryContext,
+    documentId: string,
+    signal: AbortSignal
+  ) => Promise<void>;
+  loadContent: (
+    context: DocumentListRepositoryContext,
+    document: DocumentListDocument,
+    signal: AbortSignal
+  ) => Promise<DocumentListContent>;
+  subscribe?: (
+    context: DocumentListRepositoryContext,
+    onSnapshot: (snapshot: DocumentListSnapshot) => void
+  ) => () => void;
+}
+
+export type DocumentListSyncStatus =
+  | 'idle'
+  | 'loading'
+  | 'saving'
+  | 'deleting'
+  | 'error';
+
+export type DocumentListContentStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+export interface DocumentListContentState {
+  readonly status: DocumentListContentStatus;
+  readonly content?: DocumentListContent;
+  readonly error?: string;
+}
+
+export interface DocumentListPendingOperation {
+  readonly type: 'save' | 'delete';
+  readonly documentId: string;
+}
+
+export interface DocumentListRuntimeState {
+  readonly documents: Readonly<Record<string, DocumentListDocument>>;
+  readonly documentIds: readonly string[];
+  readonly contents: Readonly<Record<string, DocumentListContentState>>;
+  readonly pendingOperations: Readonly<
+    Record<string, DocumentListPendingOperation>
+  >;
+  readonly syncStatus: DocumentListSyncStatus;
+  readonly error?: string;
+  readonly revision?: string;
+  readonly disposed: boolean;
+  readonly hydrated: boolean;
+
+  hydrateSnapshot: (snapshot: DocumentListSnapshot) => void;
+  applyRemoteSnapshot: (snapshot: DocumentListSnapshot) => void;
+  upsertDocument: (document: DocumentListDocument) => void;
+  saveDocument: (
+    document: DocumentListDocument
+  ) => Promise<DocumentListDocument>;
+  removeDocument: (documentId: string) => Promise<void>;
+  loadContent: (documentId: string) => Promise<DocumentListContent | undefined>;
+  refresh: () => Promise<void>;
+  start: () => void;
+  dispose: () => void;
+}
+
+export interface CreateDocumentListRuntimeExtensionOptions {
+  readonly formStore: FormStore;
+  readonly context: DocumentListRepositoryContext;
+  readonly repository?: DocumentListRepository;
+  readonly initialDocuments?: readonly DocumentListDocument[];
+}
+
+interface ContentRequest {
+  readonly requestId: number;
+  readonly controller: AbortController;
+  readonly promise: Promise<DocumentListContent>;
+}
+
+function documentMap(
+  documents: readonly DocumentListDocument[]
+): Readonly<Record<string, DocumentListDocument>> {
+  return Object.fromEntries(
+    documents.map((document) => [document.id, document])
+  );
+}
+
+function orderedDocuments(
+  documents: readonly DocumentListDocument[]
+): DocumentListDocument[] {
+  const seen = new Set<string>();
+  return documents.filter((document) => {
+    if (seen.has(document.id)) return false;
+    seen.add(document.id);
+    return true;
+  });
+}
+
+function syncStatusFor(
+  pendingOperations: Readonly<Record<string, DocumentListPendingOperation>>
+): DocumentListSyncStatus {
+  const operations = Object.values(pendingOperations);
+  if (operations.some((operation) => operation.type === 'delete'))
+    return 'deleting';
+  if (operations.some((operation) => operation.type === 'save'))
+    return 'saving';
+  return 'idle';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function getDocumentListRuntimeState(
+  formStore: FormStore,
+  fieldId: string
+): DocumentListRuntimeState | undefined {
+  return formStore
+    .getState()
+    .getExtension<DocumentListRuntimeState>(
+      DOCUMENT_LIST_EXTENSION_NAMESPACE,
+      fieldId
+    );
+}
+
+export function createDocumentListRuntimeExtension(
+  options: CreateDocumentListRuntimeExtensionOptions
+): DocumentListRuntimeState | undefined {
+  const { formStore, context, repository } = options;
+  const existing = getDocumentListRuntimeState(formStore, context.fieldId);
+  if (existing) return existing;
+
+  let nextOperationRequestId = 0;
+  let nextContentRequestId = 0;
+  let refreshRequestId = 0;
+  let refreshController: AbortController | undefined;
+  let unsubscribe: (() => void) | undefined;
+  let resourcesDisposed = false;
+  const operationControllers = new Map<string, AbortController>();
+  const operationRequestIds = new Map<string, number>();
+  const contentRequests = new Map<string, ContentRequest>();
+  const initialDocuments = orderedDocuments(options.initialDocuments ?? []);
+
+  const getState = (): DocumentListRuntimeState | undefined =>
+    getDocumentListRuntimeState(formStore, context.fieldId);
+
+  const updateState = (
+    updater: (state: DocumentListRuntimeState) => DocumentListRuntimeState
+  ): void => {
+    const current = getState();
+    if (!current || current.disposed) return;
+    formStore
+      .getState()
+      .updateExtension<DocumentListRuntimeState>(
+        DOCUMENT_LIST_EXTENSION_NAMESPACE,
+        context.fieldId,
+        (state) => (state ? updater(state) : current)
+      );
+  };
+
+  const setSnapshot = (snapshot: DocumentListSnapshot): void => {
+    const current = getState();
+    if (!current) return;
+    const documents = orderedDocuments(snapshot.documents);
+    const nextIds = new Set(documents.map((document) => document.id));
+    const contents = Object.fromEntries(
+      Object.entries(current.contents).filter(([documentId]) =>
+        nextIds.has(documentId)
+      )
+    );
+
+    updateState((state) => ({
+      ...state,
+      documents: documentMap(documents),
+      documentIds: documents.map((document) => document.id),
+      contents,
+      error: undefined,
+      hydrated: true,
+      revision: snapshot.revision,
+      syncStatus: syncStatusFor(state.pendingOperations),
+    }));
+  };
+
+  const disposeResources = (): void => {
+    if (resourcesDisposed) return;
+    resourcesDisposed = true;
+    refreshController?.abort();
+    refreshController = undefined;
+    for (const controller of operationControllers.values()) controller.abort();
+    for (const request of contentRequests.values()) request.controller.abort();
+    operationControllers.clear();
+    operationRequestIds.clear();
+    contentRequests.clear();
+    unsubscribe?.();
+    unsubscribe = undefined;
+  };
+
+  const state: DocumentListRuntimeState = {
+    documents: documentMap(initialDocuments),
+    documentIds: initialDocuments.map((document) => document.id),
+    contents: {},
+    pendingOperations: {},
+    syncStatus: 'idle',
+    disposed: false,
+    hydrated: initialDocuments.length > 0,
+
+    hydrateSnapshot: setSnapshot,
+
+    applyRemoteSnapshot: setSnapshot,
+
+    upsertDocument: (document) => {
+      updateState((current) => ({
+        ...current,
+        documents: { ...current.documents, [document.id]: document },
+        documentIds: current.documentIds.includes(document.id)
+          ? current.documentIds
+          : [...current.documentIds, document.id],
+        error: undefined,
+      }));
+    },
+
+    saveDocument: async (document) => {
+      const current = getState();
+      if (!current || current.disposed) return document;
+      current.upsertDocument(document);
+      if (!repository) return document;
+
+      const operationKey = `save:${document.id}`;
+      operationControllers.get(operationKey)?.abort();
+      const controller = new AbortController();
+      operationControllers.set(operationKey, controller);
+      const requestId = ++nextOperationRequestId;
+      operationRequestIds.set(operationKey, requestId);
+      updateState((next) => ({
+        ...next,
+        pendingOperations: {
+          ...next.pendingOperations,
+          [document.id]: { type: 'save', documentId: document.id },
+        },
+        syncStatus: 'saving',
+        error: undefined,
+      }));
+
+      try {
+        const saved = await repository.save(
+          context,
+          document,
+          controller.signal
+        );
+        if (!getState() || operationRequestIds.get(operationKey) !== requestId)
+          return saved;
+        getState()?.upsertDocument(saved);
+        updateState((next) => {
+          const { [document.id]: _completed, ...pendingOperations } =
+            next.pendingOperations;
+          void _completed;
+          return {
+            ...next,
+            pendingOperations,
+            syncStatus: syncStatusFor(pendingOperations),
+          };
+        });
+        return saved;
+      } catch (error) {
+        if (getState() && operationRequestIds.get(operationKey) === requestId) {
+          updateState((next) => {
+            const { [document.id]: _failed, ...pendingOperations } =
+              next.pendingOperations;
+            void _failed;
+            return {
+              ...next,
+              pendingOperations,
+              syncStatus: 'error',
+              error: errorMessage(error),
+            };
+          });
+        }
+        throw error;
+      } finally {
+        if (operationControllers.get(operationKey) === controller)
+          operationControllers.delete(operationKey);
+        if (operationRequestIds.get(operationKey) === requestId)
+          operationRequestIds.delete(operationKey);
+      }
+    },
+
+    removeDocument: async (documentId) => {
+      const current = getState();
+      if (!current || current.disposed) return;
+      const previousDocument = current.documents[documentId];
+      if (!previousDocument) return;
+      const previousIndex = current.documentIds.indexOf(documentId);
+      const previousContent = current.contents[documentId];
+      updateState((next) => {
+        const { [documentId]: _removed, ...documents } = next.documents;
+        const { [documentId]: _content, ...contents } = next.contents;
+        void _removed;
+        void _content;
+        return {
+          ...next,
+          documents,
+          documentIds: next.documentIds.filter((id) => id !== documentId),
+          contents,
+          error: undefined,
+        };
+      });
+      if (!repository) return;
+
+      const operationKey = `delete:${documentId}`;
+      operationControllers.get(operationKey)?.abort();
+      const controller = new AbortController();
+      operationControllers.set(operationKey, controller);
+      const requestId = ++nextOperationRequestId;
+      operationRequestIds.set(operationKey, requestId);
+      updateState((next) => ({
+        ...next,
+        pendingOperations: {
+          ...next.pendingOperations,
+          [documentId]: { type: 'delete', documentId },
+        },
+        syncStatus: 'deleting',
+        error: undefined,
+      }));
+
+      try {
+        await repository.remove(context, documentId, controller.signal);
+        if (!getState() || operationRequestIds.get(operationKey) !== requestId)
+          return;
+        updateState((next) => {
+          const { [documentId]: _completed, ...pendingOperations } =
+            next.pendingOperations;
+          void _completed;
+          return {
+            ...next,
+            pendingOperations,
+            syncStatus: syncStatusFor(pendingOperations),
+          };
+        });
+      } catch (error) {
+        if (getState() && operationRequestIds.get(operationKey) === requestId) {
+          updateState((next) => {
+            const documents = { ...next.documents };
+            const documentIds = [...next.documentIds];
+            documents[documentId] = previousDocument;
+            documentIds.splice(Math.max(0, previousIndex), 0, documentId);
+            const { [documentId]: _failed, ...pendingOperations } =
+              next.pendingOperations;
+            void _failed;
+            return {
+              ...next,
+              documents,
+              documentIds,
+              ...(previousContent && {
+                contents: { ...next.contents, [documentId]: previousContent },
+              }),
+              pendingOperations,
+              syncStatus: 'error',
+              error: errorMessage(error),
+            };
+          });
+        }
+        throw error;
+      } finally {
+        if (operationControllers.get(operationKey) === controller)
+          operationControllers.delete(operationKey);
+        if (operationRequestIds.get(operationKey) === requestId)
+          operationRequestIds.delete(operationKey);
+      }
+    },
+
+    loadContent: (documentId) => {
+      const existing = contentRequests.get(documentId);
+      if (existing) return existing.promise;
+      const current = getState();
+      if (!current) return Promise.resolve(undefined);
+      const cached = current.contents[documentId];
+      if (cached?.status === 'loaded' && cached.content)
+        return Promise.resolve(cached.content);
+      if (current.disposed || !repository) return Promise.resolve(undefined);
+      const document = current.documents[documentId];
+      if (!document) return Promise.resolve(undefined);
+
+      const controller = new AbortController();
+      const requestId = ++nextContentRequestId;
+      updateState((next) => ({
+        ...next,
+        contents: {
+          ...next.contents,
+          [documentId]: { status: 'loading' },
+        },
+        error: undefined,
+      }));
+
+      const promise = repository
+        .loadContent(context, document, controller.signal)
+        .then((content) => {
+          const request = contentRequests.get(documentId);
+          if (request?.requestId === requestId && getState()) {
+            updateState((next) => ({
+              ...next,
+              contents: {
+                ...next.contents,
+                [documentId]: { status: 'loaded', content },
+              },
+            }));
+          }
+          return content;
+        })
+        .catch((error: unknown) => {
+          const request = contentRequests.get(documentId);
+          if (request?.requestId === requestId && getState()) {
+            updateState((next) => ({
+              ...next,
+              contents: {
+                ...next.contents,
+                [documentId]: {
+                  status: 'error',
+                  error: errorMessage(error),
+                },
+              },
+            }));
+          }
+          throw error;
+        })
+        .finally(() => {
+          const request = contentRequests.get(documentId);
+          if (request?.requestId === requestId)
+            contentRequests.delete(documentId);
+        });
+
+      contentRequests.set(documentId, { requestId, controller, promise });
+      return promise;
+    },
+
+    refresh: async () => {
+      const current = getState();
+      if (!current || current.disposed || !repository) return;
+      refreshController?.abort();
+      const controller = new AbortController();
+      refreshController = controller;
+      const requestId = ++refreshRequestId;
+      updateState((next) => ({
+        ...next,
+        syncStatus: 'loading',
+        error: undefined,
+      }));
+      try {
+        const snapshot = await repository.load(context, controller.signal);
+        if (!getState() || requestId !== refreshRequestId) return;
+        setSnapshot(snapshot);
+      } catch (error) {
+        if (getState() && requestId === refreshRequestId) {
+          updateState((next) => ({
+            ...next,
+            syncStatus: 'error',
+            error: errorMessage(error),
+          }));
+        }
+        throw error;
+      } finally {
+        if (refreshController === controller) refreshController = undefined;
+      }
+    },
+
+    start: () => {
+      if (resourcesDisposed || unsubscribe || !repository?.subscribe) return;
+      unsubscribe = repository.subscribe(context, (snapshot) => {
+        if (getState()) setSnapshot(snapshot);
+      });
+    },
+
+    dispose: () => {
+      if (!getState()) return;
+      formStore
+        .getState()
+        .clearExtension(DOCUMENT_LIST_EXTENSION_NAMESPACE, context.fieldId);
+    },
+  };
+
+  repository?.seed?.(context, { documents: initialDocuments });
+  const registered = formStore
+    .getState()
+    .registerExtension(
+      DOCUMENT_LIST_EXTENSION_NAMESPACE,
+      context.fieldId,
+      state,
+      { onDispose: disposeResources }
+    );
+  return registered ? state : getState();
+}

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -74,10 +74,86 @@
   color: var(--mieweb-muted-foreground, #64748b);
 }
 
-.document-list-workflow__body {
+.document-list-field {
+  position: relative;
+  min-width: 0;
+}
+
+/* The panel floats over the grid, so the field reserves room for it. */
+.document-list-field--workflow-open {
+  min-height: 34rem;
+}
+
+.document-list-workflow-panel {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--mieweb-border, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--mieweb-card, #ffffff);
+  color: var(--mieweb-card-foreground, #1f2937);
+  box-shadow: 0 1.25rem 2.5rem rgb(15 23 42 / 22%);
+}
+
+.document-list-workflow-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--mieweb-border, #e5e7eb);
+}
+
+.document-list-workflow-panel__title {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.document-list-workflow-panel__form {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.document-list-workflow-panel__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.document-list-workflow-panel__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-top: 1px solid var(--mieweb-border, #e5e7eb);
+}
+
+.document-list-workflow__field--grow {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 0;
+}
+
+.document-list-workflow__field--grow .document-list-compose-editor {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  border: 1px solid var(--mieweb-border, #e5e7eb);
+  border-radius: 0.375rem;
 }
 
 .document-list-workflow__error {
@@ -87,6 +163,15 @@
 .document-list-workflow__hint {
   color: var(--mieweb-muted-foreground, #64748b);
   font-size: 0.875rem;
+}
+
+.document-list-workflow__select {
+  background: var(--mieweb-background, #ffffff);
+  border: 1px solid var(--mieweb-border, #e5e7eb);
+  border-radius: 0.375rem;
+  color: var(--mieweb-foreground, #1f2937);
+  padding: 0.375rem 0.5rem;
+  width: 100%;
 }
 
 .document-list-detail {

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -128,57 +128,40 @@
 
 .document-list-detail__preview {
   min-width: 0;
-  color: var(--kb-color-text, var(--mieweb-foreground, #1f2937));
+  color: var(--mieweb-foreground, #1f2937);
 }
 
-.document-list-detail__preview .kb-custom-menu,
-.document-list-detail__preview .kb-custom-menu__overflow-menu {
-  display: none !important;
-}
-
-.document-list-detail__preview .kb-custom-menu__editor {
-  display: block;
-  max-height: none;
-  overflow: visible;
-}
-
-.document-list-detail__preview .ProseMirror {
-  min-height: 0;
-  outline: none;
-  padding: 0 0 0 0.75rem;
-}
-
-.document-list-detail__preview .ProseMirror h1 {
+.document-list-detail__preview h1 {
   font-size: 2em;
   font-weight: bold;
   margin: 0.67em 0;
 }
 
-.document-list-detail__preview .ProseMirror h2 {
+.document-list-detail__preview h2 {
   font-size: 1.5em;
   font-weight: bold;
   margin: 0.75em 0;
 }
 
-.document-list-detail__preview .ProseMirror h3 {
+.document-list-detail__preview h3 {
   font-size: 1.17em;
   font-weight: bold;
   margin: 0.83em 0;
 }
 
-.document-list-detail__preview .ProseMirror ul {
+.document-list-detail__preview ul {
   list-style: disc;
   padding-left: 1.5em;
 }
 
-.document-list-detail__preview .ProseMirror ol {
+.document-list-detail__preview ol {
   list-style: decimal;
   padding-left: 1.5em;
 }
 
-.document-list-detail__preview .ProseMirror blockquote {
-  border-left: 3px solid var(--kb-color-border);
-  color: var(--kb-color-text-muted);
+.document-list-detail__preview blockquote {
+  border-left: 3px solid var(--mieweb-border, #e5e7eb);
+  color: var(--mieweb-muted-foreground, #64748b);
   margin-left: 0;
   padding-left: 1em;
 }

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -115,6 +115,63 @@
   overflow-wrap: anywhere;
 }
 
+.document-list-detail__preview {
+  min-width: 0;
+  color: var(--kb-color-text, var(--mieweb-foreground, #1f2937));
+}
+
+.document-list-detail__preview .kb-custom-menu,
+.document-list-detail__preview .kb-custom-menu__overflow-menu {
+  display: none !important;
+}
+
+.document-list-detail__preview .kb-custom-menu__editor {
+  display: block;
+  max-height: none;
+  overflow: visible;
+}
+
+.document-list-detail__preview .ProseMirror {
+  min-height: 0;
+  outline: none;
+  padding: 0 0 0 0.75rem;
+}
+
+.document-list-detail__preview .ProseMirror h1 {
+  font-size: 2em;
+  font-weight: bold;
+  margin: 0.67em 0;
+}
+
+.document-list-detail__preview .ProseMirror h2 {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin: 0.75em 0;
+}
+
+.document-list-detail__preview .ProseMirror h3 {
+  font-size: 1.17em;
+  font-weight: bold;
+  margin: 0.83em 0;
+}
+
+.document-list-detail__preview .ProseMirror ul {
+  list-style: disc;
+  padding-left: 1.5em;
+}
+
+.document-list-detail__preview .ProseMirror ol {
+  list-style: decimal;
+  padding-left: 1.5em;
+}
+
+.document-list-detail__preview .ProseMirror blockquote {
+  border-left: 3px solid var(--kb-color-border);
+  color: var(--kb-color-text-muted);
+  margin-left: 0;
+  padding-left: 1em;
+}
+
 .document-list-detail__image {
   max-width: 100%;
   max-height: 20rem;

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -6,17 +6,40 @@
 .document-list-grid {
   position: relative;
   width: 100%;
+  min-width: 0;
 }
 
 .document-list-grid__title-actions {
-  position: absolute;
-  top: 0;
-  right: 2rem;
-  z-index: 5;
   display: flex;
-  height: 1.8rem;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.25rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.document-list-grid .wcdv-title {
+  min-width: 0;
+}
+
+.document-list-grid .wcdv-title-actions {
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+}
+
+.document-list-grid__action-label {
+  display: inline;
+}
+
+@media (max-width: 40rem) {
+  .document-list-grid__title-actions {
+    gap: 0;
+  }
+
+  .document-list-grid__action-label {
+    display: none;
+  }
 }
 
 .document-list-grid__status,

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -19,6 +19,17 @@
   gap: 0.25rem;
 }
 
+/* The cluster overlays the DataVis title bar rather than sitting inside it, so
+   @mieweb/ui's `body.condensed` density never reaches it. */
+.document-list-grid__title-actions button {
+  font-size: 0.6875rem;
+}
+
+.document-list-grid__title-actions button svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
 .document-list-grid__status,
 .document-list-grid__error {
   margin-bottom: 0.5rem;

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -39,3 +39,62 @@
   place-items: center;
   color: var(--mieweb-muted-foreground, #64748b);
 }
+
+.document-list-workflow__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.document-list-workflow__error {
+  color: var(--mieweb-destructive, #b42318);
+}
+
+.document-list-workflow__hint {
+  color: var(--mieweb-muted-foreground, #64748b);
+  font-size: 0.875rem;
+}
+
+.document-list-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.document-list-detail__title {
+  font-size: 0.875rem;
+}
+
+.document-list-detail__metadata,
+.document-list-detail__content-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.5rem 1.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.document-list-detail__metadata dt,
+.document-list-detail__content-meta dt {
+  color: var(--mieweb-muted-foreground, #64748b);
+  font-weight: 600;
+}
+
+.document-list-detail__metadata dd,
+.document-list-detail__content-meta dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.document-list-detail__text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.document-list-detail__image {
+  max-width: 100%;
+  max-height: 20rem;
+  object-fit: contain;
+  object-position: left top;
+}

--- a/packages/document-list-field/src/index.css
+++ b/packages/document-list-field/src/index.css
@@ -1,0 +1,41 @@
+@import 'tailwindcss/theme';
+@import 'tailwindcss/utilities';
+
+@source './**/*.{ts,tsx}';
+
+.document-list-grid {
+  position: relative;
+  width: 100%;
+}
+
+.document-list-grid__title-actions {
+  position: absolute;
+  top: 0;
+  right: 2rem;
+  z-index: 5;
+  display: flex;
+  height: 1.8rem;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.document-list-grid__status,
+.document-list-grid__error {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.document-list-grid__status {
+  color: var(--mieweb-muted-foreground, #64748b);
+}
+
+.document-list-grid__error {
+  color: var(--mieweb-destructive, #b42318);
+}
+
+.document-list-grid--loading {
+  min-height: 4rem;
+  display: grid;
+  place-items: center;
+  color: var(--mieweb-muted-foreground, #64748b);
+}

--- a/packages/document-list-field/src/index.ts
+++ b/packages/document-list-field/src/index.ts
@@ -22,9 +22,9 @@ export function registerDocumentListFieldType(): void {
 export { DocumentListField } from './DocumentListField.js';
 export {
   configureDocumentListComposeEditor,
-  DocumentListComposeModal,
+  DocumentListComposePanel,
   DocumentListDetailRow,
-  DocumentListUploadModal,
+  DocumentListUploadPanel,
 } from './DocumentListWorkflows.js';
 export {
   DocumentListFieldProvider,
@@ -43,6 +43,8 @@ export {
   documentListValueFromRows,
   DOCUMENT_LIST_ACTIONS_COLUMN,
   DOCUMENT_LIST_COLUMNS,
+  DOCUMENT_LIST_DEFAULT_NOUN,
+  DOCUMENT_LIST_MARKDOWN_TYPE,
   DOCUMENT_LIST_TYPE_INFO,
   normalizeDocumentRow,
   normalizeDocumentRows,
@@ -62,9 +64,11 @@ export type {
 export type {
   DocumentListAction,
   DocumentListDefinition,
+  DocumentListDocTypeOption,
   DocumentListDocument,
   DocumentListInput,
   DocumentListValue,
+  DocumentListWorkflow,
 } from './types.js';
 export type {
   CreateDocumentListRuntimeExtensionOptions,

--- a/packages/document-list-field/src/index.ts
+++ b/packages/document-list-field/src/index.ts
@@ -21,6 +21,7 @@ export function registerDocumentListFieldType(): void {
 
 export { DocumentListField } from './DocumentListField.js';
 export {
+  configureDocumentListComposeEditor,
   DocumentListComposeModal,
   DocumentListDetailRow,
   DocumentListUploadModal,

--- a/packages/document-list-field/src/index.ts
+++ b/packages/document-list-field/src/index.ts
@@ -21,6 +21,11 @@ export function registerDocumentListFieldType(): void {
 
 export { DocumentListField } from './DocumentListField.js';
 export {
+  DocumentListComposeModal,
+  DocumentListDetailRow,
+  DocumentListUploadModal,
+} from './DocumentListWorkflows.js';
+export {
   DocumentListFieldProvider,
   DocumentListGrid,
   createDocumentListFieldProvider,
@@ -63,6 +68,7 @@ export type {
 export type {
   CreateDocumentListRuntimeExtensionOptions,
   DocumentListContent,
+  DocumentListContentInput,
   DocumentListContentState,
   DocumentListContentStatus,
   DocumentListPendingOperation,

--- a/packages/document-list-field/src/index.ts
+++ b/packages/document-list-field/src/index.ts
@@ -25,7 +25,13 @@ export {
   DocumentListGrid,
   createDocumentListFieldProvider,
   useDocumentListFieldHost,
+  useDocumentListFieldRuntime,
 } from './DocumentListGrid.js';
+export {
+  createDocumentListRuntimeExtension,
+  getDocumentListRuntimeState,
+  DOCUMENT_LIST_EXTENSION_NAMESPACE,
+} from './document-list-runtime.js';
 export {
   createLocalSourcePayload,
   documentListValueFromRows,
@@ -39,7 +45,10 @@ export {
 export type {
   DocumentListActionsRenderer,
   DocumentListColumn,
+  DocumentListFieldAction,
   DocumentListFieldHost,
+  DocumentListFieldProviderProps,
+  DocumentListFieldRuntimeOptions,
   DocumentListGridProps,
   DocumentListRowCapabilities,
   DocumentListToolbarProps,
@@ -51,4 +60,16 @@ export type {
   DocumentListInput,
   DocumentListValue,
 } from './types.js';
+export type {
+  CreateDocumentListRuntimeExtensionOptions,
+  DocumentListContent,
+  DocumentListContentState,
+  DocumentListContentStatus,
+  DocumentListPendingOperation,
+  DocumentListRepository,
+  DocumentListRepositoryContext,
+  DocumentListSnapshot,
+  DocumentListRuntimeState,
+  DocumentListSyncStatus,
+} from './document-list-runtime.js';
 export { DOCUMENT_LIST_ACTIONS } from './types.js';

--- a/packages/document-list-field/src/index.ts
+++ b/packages/document-list-field/src/index.ts
@@ -1,0 +1,54 @@
+import './index.css';
+import { registerCustomFieldTypes } from '@esheet/fields';
+import { DocumentListField } from './DocumentListField.js';
+
+export function registerDocumentListFieldType(): void {
+  registerCustomFieldTypes({
+    documentList: {
+      label: 'Document List',
+      category: 'rich',
+      answerType: 'text',
+      hasOptions: false,
+      hasMatrix: false,
+      defaultProps: {
+        question: 'Documents',
+        width: 'full',
+      },
+      component: DocumentListField,
+    },
+  });
+}
+
+export { DocumentListField } from './DocumentListField.js';
+export {
+  DocumentListFieldProvider,
+  DocumentListGrid,
+  createDocumentListFieldProvider,
+  useDocumentListFieldHost,
+} from './DocumentListGrid.js';
+export {
+  createLocalSourcePayload,
+  documentListValueFromRows,
+  DOCUMENT_LIST_ACTIONS_COLUMN,
+  DOCUMENT_LIST_COLUMNS,
+  DOCUMENT_LIST_TYPE_INFO,
+  normalizeDocumentRow,
+  normalizeDocumentRows,
+  parseDocumentListAnswer,
+} from './data.js';
+export type {
+  DocumentListActionsRenderer,
+  DocumentListColumn,
+  DocumentListFieldHost,
+  DocumentListGridProps,
+  DocumentListRowCapabilities,
+  DocumentListToolbarProps,
+} from './DocumentListGrid.js';
+export type {
+  DocumentListAction,
+  DocumentListDefinition,
+  DocumentListDocument,
+  DocumentListInput,
+  DocumentListValue,
+} from './types.js';
+export { DOCUMENT_LIST_ACTIONS } from './types.js';

--- a/packages/document-list-field/src/types.ts
+++ b/packages/document-list-field/src/types.ts
@@ -1,0 +1,43 @@
+export interface DocumentListDocument {
+  readonly id: string;
+  readonly date: string;
+  readonly title: string;
+  readonly subject: string;
+  readonly docType: string;
+  readonly docId: string;
+  readonly source: string;
+  readonly file: string;
+}
+
+export interface DocumentListValue {
+  readonly documents: readonly DocumentListDocument[];
+}
+
+export const DOCUMENT_LIST_ACTIONS = [
+  'view',
+  'compose',
+  'edit',
+  'requestSignature',
+  'delete',
+  'downloadPdf',
+] as const;
+
+export type DocumentListAction = (typeof DOCUMENT_LIST_ACTIONS)[number];
+
+export interface DocumentListInput {
+  readonly id?: unknown;
+  readonly date?: unknown;
+  readonly title?: unknown;
+  readonly subject?: unknown;
+  readonly docType?: unknown;
+  readonly docId?: unknown;
+  readonly source?: unknown;
+  readonly from?: unknown;
+  readonly author?: unknown;
+  readonly file?: unknown;
+}
+
+export interface DocumentListDefinition {
+  readonly question?: unknown;
+  readonly documents?: unknown;
+}

--- a/packages/document-list-field/src/types.ts
+++ b/packages/document-list-field/src/types.ts
@@ -14,6 +14,13 @@ export interface DocumentListDocument {
    */
   readonly sha256?: string;
   readonly size?: number;
+  /**
+   * Markdown carried on the row itself, for document types the field marks
+   * `inline`. The repository is never asked for these bytes: the answer *is*
+   * the document, so a host binding the answer to a CRDT gets collaborative
+   * prose for free. `file` still names it, for hosts that later export.
+   */
+  readonly body?: string;
 }
 
 export interface DocumentListValue {
@@ -44,9 +51,50 @@ export interface DocumentListInput {
   readonly file?: unknown;
   readonly sha256?: unknown;
   readonly size?: unknown;
+  readonly body?: unknown;
+}
+
+/** The workflows a field's toolbar offers. */
+export const DOCUMENT_LIST_WORKFLOWS = ['compose', 'upload'] as const;
+
+export type DocumentListWorkflow = (typeof DOCUMENT_LIST_WORKFLOWS)[number];
+
+/** A document type the compose form offers, instead of free text. */
+export interface DocumentListDocTypeOption {
+  readonly id: string;
+  readonly label?: string;
+  /**
+   * Keep this type's content on the row (`body`) rather than in the repository.
+   * Overrides the field's `inline`, so a mixed list can opt one type either way.
+   */
+  readonly inline?: boolean;
 }
 
 export interface DocumentListDefinition {
   readonly question?: unknown;
   readonly documents?: unknown;
+  /**
+   * Which toolbar workflows this field offers — both when unset. A list that
+   * is only ever composed (case notes) says `['compose']` and grows no upload
+   * button.
+   */
+  readonly workflows?: readonly DocumentListWorkflow[];
+  /**
+   * What one row is called, lowercase, so the same field reads as "Compose
+   * note", "Compose letter", or the default "Compose document".
+   */
+  readonly noun?: string;
+  /** Document types the compose form offers; free text when unset. */
+  readonly docTypes?: readonly DocumentListDocTypeOption[];
+  /**
+   * Compose inline by default, so every type keeps its prose on the row. Only
+   * composed prose is affected — uploaded bytes always go to the repository.
+   */
+  readonly inline?: boolean;
+  /** `accept` for the upload file input. */
+  readonly accept?: string;
+  /** Largest upload accepted, in bytes. */
+  readonly maxFileSize?: number;
+  /** Which columns to show, in order, by field name; all when unset. */
+  readonly columns?: readonly string[];
 }

--- a/packages/document-list-field/src/types.ts
+++ b/packages/document-list-field/src/types.ts
@@ -7,6 +7,13 @@ export interface DocumentListDocument {
   readonly docId: string;
   readonly source: string;
   readonly file: string;
+  /**
+   * Content hash and byte length, when the host's repository records them.
+   * eSheet never computes these — it carries them so a host that stores the
+   * bytes elsewhere can address them from the row alone.
+   */
+  readonly sha256?: string;
+  readonly size?: number;
 }
 
 export interface DocumentListValue {
@@ -35,6 +42,8 @@ export interface DocumentListInput {
   readonly from?: unknown;
   readonly author?: unknown;
   readonly file?: unknown;
+  readonly sha256?: unknown;
+  readonly size?: unknown;
 }
 
 export interface DocumentListDefinition {

--- a/packages/document-list-field/src/vite-env.d.ts
+++ b/packages/document-list-field/src/vite-env.d.ts
@@ -1,0 +1,25 @@
+/// <reference types="vite/client" />
+
+declare module 'datavis-ace' {
+  export class Source {
+    constructor(
+      spec: Record<string, unknown>,
+      params?: unknown,
+      userTypeInfo?: unknown,
+      opts?: unknown
+    );
+    source?: unknown;
+    [key: string]: unknown;
+  }
+
+  export class ComputedView {
+    constructor(source: Source);
+    clearCache(): void;
+    getData(
+      callback?: (ok: boolean, data: unknown) => void,
+      reason?: string
+    ): void;
+    source: Source;
+    [key: string]: unknown;
+  }
+}

--- a/packages/document-list-field/tsconfig.json
+++ b/packages/document-list-field/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/document-list-field/tsconfig.lib.json
+++ b/packages/document-list-field/tsconfig.lib.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node", "vite/client"],
+    "lib": ["dom", "es2022"],
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo"
+  },
+  "exclude": [
+    "out-tsc",
+    "dist",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "vite.config.mts",
+    "eslint.config.mjs"
+  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    {
+      "path": "../fields/tsconfig.lib.json"
+    },
+    {
+      "path": "../core/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/document-list-field/tsconfig.spec.json
+++ b/packages/document-list-field/tsconfig.spec.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ],
+    "lib": ["dom", "es2022"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": [
+    "vite.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/document-list-field/vite.config.mts
+++ b/packages/document-list-field/vite.config.mts
@@ -1,0 +1,88 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+
+function inlineCssDocumentListField(): import('vite').Plugin {
+  return {
+    name: 'inline-css-document-list-field',
+    apply: 'build',
+    closeBundle() {
+      const cssPath = path.resolve(import.meta.dirname, 'dist/index.css');
+      const jsPath = path.resolve(import.meta.dirname, 'dist/index.js');
+      if (!existsSync(cssPath) || !existsSync(jsPath)) return;
+
+      const css = readFileSync(cssPath, 'utf-8');
+      const js = readFileSync(jsPath, 'utf-8');
+      const injectCss =
+        `(function(){` +
+        `if(typeof document==='undefined')return;` +
+        `if(document.querySelector('#esheet-document-list-field-styles'))return;` +
+        `var s=document.createElement('style');` +
+        `s.id='esheet-document-list-field-styles';` +
+        `s.textContent=${JSON.stringify(css)};` +
+        `document.head.appendChild(s);` +
+        `})();\n`;
+
+      writeFileSync(jsPath, injectCss + js);
+      unlinkSync(cssPath);
+    },
+  };
+}
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/packages/document-list-field',
+  plugins: [
+    react(),
+    tailwindcss(),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
+    }),
+    inlineCssDocumentListField(),
+  ],
+  build: {
+    outDir: './dist',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    cssCodeSplit: false,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+    lib: {
+      entry: 'src/index.ts',
+      name: '@esheet/document-list-field',
+      fileName: 'index',
+      formats: ['es' as const],
+    },
+    rolldownOptions: {
+      external: [
+        '@esheet/core',
+        '@esheet/fields',
+        '@mieweb/datavis',
+        '@mieweb/ui',
+        '@mieweb/ui/datavis',
+        'ag-grid-community',
+        'ag-grid-react',
+        'datavis-ace',
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'tslib',
+      ],
+    },
+  },
+  test: {
+    name: '@esheet/document-list-field',
+    watch: false,
+    passWithNoTests: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+  },
+}));

--- a/packages/field-kerebron/package.json
+++ b/packages/field-kerebron/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "@esheet/core": "workspace:*",
+    "@esheet/fields": "workspace:*",
     "@kerebron/editor": "^0.8.9",
     "@kerebron/editor-kits": "^0.8.9",
     "@kerebron/editor-react": "^0.8.9",

--- a/packages/field-kerebron/package.json
+++ b/packages/field-kerebron/package.json
@@ -32,11 +32,8 @@
   ],
   "dependencies": {
     "@esheet/core": "workspace:*",
-    "@kerebron/editor": "^0.8.9",
-    "@kerebron/editor-kits": "^0.8.9",
-    "@kerebron/editor-react": "^0.8.9",
-    "@kerebron/extension-basic-editor": "^0.8.9",
-    "@kerebron/extension-menu": "^0.8.9",
+    "@kerebron/editor": "^0.8.10",
+    "@kerebron/editor-kits": "^0.8.10",
     "react": "^19.2.4",
     "tslib": "^2.3.0"
   },

--- a/packages/field-kerebron/src/KerebronNotesComposer.tsx
+++ b/packages/field-kerebron/src/KerebronNotesComposer.tsx
@@ -44,6 +44,11 @@ if (
   document.head.appendChild(style);
 }
 
+// Initial document loads are serialized across editor instances: the
+// markdown converter's tree-sitter WASM init is not concurrency-safe
+// (same pattern as echart-sim's DocumentComposeEditor).
+let initialLoadQueue: Promise<unknown> = Promise.resolve();
+
 export function KerebronNotesComposer({
   value,
   onChange,
@@ -95,15 +100,20 @@ export function KerebronNotesComposer({
     editor.addEventListener('changed', onChanged);
 
     void (async () => {
-      if (valueRef.current) {
-        try {
-          await editor.loadDocument(
-            'text/x-markdown',
-            new TextEncoder().encode(valueRef.current)
-          );
-        } catch (err) {
-          console.error('[KerebronNotesComposer] loadDocument failed:', err);
-        }
+      // Always load, even when empty — the editor needs an initial document
+      // before it will accept edits. Queued so parallel mounts (React
+      // StrictMode, several notes fields) don't race the WASM init.
+      const load = initialLoadQueue
+        .catch(() => undefined)
+        .then(async () => {
+          if (disposed) return;
+          await editor.loadDocumentText('text/x-markdown', valueRef.current);
+        });
+      initialLoadQueue = load;
+      try {
+        await load;
+      } catch (err) {
+        console.error('[KerebronNotesComposer] loadDocument failed:', err);
       }
       loading = false;
     })();

--- a/packages/field-kerebron/src/KerebronNotesComposer.tsx
+++ b/packages/field-kerebron/src/KerebronNotesComposer.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import type { NotesComposerProps } from '@esheet/fields';
+import { CoreEditor } from '@kerebron/editor';
+import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
+import { ExtensionHistory } from '@kerebron/extension-basic-editor/ExtensionHistory';
+import { getAssetLoad } from './asset-load.js';
+import '@kerebron/editor/assets/index-light.css';
+import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
+
+// ---------------------------------------------------------------------------
+// KerebronNotesComposer — rich markdown composer for NotesField.
+//
+// Register once at app startup:
+// ```ts
+// import { registerNotesComposer } from '@esheet/fields';
+// import { KerebronNotesComposer } from '@esheet/field-kerebron';
+// registerNotesComposer(KerebronNotesComposer);
+// ```
+// Markdown stays the storage format: the editor loads/saves text/x-markdown,
+// so notes composed here render identically in the read-only card list.
+// ---------------------------------------------------------------------------
+
+const COMPOSER_STYLES = `
+  .notes-kerebron-composer .ProseMirror { outline: none; min-height: 96px; padding: 8px 12px; }
+  .notes-kerebron-composer .kb-custom-menu__editor { max-height: 320px; overflow-y: auto; }
+  /* Same upstream .kb-icon touch-target fix as RichTextEditorField. */
+  .notes-kerebron-composer .kb-custom-menu__overflow-menu .kb-icon {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    line-height: 1;
+  }
+`;
+
+if (
+  typeof document !== 'undefined' &&
+  !document.getElementById('notes-kerebron-composer-styles')
+) {
+  const style = document.createElement('style');
+  style.id = 'notes-kerebron-composer-styles';
+  style.textContent = COMPOSER_STYLES;
+  document.head.appendChild(style);
+}
+
+export function KerebronNotesComposer({
+  value,
+  onChange,
+  ariaLabel,
+}: NotesComposerProps) {
+  const hostRef = React.useRef<HTMLDivElement>(null);
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const onChangeRef = React.useRef(onChange);
+  onChangeRef.current = onChange;
+
+  React.useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    // Fresh mount node: Kerebron's destroy() replaces its own mount element.
+    const mount = document.createElement('div');
+    host.replaceChildren(mount);
+
+    const editor = CoreEditor.create({
+      element: mount,
+      uri: 'file:///note.md',
+      assetLoad: getAssetLoad(),
+      editorKits: [
+        new AdvancedEditorKit(),
+        { getExtensions: () => [new ExtensionHistory()] },
+      ],
+    });
+
+    let disposed = false;
+    let loading = true;
+    let saveTimer: number | null = null;
+
+    const flush = async () => {
+      if (disposed) return;
+      try {
+        const bytes = await editor.saveDocument('text/x-markdown');
+        onChangeRef.current(new TextDecoder().decode(bytes));
+      } catch {
+        // editor gone mid-save
+      }
+    };
+
+    const onChanged = () => {
+      if (disposed || loading) return;
+      if (saveTimer != null) window.clearTimeout(saveTimer);
+      saveTimer = window.setTimeout(() => void flush(), 200);
+    };
+    editor.addEventListener('changed', onChanged);
+
+    void (async () => {
+      if (valueRef.current) {
+        try {
+          await editor.loadDocument(
+            'text/x-markdown',
+            new TextEncoder().encode(valueRef.current)
+          );
+        } catch (err) {
+          console.error('[KerebronNotesComposer] loadDocument failed:', err);
+        }
+      }
+      loading = false;
+    })();
+
+    return () => {
+      // Best-effort final save for a keystroke inside the debounce window.
+      if (saveTimer != null) {
+        window.clearTimeout(saveTimer);
+        void flush();
+      }
+      disposed = true;
+      editor.removeEventListener('changed', onChanged);
+      editor.destroy();
+      host.replaceChildren();
+    };
+  }, []);
+
+  return (
+    <div
+      className="notes-kerebron-composer"
+      aria-label={ariaLabel}
+      // isolation traps the Kerebron toolbar z-index inside the composer.
+      style={{ isolation: 'isolate' } as React.CSSProperties}
+    >
+      <div ref={hostRef} className="kb-component" />
+    </div>
+  );
+}

--- a/packages/field-kerebron/src/RichTextEditorField.tsx
+++ b/packages/field-kerebron/src/RichTextEditorField.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { FieldComponentProps } from '@esheet/core';
 import { CoreEditor } from '@kerebron/editor';
 import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
-import { ExtensionHistory } from '@kerebron/extension-basic-editor/ExtensionHistory';
 import { getAssetLoad } from './asset-load.js';
 // Core editor styles (--kb-* variables + base/ProseMirror styles).
 // index-light.css pins the light theme so the editor matches the host app
@@ -114,10 +113,7 @@ export function RichTextEditorField({
       element: mount,
       uri: 'file:///untitled.md',
       assetLoad: getAssetLoad(),
-      editorKits: [
-        new AdvancedEditorKit(),
-        { getExtensions: () => [new ExtensionHistory()] },
-      ],
+      editorKits: [new AdvancedEditorKit()],
     });
     editorRef.current = editor;
 

--- a/packages/field-kerebron/src/RichTextEditorField.tsx
+++ b/packages/field-kerebron/src/RichTextEditorField.tsx
@@ -4,23 +4,107 @@ import { CoreEditor } from '@kerebron/editor';
 import { AdvancedEditorKit } from '@kerebron/editor-kits/AdvancedEditorKit';
 import { getAssetLoad } from './asset-load.js';
 // Core editor styles (--kb-* variables + base/ProseMirror styles).
-// index-light.css pins the light theme so the editor matches the host app
-// regardless of OS dark-mode preference.
-import '@kerebron/editor/assets/index-light.css';
+import '@kerebron/editor/assets/index.css';
 import '@kerebron/editor-kits/assets/AdvancedEditorKit.css';
 
 // Base content styles for the ProseMirror editable area (headings, lists, etc.)
 const CONTENT_STYLES = `
+  [data-theme='light'],
+  [data-theme='light'] .kb-component {
+    --kb-color-primary: var(--mieweb-primary-500, #27aae1);
+    --kb-color-text: var(--mieweb-foreground, #1f2937);
+    --kb-color-text-muted: var(--mieweb-muted-foreground, #6b7280);
+    --kb-color-icon: var(--mieweb-muted-foreground, #5f6368);
+    --kb-color-surface: var(--mieweb-background, #ffffff);
+    --kb-color-surface-elevated: var(--mieweb-muted, #f9fafb);
+    --kb-color-surface-hover: rgba(60, 64, 67, 0.08);
+    --kb-color-border: var(--mieweb-border, #e5e7eb);
+    --kb-color-border-strong: var(--mieweb-border, #d1d5db);
+    --kb-color-hover: rgba(60, 64, 67, 0.08);
+    --kb-color-active: rgba(60, 64, 67, 0.1);
+    --kb-menu-dropdown-bg: var(--mieweb-card, #ffffff);
+    --kb-menu-dropdown-border: var(--mieweb-border, #dadce0);
+    --kb-menu-dropdown-text: var(--mieweb-card-foreground, #3c4043);
+    --kb-menu-dropdown-hover: rgba(60, 64, 67, 0.08);
+  }
+
+  [data-theme='dark'],
+  [data-theme='dark'] .kb-component,
+  .dark,
+  .dark .kb-component {
+    --kb-color-primary: var(--mieweb-primary-500, #27aae1);
+    --kb-color-text: var(--mieweb-foreground, #fafafa);
+    --kb-color-text-muted: var(--mieweb-muted-foreground, #a1a1aa);
+    --kb-color-icon: var(--mieweb-muted-foreground, #a1a1aa);
+    --kb-color-surface: var(--mieweb-background, #171717);
+    --kb-color-surface-elevated: var(--mieweb-muted, #404040);
+    --kb-color-surface-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+    --kb-color-border: var(--mieweb-border, #404040);
+    --kb-color-border-strong: var(--mieweb-border, #404040);
+    --kb-color-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+    --kb-color-active: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 14%, transparent);
+    --kb-menu-dropdown-bg: var(--mieweb-card, #262626);
+    --kb-menu-dropdown-border: var(--mieweb-border, #404040);
+    --kb-menu-dropdown-text: var(--mieweb-card-foreground, #fafafa);
+    --kb-menu-dropdown-hover: color-mix(in srgb, var(--mieweb-foreground, #fafafa) 8%, transparent);
+  }
+
+  [data-theme='light'] .kb-custom-menu,
+  [data-theme='dark'] .kb-custom-menu,
+  .dark .kb-custom-menu {
+    background: var(--kb-color-surface-elevated);
+    border-bottom-color: var(--kb-color-border-strong);
+    color: var(--kb-color-text);
+  }
+
+  [data-theme='light'] .kb-custom-menu .kb-menu__button,
+  [data-theme='light'] .kb-custom-menu .kb-dropdown__label,
+  [data-theme='dark'] .kb-custom-menu .kb-menu__button,
+  [data-theme='dark'] .kb-custom-menu .kb-dropdown__label,
+  .dark .kb-custom-menu .kb-menu__button,
+  .dark .kb-custom-menu .kb-dropdown__label {
+    color: var(--kb-color-icon);
+  }
+
+  [data-theme='light'] .kb-dropdown__menu,
+  [data-theme='light'] .kb-submenu__content,
+  [data-theme='light'] .kb-custom-menu__overflow-menu,
+  [data-theme='dark'] .kb-dropdown__menu,
+  [data-theme='dark'] .kb-submenu__content,
+  [data-theme='dark'] .kb-custom-menu__overflow-menu,
+  .dark .kb-dropdown__menu,
+  .dark .kb-submenu__content,
+  .dark .kb-custom-menu__overflow-menu {
+    background: var(--kb-menu-dropdown-bg) !important;
+    border-color: var(--kb-menu-dropdown-border) !important;
+    color: var(--kb-menu-dropdown-text) !important;
+  }
+
+  [data-theme='light'] .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  [data-theme='light'] .kb-custom-menu .kb-submenu__label:hover,
+  [data-theme='light'] .kb-custom-menu__overflow-item:hover,
+  [data-theme='dark'] .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  [data-theme='dark'] .kb-custom-menu .kb-submenu__label:hover,
+  [data-theme='dark'] .kb-custom-menu__overflow-item:hover,
+  .dark .kb-custom-menu .kb-dropdown__item .kb-menu__button:hover,
+  .dark .kb-custom-menu .kb-submenu__label:hover,
+  .dark .kb-custom-menu__overflow-item:hover {
+    background: var(--kb-menu-dropdown-hover) !important;
+    color: var(--kb-menu-dropdown-text) !important;
+  }
+
   .richtext-field .ProseMirror { outline: none; min-height: 80px; padding: 8px 12px; }
+  .richtext-field .kb-editor,
+  .richtext-field .ProseMirror { color: var(--kb-color-text); }
   .richtext-field .ProseMirror h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
   .richtext-field .ProseMirror h2 { font-size: 1.5em; font-weight: bold; margin: 0.75em 0; }
   .richtext-field .ProseMirror h3 { font-size: 1.17em; font-weight: bold; margin: 0.83em 0; }
   .richtext-field .ProseMirror ul { list-style: disc; padding-left: 1.5em; }
   .richtext-field .ProseMirror ol { list-style: decimal; padding-left: 1.5em; }
-  .richtext-field .ProseMirror blockquote { border-left: 3px solid #ccc; margin-left: 0; padding-left: 1em; color: #666; }
+  .richtext-field .ProseMirror blockquote { border-left: 3px solid var(--kb-color-border); margin-left: 0; padding-left: 1em; color: var(--kb-color-text-muted); }
   .richtext-field .ProseMirror strong { font-weight: bold; }
   .richtext-field .ProseMirror em { font-style: italic; }
-  .richtext-field .ProseMirror code { font-family: monospace; background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
+  .richtext-field .ProseMirror code { font-family: monospace; background: var(--kb-color-surface-elevated); padding: 0.1em 0.3em; border-radius: 3px; }
 
   /* Upstream fix: base .kb-icon keeps 48px touch-target min sizing, which
      overflows the 32px overflow-menu buttons and misaligns icons from their

--- a/packages/field-kerebron/src/index.ts
+++ b/packages/field-kerebron/src/index.ts
@@ -30,3 +30,4 @@ registerFieldType('richtext', {
 
 export { RichTextEditorField } from './RichTextEditorField.js';
 export type { RichTextFieldDefinition } from './RichTextEditorField.js';
+export { KerebronNotesComposer } from './KerebronNotesComposer.js';

--- a/packages/field-kerebron/vite.config.ts
+++ b/packages/field-kerebron/vite.config.ts
@@ -57,6 +57,10 @@ export default defineConfig(() => ({
         'react',
         'react/jsx-runtime',
         '@esheet/core',
+        // Shared registries (field components, notes composer) live in
+        // @esheet/fields — must stay external so host and field package share
+        // one module instance.
+        '@esheet/fields',
         'tslib',
         // Kerebron packages are bundled in (they are the point of this package)
       ],

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -26,6 +26,8 @@ export {
   DiagramField,
   DisplayField,
   FileField,
+  NotesField,
+  NoteCardList,
   HtmlField,
   ImageField,
   SignatureField,
@@ -35,5 +37,7 @@ export type {
   DrawingPadConfig,
   DrawingPadPayload,
   NormalizedPoint,
+  NoteCardItem,
+  NoteCardListProps,
   Stroke,
 } from './rich/index.js';

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -27,6 +27,7 @@ export {
   DisplayField,
   FileField,
   NotesField,
+  ActivityField,
   NoteCardList,
   HtmlField,
   ImageField,

--- a/packages/fields/src/fields/rich/ActivityField.spec.tsx
+++ b/packages/fields/src/fields/rich/ActivityField.spec.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import type { ActivityEntry, FieldComponentProps } from '@esheet/core';
+import { ActivityField } from './ActivityField.js';
+
+const entry = (
+  id: string,
+  at: string,
+  overrides: Partial<ActivityEntry> = {}
+): ActivityEntry => ({
+  id,
+  at,
+  fieldId: 'status',
+  question: 'Case status',
+  from: 'Open',
+  to: 'Closed',
+  ...overrides,
+});
+
+function createProps(
+  activity: ActivityEntry[],
+  overrides: Partial<FieldComponentProps> = {}
+): FieldComponentProps {
+  const state = {
+    instanceId: 'test',
+    responses: { _activity: { activity } },
+  };
+  return {
+    field: { definition: { fieldType: 'activity', id: 'log' } },
+    form: {
+      getState: () => state,
+      subscribe: () => () => undefined,
+    },
+    isPreview: true,
+    isEnabled: true,
+    ...overrides,
+  } as unknown as FieldComponentProps;
+}
+
+describe('ActivityField', () => {
+  it('renders change entries newest first', () => {
+    render(
+      <ActivityField
+        {...createProps([
+          entry('e1', '2026-01-01T10:00:00Z', {
+            author: 'Alice',
+            to: 'In progress',
+          }),
+          entry('e2', '2026-02-01T10:00:00Z', { author: 'Bob' }),
+        ])}
+      />
+    );
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain('Bob');
+    expect(items[0].textContent).toContain('Case status');
+    expect(items[0].textContent).toContain('Open');
+    expect(items[0].textContent).toContain('Closed');
+    expect(items[1].textContent).toContain('Alice');
+  });
+
+  it('is immutable — no buttons or inputs in the DOM', () => {
+    const { container } = render(
+      <ActivityField {...createProps([entry('e1', '2026-01-01T10:00:00Z')])} />
+    );
+    expect(container.querySelectorAll('button, input, textarea')).toHaveLength(
+      0
+    );
+  });
+
+  it('shows an empty state when there is no activity', () => {
+    render(<ActivityField {...createProps([])} />);
+    expect(screen.getByText('No activity yet')).toBeTruthy();
+  });
+});

--- a/packages/fields/src/fields/rich/ActivityField.tsx
+++ b/packages/fields/src/fields/rich/ActivityField.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  ACTIVITY_RESPONSE_KEY,
+  type ActivityFieldDefinition,
+  type FieldComponentProps,
+} from '@esheet/core';
+import { NoteCardList, type NoteCardItem } from './NoteCardList.js';
+
+// ---------------------------------------------------------------------------
+// ActivityField — read-only, append-only log of response changes over time.
+// Shares NoteCardList with NotesField; offers no mutation affordances.
+// ---------------------------------------------------------------------------
+
+const formatTimestamp = (iso: string): string => {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
+};
+
+export const ActivityField = React.memo(function ActivityField({
+  field,
+  form,
+  isPreview,
+}: FieldComponentProps) {
+  const def = field.definition as ActivityFieldDefinition;
+  const { responses } = React.useSyncExternalStore(
+    (cb) => form.subscribe(cb),
+    () => form.getState(),
+    () => form.getState()
+  );
+
+  const log = responses[ACTIVITY_RESPONSE_KEY]?.activity ?? [];
+  // Newest first, always.
+  const items: NoteCardItem[] = [...log]
+    .sort((a, b) => b.at.localeCompare(a.at) || b.id.localeCompare(a.id))
+    .map((entry) => ({
+      id: entry.id,
+      title: entry.author,
+      timestamp: formatTimestamp(entry.at),
+      body: (
+        <span>
+          <span className="activity-field-label ms:font-medium">
+            {entry.question ?? entry.fieldId}
+          </span>
+          {': '}
+          <span className="activity-field-from ms:text-mstextmuted">
+            {entry.from ?? '—'}
+          </span>
+          {' → '}
+          <span className="activity-field-to">{entry.to ?? '—'}</span>
+        </span>
+      ),
+    }));
+
+  return (
+    <div className="activity-field ms:flex ms:flex-col ms:gap-3 ms:pb-4">
+      <div className="ms:font-light ms:text-mstext ms:break-words">
+        {def.question || 'Activity'}
+      </div>
+      {!isPreview && (
+        <p className="ms:text-xs ms:text-mstextmuted">
+          Read-only log of response changes — filled in automatically while the
+          form is answered.
+        </p>
+      )}
+      <NoteCardList
+        items={items}
+        emptyLabel="No activity yet"
+        ariaLabel={def.question || 'Activity log'}
+      />
+    </div>
+  );
+});

--- a/packages/fields/src/fields/rich/AttachmentManager.spec.tsx
+++ b/packages/fields/src/fields/rich/AttachmentManager.spec.tsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type {
+  AttachmentAnswer,
+  AttachmentManager,
+  FieldComponentProps,
+} from '@esheet/core';
+import { FileField } from './FileField.js';
+import { NotesField } from './NotesField.js';
+import { createAttachmentManagerProvider } from '../../lib/AttachmentManagerProvider.js';
+
+// ---------------------------------------------------------------------------
+// The contract: with a manager the response carries a reference and never the
+// bytes; without one it carries the bytes exactly as it always has.
+// ---------------------------------------------------------------------------
+
+function fakeManager(): AttachmentManager & { removed: AttachmentAnswer[] } {
+  const removed: AttachmentAnswer[] = [];
+  return {
+    removed,
+    store: async ({ dataUrl: _dataUrl, ...rest }: AttachmentAnswer) => ({
+      ...rest,
+      path: `blobs/${rest.title}`,
+    }),
+    load: async (attachment) => ({ ...attachment, dataUrl: 'data:,loaded' }),
+    remove: async (attachment) => {
+      removed.push(attachment);
+    },
+  };
+}
+
+/** Renders through the provider stack exactly as the renderer would. */
+function withManager(manager: AttachmentManager, children: React.ReactNode) {
+  return createAttachmentManagerProvider(manager)(children);
+}
+
+function props(
+  definition: Record<string, unknown>,
+  overrides: Partial<FieldComponentProps> = {}
+): FieldComponentProps {
+  return {
+    field: { definition: { id: 'attachment', ...definition } },
+    form: { getState: () => ({ instanceId: 'test' }) },
+    isPreview: true,
+    isEnabled: true,
+    isReadOnly: false,
+    isRequired: false,
+    isSoftRequired: false,
+    onResponse: vi.fn(),
+    onUpdate: vi.fn(),
+    ...overrides,
+  } as unknown as FieldComponentProps;
+}
+
+const pick = (label: string, file: File) => {
+  const input = screen
+    .getByLabelText(label)
+    .parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+};
+
+const report = () => new File(['bytes'], 'report.txt', { type: 'text/plain' });
+
+describe('FileField attachment storage', () => {
+  it('stores through the manager and keeps only the reference', async () => {
+    const manager = fakeManager();
+    const fieldProps = props({ fieldType: 'file', question: 'Upload file' });
+
+    render(withManager(manager, <FileField {...fieldProps} />));
+    pick('Choose file or drag and drop', report());
+
+    await waitFor(() => expect(fieldProps.onResponse).toHaveBeenCalled());
+    expect(fieldProps.onResponse).toHaveBeenCalledWith({
+      fileData: {
+        contentType: 'text/plain',
+        title: 'report.txt',
+        size: 5,
+        path: 'blobs/report.txt',
+      },
+    });
+  });
+
+  it('keeps the bytes inline when no manager is supplied', async () => {
+    const fieldProps = props({ fieldType: 'file', question: 'Upload file' });
+
+    render(<FileField {...fieldProps} />);
+    pick('Choose file or drag and drop', report());
+
+    await waitFor(() => expect(fieldProps.onResponse).toHaveBeenCalled());
+    const { fileData } = (fieldProps.onResponse as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0];
+    expect(fileData.dataUrl).toMatch(/^data:text\/plain/);
+  });
+
+  it('tells the manager when a file is removed', async () => {
+    const manager = fakeManager();
+    const stored = { contentType: 'text/plain', title: 'report.txt', size: 5 };
+    const fieldProps = props(
+      { fieldType: 'file', question: 'Upload file' },
+      { response: { fileData: stored } }
+    );
+
+    render(withManager(manager, <FileField {...fieldProps} />));
+    fireEvent.click(screen.getByLabelText('Remove report.txt'));
+
+    await waitFor(() => expect(manager.removed).toEqual([stored]));
+    expect(fieldProps.onResponse).toHaveBeenCalledWith({ fileData: undefined });
+  });
+});
+
+describe('NotesField attachment storage', () => {
+  const openComposerAndSave = async (label: string) => {
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }));
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [report()] } });
+    await screen.findByText(label);
+    fireEvent.change(screen.getByLabelText('Note text'), {
+      target: { value: 'Saw the patient' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  };
+
+  it('stores composed attachments before the note reaches the response', async () => {
+    const manager = fakeManager();
+    const fieldProps = props({
+      fieldType: 'notes',
+      question: 'Case notes',
+      allowAttachments: true,
+    });
+
+    render(withManager(manager, <NotesField {...fieldProps} />));
+    await openComposerAndSave('report.txt');
+
+    await waitFor(() => expect(fieldProps.onResponse).toHaveBeenCalled());
+    const { notes } = (fieldProps.onResponse as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(notes[0].attachments).toEqual([
+      {
+        contentType: 'text/plain',
+        title: 'report.txt',
+        size: 5,
+        path: 'blobs/report.txt',
+      },
+    ]);
+  });
+
+  it('keeps composed attachments inline when no manager is supplied', async () => {
+    const fieldProps = props({
+      fieldType: 'notes',
+      question: 'Case notes',
+      allowAttachments: true,
+    });
+
+    render(<NotesField {...fieldProps} />);
+    await openComposerAndSave('report.txt');
+
+    await waitFor(() => expect(fieldProps.onResponse).toHaveBeenCalled());
+    const { notes } = (fieldProps.onResponse as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(notes[0].attachments[0].dataUrl).toMatch(/^data:text\/plain/);
+  });
+
+  it('tells the manager when a note carrying attachments is deleted', async () => {
+    const manager = fakeManager();
+    const stored = { contentType: 'text/plain', title: 'report.txt', size: 5 };
+    const fieldProps = props(
+      { fieldType: 'notes', question: 'Case notes' },
+      {
+        response: {
+          notes: [
+            {
+              id: 'n1',
+              createdAt: '2026-01-01T00:00:00Z',
+              markdown: 'Saw the patient',
+              attachments: [stored],
+            },
+          ],
+        },
+      }
+    );
+
+    render(withManager(manager, <NotesField {...fieldProps} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete note' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(manager.removed).toEqual([stored]));
+  });
+});

--- a/packages/fields/src/fields/rich/DisplayField.tsx
+++ b/packages/fields/src/fields/rich/DisplayField.tsx
@@ -5,6 +5,7 @@ import {
   type FieldComponentProps,
   type DisplayFieldDefinition,
 } from '@esheet/core';
+import { renderMarkdownContent } from '../../lib/markdown.js';
 
 function formatComputedValue(value: unknown): string {
   if (value == null) return '';
@@ -104,133 +105,9 @@ function interpolateExpressions(
   return result;
 }
 
-// Renders inline markdown with recursive nesting so formats can combine.
-// Syntax: *bold*, -italic-, _underline_, ~strike~, bullets with `- ` at line start.
-// Interpolation: {field-id} = field value, <expression> = computed result (e.g. <{a} + {b}>).
-function renderInlineNode(text: string, key: string): React.ReactNode {
-  // Bold — *text* (single asterisk)
-  const bold = text.match(/^(.*?)\*([^*]+)\*(.*)$/s);
-  if (bold) {
-    return (
-      <React.Fragment key={key}>
-        {bold[1] && renderInlineNode(bold[1], `${key}a`)}
-        <strong>{renderInlineNode(bold[2], `${key}b`)}</strong>
-        {bold[3] && renderInlineNode(bold[3], `${key}c`)}
-      </React.Fragment>
-    );
-  }
-  // Italic — -text- (no leading/trailing space to avoid conflicting with bullet `- `).
-  // Digit-flanked hyphens are skipped so ISO dates (2026-01-31), ranges, and
-  // negative numbers from computed expressions are not mangled into <em>.
-  const italic = text.match(
-    /^(.*?)(?<!\d)-([^\s-][^-]*[^\s-]|[^\s-])-(?!\d)(.*)$/s
-  );
-  if (italic) {
-    return (
-      <React.Fragment key={key}>
-        {italic[1] && renderInlineNode(italic[1], `${key}a`)}
-        <em>{renderInlineNode(italic[2], `${key}b`)}</em>
-        {italic[3] && renderInlineNode(italic[3], `${key}c`)}
-      </React.Fragment>
-    );
-  }
-  // Underline — _text_ (single underscore)
-  const under = text.match(/^(.*?)_([^_]+)_(.*)$/s);
-  if (under) {
-    return (
-      <React.Fragment key={key}>
-        {under[1] && renderInlineNode(under[1], `${key}a`)}
-        <span className="ms:underline">
-          {renderInlineNode(under[2], `${key}b`)}
-        </span>
-        {under[3] && renderInlineNode(under[3], `${key}c`)}
-      </React.Fragment>
-    );
-  }
-  // Strikethrough — ~text~
-  const strike = text.match(/^(.*?)~(.+?)~(.*)$/s);
-  if (strike) {
-    return (
-      <React.Fragment key={key}>
-        {strike[1] && renderInlineNode(strike[1], `${key}a`)}
-        <span className="ms:line-through">
-          {renderInlineNode(strike[2], `${key}b`)}
-        </span>
-        {strike[3] && renderInlineNode(strike[3], `${key}c`)}
-      </React.Fragment>
-    );
-  }
-  return <React.Fragment key={key}>{text}</React.Fragment>;
-}
-
-function renderInline(text: string): React.ReactNode[] {
-  if (!text) return [];
-  return [renderInlineNode(text, 'r')];
-}
-
-function renderContent(content: string): React.ReactNode {
-  const lines = content.split(/\r?\n/);
-  const blocks: React.ReactNode[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (!line.trim()) {
-      blocks.push(<div key={`sp-${i}`} className="ms:h-3" />);
-      i += 1;
-      continue;
-    }
-
-    if (/^-\s+/.test(line)) {
-      const items: React.ReactNode[] = [];
-      while (i < lines.length && /^-\s+/.test(lines[i])) {
-        items.push(
-          <li key={`li-${i}`} className="ms:ml-4 ms:list-disc">
-            {renderInline(lines[i].replace(/^-\s+/, ''))}
-          </li>
-        );
-        i += 1;
-      }
-      blocks.push(
-        <ul key={`ul-${i}`} className="ms:my-2">
-          {items}
-        </ul>
-      );
-      continue;
-    }
-
-    const heading = line.match(/^(#{1,6})\s+(.*)$/);
-    if (heading) {
-      const level = heading[1].length;
-      const text = heading[2];
-      const headingClass =
-        level === 1
-          ? 'ms:text-2xl ms:font-semibold'
-          : level === 2
-          ? 'ms:text-xl ms:font-semibold'
-          : level === 3
-          ? 'ms:text-lg ms:font-semibold'
-          : 'ms:text-base ms:font-semibold';
-      blocks.push(
-        <div key={`h-${i}`} className={`ms:my-1 ${headingClass}`}>
-          {renderInline(text)}
-        </div>
-      );
-      i += 1;
-      continue;
-    }
-
-    blocks.push(
-      <p key={`p-${i}`} className="ms:my-1 ms:leading-relaxed">
-        {renderInline(line)}
-      </p>
-    );
-    i += 1;
-  }
-
-  return <>{blocks}</>;
-}
+// Markdown-lite rendering (bold/italic/underline/strike, headings, bullets)
+// lives in the shared lib/markdown.tsx pipeline; this file only adds
+// expression interpolation on top of it.
 
 function wrapSelection(
   ref: React.RefObject<HTMLTextAreaElement | null>,
@@ -300,7 +177,7 @@ export const DisplayField = React.memo(function DisplayField({
   if (isPreview) {
     return (
       <div className="display-field-preview ms:text-mstext">
-        {renderContent(rendered)}
+        {renderMarkdownContent(rendered)}
       </div>
     );
   }
@@ -388,7 +265,7 @@ export const DisplayField = React.memo(function DisplayField({
           Live Preview
         </div>
         <div className="display-field-live-preview ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:p-4 ms:text-mstext">
-          {renderContent(rendered)}
+          {renderMarkdownContent(rendered)}
         </div>
       </div>
     </div>

--- a/packages/fields/src/fields/rich/FileField.tsx
+++ b/packages/fields/src/fields/rich/FileField.tsx
@@ -1,11 +1,16 @@
 import React, { useCallback, useState } from 'react';
-import type {
-  FieldComponentProps,
-  AttachmentAnswer,
-  FileFieldDefinition,
-} from '@esheet/core';
+import type { FieldComponentProps, FileFieldDefinition } from '@esheet/core';
 import { TrashIcon, UploadIcon } from '../../icons.js';
-import { formatFileSize, fileMatchesAccept } from '../../lib/file-utils.js';
+import {
+  formatFileSize,
+  fileMatchesAccept,
+  readFileAsAttachment,
+} from '../../lib/file-utils.js';
+import {
+  removeUnreferenced,
+  storeAttachments,
+  useAttachmentManager,
+} from '../../lib/AttachmentManagerProvider.js';
 
 const PREDEFINED_FILE_TYPES = [
   { label: 'JPEG', value: 'image/jpeg', accept: '.jpg,.jpeg' },
@@ -90,6 +95,7 @@ export const FileField = React.memo(function FileField({
   const def = field.definition as FileFieldDefinition & { question?: string };
   const instanceId = form.getState().instanceId;
   const maxFiles = def.maxFiles ?? 1;
+  const attachmentManager = useAttachmentManager();
   const [isDragActive, setIsDragActive] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [sizeUnit, setSizeUnit] = useState<SizeUnit>(
@@ -148,36 +154,29 @@ export const FileField = React.memo(function FileField({
         if (validFiles.length === 0) return;
       }
 
-      let processed = 0;
-      const newFiles: AttachmentAnswer[] = [];
-
-      validFiles.forEach((file) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result as string;
-          const ans: AttachmentAnswer = {
-            contentType: file.type || 'application/octet-stream',
-            dataUrl: result,
-            title: file.name,
-            size: file.size,
-          };
-          newFiles.push(ans);
-          processed++;
-
-          if (processed === validFiles.length) {
-            const updated = [...fileDataArr, ...newFiles];
-            onResponse({ fileData: maxFiles === 1 ? updated[0] : updated });
-          }
-        };
-        reader.readAsDataURL(file);
-      });
+      void (async () => {
+        const read = await Promise.all(validFiles.map(readFileAsAttachment));
+        // The host's manager takes the bytes and hands back a reference; with
+        // no manager the data URL stays on the response, as it always has.
+        const stored = await storeAttachments(attachmentManager, read);
+        const updated = [...fileDataArr, ...stored];
+        onResponse({ fileData: maxFiles === 1 ? updated[0] : updated });
+      })();
     },
-    [fileDataArr, maxFiles, def.maxFileSize, def.accept, onResponse]
+    [
+      fileDataArr,
+      maxFiles,
+      def.maxFileSize,
+      def.accept,
+      onResponse,
+      attachmentManager,
+    ]
   );
 
   const handleRemoveFile = useCallback(
     (index: number) => {
       const updated = fileDataArr.filter((_, i) => i !== index);
+      removeUnreferenced(attachmentManager, fileDataArr, updated);
       onResponse({
         fileData:
           updated.length === 0
@@ -187,7 +186,7 @@ export const FileField = React.memo(function FileField({
             : updated,
       });
     },
-    [fileDataArr, maxFiles, onResponse]
+    [fileDataArr, maxFiles, onResponse, attachmentManager]
   );
 
   const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {

--- a/packages/fields/src/fields/rich/FileField.tsx
+++ b/packages/fields/src/fields/rich/FileField.tsx
@@ -5,6 +5,7 @@ import type {
   FileFieldDefinition,
 } from '@esheet/core';
 import { TrashIcon, UploadIcon } from '../../icons.js';
+import { formatFileSize, fileMatchesAccept } from '../../lib/file-utils.js';
 
 const PREDEFINED_FILE_TYPES = [
   { label: 'JPEG', value: 'image/jpeg', accept: '.jpg,.jpeg' },
@@ -51,14 +52,6 @@ const getSelectedTypes = (acceptString?: string): string[] => {
     const ftParts = ft.accept.split(',').map((s) => s.trim());
     return ftParts.some((p) => parts.has(p)) || parts.has(ft.value);
   }).map((ft) => ft.value);
-};
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
 };
 
 const SIZE_UNITS = {
@@ -121,23 +114,11 @@ export const FileField = React.memo(function FileField({
       const maxFileSize = def.maxFileSize;
 
       // Validate file types against accept filter
-      const acceptParts = def.accept
-        ? def.accept.split(',').map((s) => s.trim())
-        : [];
       const rejectedTypes: string[] = [];
       const typeAccepted: File[] = [];
 
       filesToProcess.forEach((file) => {
-        const ok =
-          acceptParts.length === 0 ||
-          acceptParts.some((part) => {
-            if (part.startsWith('.'))
-              return file.name.toLowerCase().endsWith(part.toLowerCase());
-            if (part.endsWith('/*'))
-              return file.type.startsWith(part.slice(0, -1));
-            return file.type === part;
-          });
-        if (ok) typeAccepted.push(file);
+        if (fileMatchesAccept(file, def.accept)) typeAccepted.push(file);
         else rejectedTypes.push(file.name);
       });
 

--- a/packages/fields/src/fields/rich/NoteCardList.tsx
+++ b/packages/fields/src/fields/rich/NoteCardList.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// NoteCardList — shared presentational entry list used by NotesField and
+// ActivityField. Pure display: any mutation affordances come in via `actions`.
+// ---------------------------------------------------------------------------
+
+export interface NoteCardItem {
+  id: string;
+  /** Card header title, e.g. the author display name. */
+  title?: string;
+  /** Card header timestamp text (already formatted for display). */
+  timestamp?: string;
+  /** Card body (rendered markdown, change summary, ...). */
+  body: React.ReactNode;
+  /** Optional footer (attachments, ...). */
+  footer?: React.ReactNode;
+  /** Optional header-right action buttons (edit / delete). */
+  actions?: React.ReactNode;
+}
+
+export interface NoteCardListProps {
+  items: NoteCardItem[];
+  /** Shown when there are no items. */
+  emptyLabel: string;
+  /** Accessible label for the list. */
+  ariaLabel: string;
+}
+
+export function NoteCardList({
+  items,
+  emptyLabel,
+  ariaLabel,
+}: NoteCardListProps) {
+  if (items.length === 0) {
+    return (
+      <p className="note-list-empty ms:text-sm ms:text-mstextmuted ms:italic">
+        {emptyLabel}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="note-list ms:space-y-2 ms:list-none" aria-label={ariaLabel}>
+      {items.map((item) => (
+        <li
+          key={item.id}
+          className="note-card ms:border ms:border-msborder ms:bg-mssurface ms:rounded-lg ms:p-3"
+        >
+          {(item.title || item.timestamp || item.actions) && (
+            <div className="note-card-header ms:flex ms:items-baseline ms:justify-between ms:gap-2 ms:mb-1">
+              <div className="ms:flex ms:items-baseline ms:gap-2 ms:min-w-0">
+                {item.title && (
+                  <span className="note-card-author ms:text-sm ms:font-medium ms:text-mstext ms:truncate">
+                    {item.title}
+                  </span>
+                )}
+                {item.timestamp && (
+                  <span className="note-card-timestamp ms:text-xs ms:text-mstextmuted ms:whitespace-nowrap">
+                    {item.timestamp}
+                  </span>
+                )}
+              </div>
+              {item.actions && (
+                <div className="note-card-actions ms:flex ms:items-center ms:gap-1">
+                  {item.actions}
+                </div>
+              )}
+            </div>
+          )}
+          <div className="note-card-body ms:text-sm ms:text-mstext ms:break-words">
+            {item.body}
+          </div>
+          {item.footer && (
+            <div className="note-card-footer ms:mt-2">{item.footer}</div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/fields/src/fields/rich/NotesField.spec.tsx
+++ b/packages/fields/src/fields/rich/NotesField.spec.tsx
@@ -1,0 +1,259 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { FieldComponentProps, NoteEntry } from '@esheet/core';
+import { NotesField } from './NotesField.js';
+
+const note = (
+  id: string,
+  createdAt: string,
+  overrides: Partial<NoteEntry> = {}
+): NoteEntry => ({
+  id,
+  createdAt,
+  markdown: `Body of ${id}`,
+  ...overrides,
+});
+
+function createProps(
+  definition: Record<string, unknown>,
+  overrides: Partial<FieldComponentProps> = {}
+): FieldComponentProps {
+  return {
+    field: { definition: { fieldType: 'notes', id: 'case-notes', ...definition } },
+    form: {
+      getState: () => ({
+        instanceId: 'test',
+        identity: { name: 'Dr. Demo' },
+      }),
+    },
+    isPreview: true,
+    isEnabled: true,
+    isReadOnly: false,
+    isRequired: false,
+    isSoftRequired: false,
+    onResponse: vi.fn(),
+    onUpdate: vi.fn(),
+    ...overrides,
+  } as unknown as FieldComponentProps;
+}
+
+describe('NotesField', () => {
+  it('renders entries newest first by default with author and markdown body', () => {
+    render(
+      <NotesField
+        {...createProps(
+          { question: 'Case notes' },
+          {
+            response: {
+              notes: [
+                note('old', '2026-01-01T10:00:00Z', {
+                  author: 'Alice',
+                  markdown: 'First *bold* note',
+                }),
+                note('new', '2026-02-01T10:00:00Z', { author: 'Bob' }),
+              ],
+            },
+          }
+        )}
+      />
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0].textContent).toContain('Bob');
+    expect(items[1].textContent).toContain('Alice');
+    expect(screen.getByText('bold').tagName).toBe('STRONG');
+  });
+
+  it('respects sortOrder oldest', () => {
+    render(
+      <NotesField
+        {...createProps(
+          { sortOrder: 'oldest' },
+          {
+            response: {
+              notes: [
+                note('old', '2026-01-01T10:00:00Z', { author: 'Alice' }),
+                note('new', '2026-02-01T10:00:00Z', { author: 'Bob' }),
+              ],
+            },
+          }
+        )}
+      />
+    );
+    const items = screen.getAllByRole('listitem');
+    expect(items[0].textContent).toContain('Alice');
+  });
+
+  it('adds a note stamped with GUID, createdAt, and identity author', () => {
+    const onResponse = vi.fn();
+    render(<NotesField {...createProps({}, { onResponse })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Note text' }), {
+      target: { value: 'A new *note*' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onResponse).toHaveBeenCalledTimes(1);
+    const saved = onResponse.mock.calls[0][0].notes as NoteEntry[];
+    expect(saved).toHaveLength(1);
+    expect(saved[0].id).toMatch(/[0-9a-f-]{36}/);
+    expect(saved[0].markdown).toBe('A new *note*');
+    expect(saved[0].author).toBe('Dr. Demo');
+    expect(saved[0].createdAt).toBeTruthy();
+    expect(saved[0].updatedAt).toBeUndefined();
+  });
+
+  it('edits a note in place and stamps updatedAt', () => {
+    const onResponse = vi.fn();
+    const existing = note('n1', '2026-01-01T10:00:00Z');
+    render(
+      <NotesField
+        {...createProps({}, { onResponse, response: { notes: [existing] } })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit note' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Note text' }), {
+      target: { value: 'Edited body' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    const saved = onResponse.mock.calls[0][0].notes as NoteEntry[];
+    expect(saved).toHaveLength(1);
+    expect(saved[0].id).toBe('n1');
+    expect(saved[0].markdown).toBe('Edited body');
+    expect(saved[0].updatedAt).toBeTruthy();
+  });
+
+  it('deletes a note only after confirmation', () => {
+    const onResponse = vi.fn();
+    render(
+      <NotesField
+        {...createProps(
+          {},
+          { onResponse, response: { notes: [note('n1', '2026-01-01T10:00:00Z')] } }
+        )}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete note' }));
+    expect(onResponse).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onResponse.mock.calls[0][0].notes).toEqual([]);
+  });
+
+  it('hides the add button at maxNotes', () => {
+    render(
+      <NotesField
+        {...createProps(
+          { maxNotes: 1 },
+          { response: { notes: [note('n1', '2026-01-01T10:00:00Z')] } }
+        )}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Add note' })).toBeNull();
+  });
+
+  it('renders read-only (no compose/edit/delete) when not enabled', () => {
+    render(
+      <NotesField
+        {...createProps(
+          {},
+          {
+            isEnabled: false,
+            response: { notes: [note('n1', '2026-01-01T10:00:00Z')] },
+          }
+        )}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Add note' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit note' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Delete note' })).toBeNull();
+    expect(screen.getByText('Body of n1')).toBeTruthy();
+  });
+
+  it('respects a canModify hook', () => {
+    render(
+      <NotesField
+        {...createProps(
+          { canModify: (n: NoteEntry) => n.author === 'Dr. Demo' },
+          {
+            response: {
+              notes: [
+                note('mine', '2026-01-01T10:00:00Z', { author: 'Dr. Demo' }),
+                note('theirs', '2026-01-02T10:00:00Z', { author: 'Other' }),
+              ],
+            },
+          }
+        )}
+      />
+    );
+    expect(screen.getAllByRole('button', { name: 'Edit note' })).toHaveLength(1);
+  });
+
+  it('uses entryLabel for actions and empty state', () => {
+    render(<NotesField {...createProps({ entryLabel: 'Letter' })} />);
+    expect(
+      screen.getByRole('button', { name: 'Add letter' })
+    ).toBeTruthy();
+    expect(screen.getByText('No letters yet')).toBeTruthy();
+  });
+
+  it('toggles write/preview in the composer', () => {
+    render(<NotesField {...createProps({})} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Note text' }), {
+      target: { value: 'Show *this* rendered' },
+    });
+    fireEvent.click(screen.getByRole('tab', { name: 'Preview' }));
+    expect(screen.getByText('this').tagName).toBe('STRONG');
+  });
+
+  it('shows the attach control only when allowAttachments', () => {
+    const { rerender } = render(<NotesField {...createProps({})} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }));
+    expect(screen.queryByText('Attach file')).toBeNull();
+
+    rerender(<NotesField {...createProps({ allowAttachments: true })} />);
+    expect(screen.getByText('Attach file')).toBeTruthy();
+  });
+
+  it('lists attachments on saved notes', () => {
+    render(
+      <NotesField
+        {...createProps(
+          { allowAttachments: true },
+          {
+            response: {
+              notes: [
+                note('n1', '2026-01-01T10:00:00Z', {
+                  attachments: [
+                    {
+                      contentType: 'application/pdf',
+                      dataUrl: 'data:...',
+                      title: 'report.pdf',
+                      size: 2048,
+                    },
+                  ],
+                }),
+              ],
+            },
+          }
+        )}
+      />
+    );
+    expect(screen.getByText('report.pdf')).toBeTruthy();
+    expect(screen.getByText('(2 KB)')).toBeTruthy();
+  });
+
+  it('builder mode edits definition properties', () => {
+    const onUpdate = vi.fn();
+    render(
+      <NotesField {...createProps({}, { isPreview: false, onUpdate })} />
+    );
+    fireEvent.change(screen.getByLabelText('Entry label'), {
+      target: { value: 'Comment' },
+    });
+    expect(onUpdate).toHaveBeenCalledWith({ entryLabel: 'Comment' });
+  });
+});

--- a/packages/fields/src/fields/rich/NotesField.tsx
+++ b/packages/fields/src/fields/rich/NotesField.tsx
@@ -269,8 +269,7 @@ export const NotesField = React.memo(function NotesField({
   const entryLabel = def.entryLabel ?? 'Note';
   const readOnly = !(isPreview && isEnabled) || isReadOnly;
   // Renderer identity (when the host provides one) stamps `author`.
-  const identity = (form.getState() as { identity?: { name?: string } })
-    .identity;
+  const identity = form.getState().identity;
 
   const [composer, setComposer] = React.useState<ComposerState>({
     mode: 'closed',

--- a/packages/fields/src/fields/rich/NotesField.tsx
+++ b/packages/fields/src/fields/rich/NotesField.tsx
@@ -12,6 +12,11 @@ import {
   fileMatchesAccept,
   readFileAsAttachment,
 } from '../../lib/file-utils.js';
+import {
+  removeUnreferenced,
+  storeAttachments,
+  useAttachmentManager,
+} from '../../lib/AttachmentManagerProvider.js';
 import { NoteCardList, type NoteCardItem } from './NoteCardList.js';
 import { getNotesComposer } from '../../lib/notes-composer.js';
 
@@ -289,6 +294,7 @@ export const NotesField = React.memo(function NotesField({
   const readOnly = !(isPreview && isEnabled) || isReadOnly;
   // Renderer identity (when the host provides one) stamps `author`.
   const identity = form.getState().identity;
+  const attachmentManager = useAttachmentManager();
 
   const [composer, setComposer] = React.useState<ComposerState>({
     mode: 'closed',
@@ -320,43 +326,68 @@ export const NotesField = React.memo(function NotesField({
     [onResponse, response]
   );
 
+  // Storage happens on save, not on attach: a cancelled composer must not
+  // leave bytes behind. With no manager the commit stays synchronous.
   const saveNote = React.useCallback(
-    (markdown: string, attachments: AttachmentAnswer[]) => {
-      const now = new Date().toISOString();
-      if (composer.mode === 'edit') {
-        commitNotes(
-          notes.map((note) =>
-            note.id === composer.noteId
-              ? {
-                  ...note,
-                  markdown,
-                  updatedAt: now,
-                  attachments: attachments.length ? attachments : undefined,
-                }
-              : note
-          )
-        );
+    (markdown: string, composed: AttachmentAnswer[]) => {
+      const commit = (attachments: AttachmentAnswer[]) => {
+        const now = new Date().toISOString();
+        if (composer.mode === 'edit') {
+          const edited = notes.find((note) => note.id === composer.noteId);
+          removeUnreferenced(
+            attachmentManager,
+            edited?.attachments ?? [],
+            attachments
+          );
+          commitNotes(
+            notes.map((note) =>
+              note.id === composer.noteId
+                ? {
+                    ...note,
+                    markdown,
+                    updatedAt: now,
+                    attachments: attachments.length ? attachments : undefined,
+                  }
+                : note
+            )
+          );
+        } else {
+          const entry: NoteEntry = {
+            id: crypto.randomUUID(),
+            createdAt: now,
+            markdown,
+            ...(identity?.name ? { author: identity.name } : {}),
+            ...(attachments.length ? { attachments } : {}),
+          };
+          commitNotes([...notes, entry]);
+        }
+      };
+
+      if (attachmentManager) {
+        void storeAttachments(attachmentManager, composed).then(commit);
       } else {
-        const entry: NoteEntry = {
-          id: crypto.randomUUID(),
-          createdAt: now,
-          markdown,
-          ...(identity?.name ? { author: identity.name } : {}),
-          ...(attachments.length ? { attachments } : {}),
-        };
-        commitNotes([...notes, entry]);
+        commit(composed);
       }
       closeComposer();
     },
-    [composer, notes, identity?.name, commitNotes, closeComposer]
+    [
+      composer,
+      notes,
+      identity?.name,
+      commitNotes,
+      closeComposer,
+      attachmentManager,
+    ]
   );
 
   const deleteNote = React.useCallback(
     (noteId: string) => {
+      const removed = notes.find((note) => note.id === noteId);
+      removeUnreferenced(attachmentManager, removed?.attachments ?? [], []);
       commitNotes(notes.filter((note) => note.id !== noteId));
       setConfirmingDeleteId(null);
     },
-    [notes, commitNotes]
+    [notes, commitNotes, attachmentManager]
   );
 
   const canModify = def.canModify ?? (() => true);
@@ -374,9 +405,7 @@ export const NotesField = React.memo(function NotesField({
       title: note.author,
       timestamp:
         formatTimestamp(note.createdAt) +
-        (note.updatedAt
-          ? ` (edited ${formatTimestamp(note.updatedAt)})`
-          : ''),
+        (note.updatedAt ? ` (edited ${formatTimestamp(note.updatedAt)})` : ''),
       body: renderMarkdownContent(note.markdown),
       footer: note.attachments?.length ? (
         <AttachmentChips attachments={note.attachments} />

--- a/packages/fields/src/fields/rich/NotesField.tsx
+++ b/packages/fields/src/fields/rich/NotesField.tsx
@@ -13,6 +13,7 @@ import {
   readFileAsAttachment,
 } from '../../lib/file-utils.js';
 import { NoteCardList, type NoteCardItem } from './NoteCardList.js';
+import { getNotesComposer } from '../../lib/notes-composer.js';
 
 // ---------------------------------------------------------------------------
 // NotesField — journal-style list of rich (markdown) note entries, each
@@ -105,6 +106,13 @@ function NoteComposer({
   const [tab, setTab] = React.useState<'write' | 'preview'>('write');
   const [errorMsg, setErrorMsg] = React.useState('');
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  // Host-registered rich composer (e.g. Kerebron). It edits markdown
+  // in place, so the Write/Preview tabs only apply to the textarea default.
+  const RichComposer = getNotesComposer();
+  // The rich composer may debounce onChange; keep the latest markdown in a
+  // ref so Save never captures a stale value.
+  const markdownRef = React.useRef(initialMarkdown);
+  markdownRef.current = markdown;
 
   React.useEffect(() => {
     textareaRef.current?.focus();
@@ -145,55 +153,66 @@ function NoteComposer({
 
   return (
     <div className="note-composer ms:border ms:border-msprimary/50 ms:rounded-lg ms:p-3 ms:space-y-2">
-      <div
-        className="note-composer-tabs ms:flex ms:gap-2"
-        role="tablist"
-        aria-label={`${entryLabel} composer mode`}
-      >
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'write'}
-          className={`${buttonClass} ${
-            tab === 'write' ? 'ms:border-msprimary' : ''
-          }`}
-          onClick={() => setTab('write')}
-        >
-          Write
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'preview'}
-          className={`${buttonClass} ${
-            tab === 'preview' ? 'ms:border-msprimary' : ''
-          }`}
-          onClick={() => setTab('preview')}
-        >
-          Preview
-        </button>
-      </div>
-
-      {tab === 'write' ? (
-        <textarea
-          ref={textareaRef}
-          value={markdown}
-          onChange={(e) => setMarkdown(e.target.value)}
-          rows={5}
-          aria-label={`${entryLabel} text`}
-          placeholder={`Write a ${entryLabel.toLowerCase()}... (markdown supported)`}
-          className="note-composer-textarea ms:px-3 ms:py-2 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:text-sm ms:resize-y"
+      {RichComposer ? (
+        <RichComposer
+          value={initialMarkdown}
+          onChange={setMarkdown}
+          ariaLabel={`${entryLabel} text`}
+          placeholder={`Write a ${entryLabel.toLowerCase()}...`}
         />
       ) : (
-        <div className="note-composer-preview ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:p-3 ms:text-sm ms:text-mstext">
-          {markdown.trim() ? (
-            renderMarkdownContent(markdown)
+        <>
+          <div
+            className="note-composer-tabs ms:flex ms:gap-2"
+            role="tablist"
+            aria-label={`${entryLabel} composer mode`}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'write'}
+              className={`${buttonClass} ${
+                tab === 'write' ? 'ms:border-msprimary' : ''
+              }`}
+              onClick={() => setTab('write')}
+            >
+              Write
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'preview'}
+              className={`${buttonClass} ${
+                tab === 'preview' ? 'ms:border-msprimary' : ''
+              }`}
+              onClick={() => setTab('preview')}
+            >
+              Preview
+            </button>
+          </div>
+
+          {tab === 'write' ? (
+            <textarea
+              ref={textareaRef}
+              value={markdown}
+              onChange={(e) => setMarkdown(e.target.value)}
+              rows={5}
+              aria-label={`${entryLabel} text`}
+              placeholder={`Write a ${entryLabel.toLowerCase()}... (markdown supported)`}
+              className="note-composer-textarea ms:px-3 ms:py-2 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:text-sm ms:resize-y"
+            />
           ) : (
-            <span className="ms:text-mstextmuted ms:italic">
-              Nothing to preview
-            </span>
+            <div className="note-composer-preview ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:p-3 ms:text-sm ms:text-mstext">
+              {markdown.trim() ? (
+                renderMarkdownContent(markdown)
+              ) : (
+                <span className="ms:text-mstextmuted ms:italic">
+                  Nothing to preview
+                </span>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
 
       {def.allowAttachments && (
@@ -238,7 +257,7 @@ function NoteComposer({
           type="button"
           className={primaryButtonClass}
           disabled={!markdown.trim()}
-          onClick={() => onSave(markdown, attachments)}
+          onClick={() => onSave(markdownRef.current, attachments)}
         >
           Save
         </button>

--- a/packages/fields/src/fields/rich/NotesField.tsx
+++ b/packages/fields/src/fields/rich/NotesField.tsx
@@ -1,0 +1,620 @@
+import React from 'react';
+import type {
+  AttachmentAnswer,
+  FieldComponentProps,
+  NoteEntry,
+  NotesFieldDefinition,
+} from '@esheet/core';
+import { PencilIcon, TrashIcon } from '../../icons.js';
+import { renderMarkdownContent } from '../../lib/markdown.js';
+import {
+  formatFileSize,
+  fileMatchesAccept,
+  readFileAsAttachment,
+} from '../../lib/file-utils.js';
+import { NoteCardList, type NoteCardItem } from './NoteCardList.js';
+
+// ---------------------------------------------------------------------------
+// NotesField — journal-style list of rich (markdown) note entries, each
+// optionally carrying attachments. Entries are GUID-keyed (see core
+// mergeNotes); this component only appends / edits / removes by id.
+// ---------------------------------------------------------------------------
+
+/** Host-side edit policy hook — enforcement belongs server-side. */
+type CanModify = (note: NoteEntry) => boolean;
+
+type ComposerState =
+  | { mode: 'closed' }
+  | { mode: 'new' }
+  | { mode: 'edit'; noteId: string };
+
+const formatTimestamp = (iso: string): string => {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
+};
+
+const buttonClass =
+  'ms:px-2 ms:py-1 ms:rounded ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:text-sm';
+const primaryButtonClass =
+  'ms:px-3 ms:py-1 ms:rounded ms:bg-msprimary ms:text-white ms:text-sm ms:disabled:opacity-50';
+
+function AttachmentChips({
+  attachments,
+  onRemove,
+}: {
+  attachments: AttachmentAnswer[];
+  onRemove?: (index: number) => void;
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <ul
+      className="note-attachments ms:flex ms:flex-wrap ms:gap-2 ms:list-none"
+      aria-label="Attachments"
+    >
+      {attachments.map((att, index) => (
+        <li
+          key={index}
+          className="note-attachment ms:flex ms:items-center ms:gap-1 ms:px-2 ms:py-1 ms:rounded ms:border ms:border-msborder ms:bg-msbg ms:text-xs ms:text-mstext"
+        >
+          <span className="ms:truncate ms:max-w-40">
+            {att.title || 'Attachment'}
+          </span>
+          {att.size !== undefined && (
+            <span className="ms:text-mstextmuted">
+              ({formatFileSize(att.size)})
+            </span>
+          )}
+          {onRemove && (
+            <button
+              type="button"
+              onClick={() => onRemove(index)}
+              aria-label={`Remove attachment ${att.title || index + 1}`}
+              className="ms:text-mstextmuted ms:hover:text-msdanger"
+            >
+              ×
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface ComposerProps {
+  def: NotesFieldDefinition;
+  instanceId: string;
+  entryLabel: string;
+  initialMarkdown: string;
+  initialAttachments: AttachmentAnswer[];
+  onSave: (markdown: string, attachments: AttachmentAnswer[]) => void;
+  onCancel: () => void;
+}
+
+function NoteComposer({
+  def,
+  instanceId,
+  entryLabel,
+  initialMarkdown,
+  initialAttachments,
+  onSave,
+  onCancel,
+}: ComposerProps) {
+  const [markdown, setMarkdown] = React.useState(initialMarkdown);
+  const [attachments, setAttachments] =
+    React.useState<AttachmentAnswer[]>(initialAttachments);
+  const [tab, setTab] = React.useState<'write' | 'preview'>('write');
+  const [errorMsg, setErrorMsg] = React.useState('');
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setErrorMsg('');
+    const errors: string[] = [];
+    const accepted: AttachmentAnswer[] = [];
+    const maxAttachments = def.maxAttachments;
+    let count = attachments.length;
+
+    for (const file of Array.from(files)) {
+      if (maxAttachments !== undefined && count >= maxAttachments) {
+        errors.push(`Max ${maxAttachments} attachment(s) per ${entryLabel}`);
+        break;
+      }
+      if (!fileMatchesAccept(file, def.accept)) {
+        errors.push(`File type not accepted: ${file.name}`);
+        continue;
+      }
+      if (def.maxFileSize && file.size > def.maxFileSize) {
+        errors.push(
+          `${file.name} exceeds max size of ${formatFileSize(def.maxFileSize)}`
+        );
+        continue;
+      }
+      accepted.push(await readFileAsAttachment(file));
+      count += 1;
+    }
+
+    if (errors.length > 0) setErrorMsg(errors.join('; '));
+    if (accepted.length > 0) setAttachments((prev) => [...prev, ...accepted]);
+  };
+
+  const fileInputId = `${instanceId}-note-attachment-${def.id}`;
+
+  return (
+    <div className="note-composer ms:border ms:border-msprimary/50 ms:rounded-lg ms:p-3 ms:space-y-2">
+      <div
+        className="note-composer-tabs ms:flex ms:gap-2"
+        role="tablist"
+        aria-label={`${entryLabel} composer mode`}
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'write'}
+          className={`${buttonClass} ${
+            tab === 'write' ? 'ms:border-msprimary' : ''
+          }`}
+          onClick={() => setTab('write')}
+        >
+          Write
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'preview'}
+          className={`${buttonClass} ${
+            tab === 'preview' ? 'ms:border-msprimary' : ''
+          }`}
+          onClick={() => setTab('preview')}
+        >
+          Preview
+        </button>
+      </div>
+
+      {tab === 'write' ? (
+        <textarea
+          ref={textareaRef}
+          value={markdown}
+          onChange={(e) => setMarkdown(e.target.value)}
+          rows={5}
+          aria-label={`${entryLabel} text`}
+          placeholder={`Write a ${entryLabel.toLowerCase()}... (markdown supported)`}
+          className="note-composer-textarea ms:px-3 ms:py-2 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:text-sm ms:resize-y"
+        />
+      ) : (
+        <div className="note-composer-preview ms:rounded-lg ms:border ms:border-msborder ms:bg-mssurface ms:p-3 ms:text-sm ms:text-mstext">
+          {markdown.trim() ? (
+            renderMarkdownContent(markdown)
+          ) : (
+            <span className="ms:text-mstextmuted ms:italic">
+              Nothing to preview
+            </span>
+          )}
+        </div>
+      )}
+
+      {def.allowAttachments && (
+        <div className="note-composer-attachments ms:space-y-2">
+          <AttachmentChips
+            attachments={attachments}
+            onRemove={(index) =>
+              setAttachments((prev) => prev.filter((_, i) => i !== index))
+            }
+          />
+          <input
+            id={fileInputId}
+            type="file"
+            multiple
+            accept={def.accept}
+            onClick={(e) => {
+              (e.target as HTMLInputElement).value = '';
+            }}
+            onChange={(e) => void handleFiles(e.target.files)}
+            className="ms:hidden"
+          />
+          <label
+            htmlFor={fileInputId}
+            className={`${buttonClass} ms:inline-block ms:cursor-pointer`}
+          >
+            Attach file
+          </label>
+        </div>
+      )}
+
+      {errorMsg && (
+        <div
+          role="alert"
+          className="ms:p-2 ms:bg-msdanger/10 ms:border ms:border-msdanger ms:rounded ms:text-xs ms:text-msdanger"
+        >
+          {errorMsg}
+        </div>
+      )}
+
+      <div className="note-composer-actions ms:flex ms:gap-2">
+        <button
+          type="button"
+          className={primaryButtonClass}
+          disabled={!markdown.trim()}
+          onClick={() => onSave(markdown, attachments)}
+        >
+          Save
+        </button>
+        <button type="button" className={buttonClass} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const NotesField = React.memo(function NotesField({
+  field,
+  form,
+  isPreview,
+  isEnabled,
+  isRequired,
+  isSoftRequired,
+  isReadOnly,
+  response,
+  onUpdate,
+  onResponse,
+}: FieldComponentProps) {
+  const def = field.definition as NotesFieldDefinition & {
+    canModify?: CanModify;
+  };
+  const instanceId = form.getState().instanceId;
+  const entryLabel = def.entryLabel ?? 'Note';
+  const readOnly = !(isPreview && isEnabled) || isReadOnly;
+  // Renderer identity (when the host provides one) stamps `author`.
+  const identity = (form.getState() as { identity?: { name?: string } })
+    .identity;
+
+  const [composer, setComposer] = React.useState<ComposerState>({
+    mode: 'closed',
+  });
+  const [confirmingDeleteId, setConfirmingDeleteId] = React.useState<
+    string | null
+  >(null);
+  const addButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  const notes = React.useMemo(() => response?.notes ?? [], [response?.notes]);
+  const sortedNotes = React.useMemo(() => {
+    const byCreated = [...notes].sort((a, b) =>
+      a.createdAt.localeCompare(b.createdAt)
+    );
+    return (def.sortOrder ?? 'newest') === 'newest'
+      ? byCreated.reverse()
+      : byCreated;
+  }, [notes, def.sortOrder]);
+
+  const closeComposer = React.useCallback(() => {
+    setComposer({ mode: 'closed' });
+    addButtonRef.current?.focus();
+  }, []);
+
+  const commitNotes = React.useCallback(
+    (next: NoteEntry[]) => {
+      onResponse({ ...response, notes: next });
+    },
+    [onResponse, response]
+  );
+
+  const saveNote = React.useCallback(
+    (markdown: string, attachments: AttachmentAnswer[]) => {
+      const now = new Date().toISOString();
+      if (composer.mode === 'edit') {
+        commitNotes(
+          notes.map((note) =>
+            note.id === composer.noteId
+              ? {
+                  ...note,
+                  markdown,
+                  updatedAt: now,
+                  attachments: attachments.length ? attachments : undefined,
+                }
+              : note
+          )
+        );
+      } else {
+        const entry: NoteEntry = {
+          id: crypto.randomUUID(),
+          createdAt: now,
+          markdown,
+          ...(identity?.name ? { author: identity.name } : {}),
+          ...(attachments.length ? { attachments } : {}),
+        };
+        commitNotes([...notes, entry]);
+      }
+      closeComposer();
+    },
+    [composer, notes, identity?.name, commitNotes, closeComposer]
+  );
+
+  const deleteNote = React.useCallback(
+    (noteId: string) => {
+      commitNotes(notes.filter((note) => note.id !== noteId));
+      setConfirmingDeleteId(null);
+    },
+    [notes, commitNotes]
+  );
+
+  const canModify = def.canModify ?? (() => true);
+  const canAdd =
+    !readOnly && (def.maxNotes === undefined || notes.length < def.maxNotes);
+  const editingNote =
+    composer.mode === 'edit'
+      ? notes.find((note) => note.id === composer.noteId)
+      : undefined;
+
+  const items: NoteCardItem[] = sortedNotes.map((note) => {
+    const modifiable = !readOnly && canModify(note);
+    return {
+      id: note.id,
+      title: note.author,
+      timestamp:
+        formatTimestamp(note.createdAt) +
+        (note.updatedAt
+          ? ` (edited ${formatTimestamp(note.updatedAt)})`
+          : ''),
+      body: renderMarkdownContent(note.markdown),
+      footer: note.attachments?.length ? (
+        <AttachmentChips attachments={note.attachments} />
+      ) : undefined,
+      actions: modifiable ? (
+        confirmingDeleteId === note.id ? (
+          <>
+            <span className="ms:text-xs ms:text-msdanger">Delete?</span>
+            <button
+              type="button"
+              className={`${buttonClass} ms:text-msdanger`}
+              onClick={() => deleteNote(note.id)}
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              className={buttonClass}
+              onClick={() => setConfirmingDeleteId(null)}
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              aria-label={`Edit ${entryLabel.toLowerCase()}`}
+              className="ms:p-1 ms:text-mstextmuted ms:hover:text-msprimary"
+              onClick={() => setComposer({ mode: 'edit', noteId: note.id })}
+            >
+              <PencilIcon className="ms:w-4 ms:h-4" />
+            </button>
+            <button
+              type="button"
+              aria-label={`Delete ${entryLabel.toLowerCase()}`}
+              className="ms:p-1 ms:text-mstextmuted ms:hover:text-msdanger"
+              onClick={() => setConfirmingDeleteId(note.id)}
+            >
+              <TrashIcon />
+            </button>
+          </>
+        )
+      ) : undefined,
+    };
+  });
+
+  if (isPreview) {
+    return (
+      <div className="notes-field-preview ms:flex ms:flex-col ms:gap-3 ms:pb-4">
+        <div className="ms:font-light ms:text-mstext ms:break-words">
+          {def.question || `${entryLabel}s`}
+          {(isRequired || isSoftRequired) && (
+            <span
+              className={`ms:ml-0.5 ${
+                isSoftRequired ? 'ms:text-mswarning' : 'ms:text-msdanger'
+              }`}
+            >
+              *
+            </span>
+          )}
+          {def.maxNotes !== undefined && (
+            <span className="ms:ml-2 ms:text-xs ms:text-mstextmuted">
+              ({notes.length}/{def.maxNotes})
+            </span>
+          )}
+        </div>
+
+        {canAdd && composer.mode === 'closed' && (
+          <div>
+            <button
+              ref={addButtonRef}
+              type="button"
+              className={primaryButtonClass}
+              onClick={() => setComposer({ mode: 'new' })}
+            >
+              Add {entryLabel.toLowerCase()}
+            </button>
+          </div>
+        )}
+
+        {composer.mode !== 'closed' && (
+          <NoteComposer
+            def={def}
+            instanceId={instanceId}
+            entryLabel={entryLabel}
+            initialMarkdown={editingNote?.markdown ?? ''}
+            initialAttachments={editingNote?.attachments ?? []}
+            onSave={saveNote}
+            onCancel={closeComposer}
+          />
+        )}
+
+        <NoteCardList
+          items={items}
+          emptyLabel={`No ${entryLabel.toLowerCase()}s yet`}
+          ariaLabel={def.question || `${entryLabel} entries`}
+        />
+      </div>
+    );
+  }
+
+  // Builder mode — property editing
+  return (
+    <div className="notes-field-edit ms:space-y-3">
+      <div>
+        <label
+          htmlFor={`${instanceId}-canvas-question-${def.id}`}
+          className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+        >
+          Question
+        </label>
+        <input
+          id={`${instanceId}-canvas-question-${def.id}`}
+          type="text"
+          value={def.question || ''}
+          onChange={(e) => onUpdate({ question: e.target.value })}
+          placeholder="Enter question"
+          className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+        />
+      </div>
+
+      <div className="ms:grid ms:grid-cols-2 ms:gap-3">
+        <div>
+          <label
+            htmlFor={`${instanceId}-notes-entry-label-${def.id}`}
+            className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+          >
+            Entry label
+          </label>
+          <input
+            id={`${instanceId}-notes-entry-label-${def.id}`}
+            type="text"
+            value={def.entryLabel ?? 'Note'}
+            onChange={(e) => onUpdate({ entryLabel: e.target.value })}
+            className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor={`${instanceId}-notes-sort-order-${def.id}`}
+            className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+          >
+            Sort order
+          </label>
+          <select
+            id={`${instanceId}-notes-sort-order-${def.id}`}
+            value={def.sortOrder ?? 'newest'}
+            onChange={(e) => onUpdate({ sortOrder: e.target.value })}
+            className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor={`${instanceId}-notes-max-notes-${def.id}`}
+            className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+          >
+            Max entries
+          </label>
+          <input
+            id={`${instanceId}-notes-max-notes-${def.id}`}
+            type="number"
+            min={1}
+            value={def.maxNotes ?? ''}
+            onChange={(e) =>
+              onUpdate({
+                maxNotes: e.target.value ? Number(e.target.value) : undefined,
+              })
+            }
+            placeholder="Unlimited"
+            className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+          />
+        </div>
+        <div className="ms:flex ms:items-end ms:pb-2">
+          <label className="ms:flex ms:items-center ms:gap-2 ms:text-sm ms:text-mstext">
+            <input
+              type="checkbox"
+              checked={def.allowAttachments ?? false}
+              onChange={(e) => onUpdate({ allowAttachments: e.target.checked })}
+            />
+            Allow attachments
+          </label>
+        </div>
+      </div>
+
+      {def.allowAttachments && (
+        <div className="ms:grid ms:grid-cols-3 ms:gap-3">
+          <div>
+            <label
+              htmlFor={`${instanceId}-notes-accept-${def.id}`}
+              className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+            >
+              Accepted types
+            </label>
+            <input
+              id={`${instanceId}-notes-accept-${def.id}`}
+              type="text"
+              value={def.accept ?? ''}
+              onChange={(e) =>
+                onUpdate({ accept: e.target.value || undefined })
+              }
+              placeholder="image/*,.pdf"
+              className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={`${instanceId}-notes-max-file-size-${def.id}`}
+              className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+            >
+              Max file size (bytes)
+            </label>
+            <input
+              id={`${instanceId}-notes-max-file-size-${def.id}`}
+              type="number"
+              min={1}
+              value={def.maxFileSize ?? ''}
+              onChange={(e) =>
+                onUpdate({
+                  maxFileSize: e.target.value
+                    ? Number(e.target.value)
+                    : undefined,
+                })
+              }
+              placeholder="Unlimited"
+              className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={`${instanceId}-notes-max-attachments-${def.id}`}
+              className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+            >
+              Max attachments per entry
+            </label>
+            <input
+              id={`${instanceId}-notes-max-attachments-${def.id}`}
+              type="number"
+              min={1}
+              value={def.maxAttachments ?? ''}
+              onChange={(e) =>
+                onUpdate({
+                  maxAttachments: e.target.value
+                    ? Number(e.target.value)
+                    : undefined,
+                })
+              }
+              placeholder="Unlimited"
+              className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/fields/src/fields/rich/index.ts
+++ b/packages/fields/src/fields/rich/index.ts
@@ -11,6 +11,7 @@ export { DiagramField } from './DiagramField.js';
 export { DisplayField } from './DisplayField.js';
 export { FileField } from './FileField.js';
 export { NotesField } from './NotesField.js';
+export { ActivityField } from './ActivityField.js';
 export { NoteCardList } from './NoteCardList.js';
 export type { NoteCardItem, NoteCardListProps } from './NoteCardList.js';
 export { HtmlField } from './HtmlField.js';

--- a/packages/fields/src/fields/rich/index.ts
+++ b/packages/fields/src/fields/rich/index.ts
@@ -10,6 +10,9 @@ export type {
 export { DiagramField } from './DiagramField.js';
 export { DisplayField } from './DisplayField.js';
 export { FileField } from './FileField.js';
+export { NotesField } from './NotesField.js';
+export { NoteCardList } from './NoteCardList.js';
+export type { NoteCardItem, NoteCardListProps } from './NoteCardList.js';
 export { HtmlField } from './HtmlField.js';
 export { ImageField } from './ImageField.js';
 export { SignatureField } from './SignatureField.js';

--- a/packages/fields/src/icons.tsx
+++ b/packages/fields/src/icons.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Clipboard, Folder, Info, Minus, Plus } from 'lucide-react';
+import { Clipboard, Folder, Info, Minus, Pencil, Plus } from 'lucide-react';
 
 type IconProps = { className?: string };
 
@@ -33,6 +33,7 @@ export const TrashIcon = React.memo(
 
 export const PlusIcon = Plus;
 export const MinusIcon = Minus;
+export const PencilIcon = Pencil;
 
 export const ArrowUpIcon = React.memo(
   ({ className = '' }: IconProps) => (

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -111,11 +111,18 @@ export {
   type FieldProviderStackProps,
 } from './lib/FieldProviders.js';
 
-// Shared markdown-lite rendering
+// Optional host-supplied attachment byte storage
 export {
-  renderMarkdownContent,
-  renderMarkdownInline,
-} from './lib/markdown.js';
+  AttachmentManagerProvider,
+  createAttachmentManagerProvider,
+  useAttachmentManager,
+  storeAttachments,
+  removeUnreferenced,
+  type AttachmentManagerProviderProps,
+} from './lib/AttachmentManagerProvider.js';
+
+// Shared markdown-lite rendering
+export { renderMarkdownContent, renderMarkdownInline } from './lib/markdown.js';
 
 // Shared file/attachment helpers
 export {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -97,3 +97,10 @@ export {
   useFieldGridLayout,
 } from './lib/FieldGrid.js';
 export type { FieldGridItemProps, FieldGridProps } from './lib/FieldGrid.js';
+
+// Optional field extension providers
+export {
+  FieldProviderStack,
+  type FieldProvider,
+  type FieldProviderStackProps,
+} from './lib/FieldProviders.js';

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -45,6 +45,7 @@ export {
   SignatureField,
   FileField,
   NotesField,
+  ActivityField,
   NoteCardList,
 } from './fields/index.js';
 export type {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -123,3 +123,12 @@ export {
   fileMatchesAccept,
   readFileAsAttachment,
 } from './lib/file-utils.js';
+
+// Pluggable notes composer (rich markdown editors, e.g. @esheet/field-kerebron)
+export {
+  registerNotesComposer,
+  getNotesComposer,
+  // NOTE: resetNotesComposer intentionally not exported - internal/test-only
+  type NotesComposerProps,
+  type NotesComposerComponent,
+} from './lib/notes-composer.js';

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -10,6 +10,7 @@ export {
   TrashIcon,
   PlusIcon,
   MinusIcon,
+  PencilIcon,
   ArrowUpIcon,
   ArrowDownIcon,
   UpDownArrowIcon,
@@ -43,12 +44,16 @@ export {
   ImageField,
   SignatureField,
   FileField,
+  NotesField,
+  NoteCardList,
 } from './fields/index.js';
 export type {
   DrawingData,
   DrawingPadConfig,
   DrawingPadPayload,
   NormalizedPoint,
+  NoteCardItem,
+  NoteCardListProps,
   Stroke,
 } from './fields/index.js';
 
@@ -104,3 +109,16 @@ export {
   type FieldProvider,
   type FieldProviderStackProps,
 } from './lib/FieldProviders.js';
+
+// Shared markdown-lite rendering
+export {
+  renderMarkdownContent,
+  renderMarkdownInline,
+} from './lib/markdown.js';
+
+// Shared file/attachment helpers
+export {
+  formatFileSize,
+  fileMatchesAccept,
+  readFileAsAttachment,
+} from './lib/file-utils.js';

--- a/packages/fields/src/lib/AttachmentManagerProvider.tsx
+++ b/packages/fields/src/lib/AttachmentManagerProvider.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import type { AttachmentAnswer, AttachmentManager } from '@esheet/core';
+import type { FieldProvider } from './FieldProviders.js';
+
+// ---------------------------------------------------------------------------
+// AttachmentManagerProvider — delivers the host's byte storage to the fields.
+// ---------------------------------------------------------------------------
+
+const AttachmentManagerContext = React.createContext<
+  AttachmentManager | undefined
+>(undefined);
+
+export interface AttachmentManagerProviderProps {
+  readonly manager: AttachmentManager;
+  readonly children: React.ReactNode;
+}
+
+export function AttachmentManagerProvider({
+  manager,
+  children,
+}: AttachmentManagerProviderProps): React.JSX.Element {
+  return (
+    <AttachmentManagerContext.Provider value={manager}>
+      {children}
+    </AttachmentManagerContext.Provider>
+  );
+}
+
+/** Wraps a manager as a `fieldProviders` entry for the renderer. */
+export function createAttachmentManagerProvider(
+  manager: AttachmentManager
+): FieldProvider {
+  return (children) => (
+    <AttachmentManagerProvider manager={manager}>
+      {children}
+    </AttachmentManagerProvider>
+  );
+}
+
+/** The host's attachment storage, or `undefined` when it keeps bytes inline. */
+export function useAttachmentManager(): AttachmentManager | undefined {
+  return React.useContext(AttachmentManagerContext);
+}
+
+/**
+ * `store` through the manager when there is one, unchanged when there is not —
+ * the shape every field's upload path wants.
+ */
+export async function storeAttachments(
+  manager: AttachmentManager | undefined,
+  attachments: readonly AttachmentAnswer[]
+): Promise<AttachmentAnswer[]> {
+  if (!manager) return [...attachments];
+  return Promise.all(
+    attachments.map((attachment) => manager.store(attachment))
+  );
+}
+
+/** Identity of a stored attachment: everything the host wrote, minus the bytes. */
+function referenceKey({
+  dataUrl: _dataUrl,
+  ...rest
+}: AttachmentAnswer): string {
+  return JSON.stringify(rest);
+}
+
+/**
+ * Hands back what the next response drops. Two uploads of the same bytes
+ * usually store to the same reference, so what is compared is the reference,
+ * not the array slot — removing one copy must not delete the other's bytes.
+ *
+ * Best effort: a field must not fail its own edit because storage did.
+ */
+export function removeUnreferenced(
+  manager: AttachmentManager | undefined,
+  before: readonly AttachmentAnswer[],
+  after: readonly AttachmentAnswer[]
+): void {
+  if (!manager) return;
+  const kept = new Set(after.map(referenceKey));
+  for (const attachment of before) {
+    if (kept.has(referenceKey(attachment))) continue;
+    void manager.remove(attachment).catch(() => undefined);
+  }
+}

--- a/packages/fields/src/lib/FieldProviders.spec.tsx
+++ b/packages/fields/src/lib/FieldProviders.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FieldProviderStack } from './FieldProviders.js';
+
+describe('FieldProviderStack', () => {
+  it('composes optional providers around the shared render tree', () => {
+    const firstProvider = vi.fn((children: ReactNode) => (
+      <div data-testid="first-provider">{children}</div>
+    ));
+    const secondProvider = vi.fn((children: ReactNode) => (
+      <div data-testid="second-provider">{children}</div>
+    ));
+
+    render(
+      <FieldProviderStack providers={[firstProvider, secondProvider]}>
+        <output>content</output>
+      </FieldProviderStack>
+    );
+
+    expect(screen.getByText('content')).toBeTruthy();
+    expect(
+      within(screen.getByTestId('first-provider')).getByTestId(
+        'second-provider'
+      )
+    ).toBeTruthy();
+    expect(firstProvider).toHaveBeenCalledOnce();
+    expect(secondProvider).toHaveBeenCalledOnce();
+  });
+
+  it('renders the shared tree when no providers are supplied', () => {
+    render(
+      <FieldProviderStack>
+        <output>content</output>
+      </FieldProviderStack>
+    );
+
+    expect(screen.getByText('content')).toBeTruthy();
+  });
+});

--- a/packages/fields/src/lib/FieldProviders.tsx
+++ b/packages/fields/src/lib/FieldProviders.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export type FieldProvider = (children: React.ReactNode) => React.ReactNode;
+
+export interface FieldProviderStackProps {
+  providers?: readonly FieldProvider[];
+  children: React.ReactNode;
+}
+
+export function FieldProviderStack({
+  providers = [],
+  children,
+}: FieldProviderStackProps): React.JSX.Element {
+  let content = children;
+  for (let index = providers.length - 1; index >= 0; index -= 1) {
+    content = providers[index](content);
+  }
+
+  return <>{content}</>;
+}

--- a/packages/fields/src/lib/file-utils.ts
+++ b/packages/fields/src/lib/file-utils.ts
@@ -1,0 +1,42 @@
+import type { AttachmentAnswer } from '@esheet/core';
+
+// ---------------------------------------------------------------------------
+// Shared file/attachment helpers — used by FileField and NotesField.
+// ---------------------------------------------------------------------------
+
+/** Human-readable file size (e.g. `1.5 MB`). */
+export const formatFileSize = (bytes: number): string => {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
+};
+
+/** Match a file against an `accept` string (MIME types, wildcards, extensions). */
+export const fileMatchesAccept = (file: File, accept?: string): boolean => {
+  if (!accept) return true;
+  const parts = accept.split(',').map((s) => s.trim());
+  if (parts.length === 0) return true;
+  return parts.some((part) => {
+    if (part.startsWith('.'))
+      return file.name.toLowerCase().endsWith(part.toLowerCase());
+    if (part.endsWith('/*')) return file.type.startsWith(part.slice(0, -1));
+    return file.type === part;
+  });
+};
+
+/** Read a File into the AttachmentAnswer shape (dataUrl-based). */
+export const readFileAsAttachment = (file: File): Promise<AttachmentAnswer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () =>
+      resolve({
+        contentType: file.type || 'application/octet-stream',
+        dataUrl: reader.result as string,
+        title: file.name,
+        size: file.size,
+      });
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });

--- a/packages/fields/src/lib/markdown.tsx
+++ b/packages/fields/src/lib/markdown.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Shared markdown-lite rendering pipeline.
+//
+// Used by DisplayField (after expression interpolation) and NotesField (raw
+// note bodies). Renders inline markdown with recursive nesting so formats can
+// combine. Syntax: *bold*, -italic-, _underline_, ~strike~, `#`..`######`
+// headings, bullets with `- ` at line start.
+// ---------------------------------------------------------------------------
+
+function renderInlineNode(text: string, key: string): React.ReactNode {
+  // Bold — *text* (single asterisk)
+  const bold = text.match(/^(.*?)\*([^*]+)\*(.*)$/s);
+  if (bold) {
+    return (
+      <React.Fragment key={key}>
+        {bold[1] && renderInlineNode(bold[1], `${key}a`)}
+        <strong>{renderInlineNode(bold[2], `${key}b`)}</strong>
+        {bold[3] && renderInlineNode(bold[3], `${key}c`)}
+      </React.Fragment>
+    );
+  }
+  // Italic — -text- (no leading/trailing space to avoid conflicting with bullet `- `).
+  // Digit-flanked hyphens are skipped so ISO dates (2026-01-31), ranges, and
+  // negative numbers from computed expressions are not mangled into <em>.
+  const italic = text.match(
+    /^(.*?)(?<!\d)-([^\s-][^-]*[^\s-]|[^\s-])-(?!\d)(.*)$/s
+  );
+  if (italic) {
+    return (
+      <React.Fragment key={key}>
+        {italic[1] && renderInlineNode(italic[1], `${key}a`)}
+        <em>{renderInlineNode(italic[2], `${key}b`)}</em>
+        {italic[3] && renderInlineNode(italic[3], `${key}c`)}
+      </React.Fragment>
+    );
+  }
+  // Underline — _text_ (single underscore)
+  const under = text.match(/^(.*?)_([^_]+)_(.*)$/s);
+  if (under) {
+    return (
+      <React.Fragment key={key}>
+        {under[1] && renderInlineNode(under[1], `${key}a`)}
+        <span className="ms:underline">
+          {renderInlineNode(under[2], `${key}b`)}
+        </span>
+        {under[3] && renderInlineNode(under[3], `${key}c`)}
+      </React.Fragment>
+    );
+  }
+  // Strikethrough — ~text~
+  const strike = text.match(/^(.*?)~(.+?)~(.*)$/s);
+  if (strike) {
+    return (
+      <React.Fragment key={key}>
+        {strike[1] && renderInlineNode(strike[1], `${key}a`)}
+        <span className="ms:line-through">
+          {renderInlineNode(strike[2], `${key}b`)}
+        </span>
+        {strike[3] && renderInlineNode(strike[3], `${key}c`)}
+      </React.Fragment>
+    );
+  }
+  return <React.Fragment key={key}>{text}</React.Fragment>;
+}
+
+/** Render one line of inline markdown (no block structure). */
+export function renderMarkdownInline(text: string): React.ReactNode[] {
+  if (!text) return [];
+  return [renderInlineNode(text, 'r')];
+}
+
+/** Render a block of markdown-lite content (headings, bullets, paragraphs). */
+export function renderMarkdownContent(content: string): React.ReactNode {
+  const lines = content.split(/\r?\n/);
+  const blocks: React.ReactNode[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (!line.trim()) {
+      blocks.push(<div key={`sp-${i}`} className="ms:h-3" />);
+      i += 1;
+      continue;
+    }
+
+    if (/^-\s+/.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^-\s+/.test(lines[i])) {
+        items.push(
+          <li key={`li-${i}`} className="ms:ml-4 ms:list-disc">
+            {renderMarkdownInline(lines[i].replace(/^-\s+/, ''))}
+          </li>
+        );
+        i += 1;
+      }
+      blocks.push(
+        <ul key={`ul-${i}`} className="ms:my-2">
+          {items}
+        </ul>
+      );
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      const level = heading[1].length;
+      const text = heading[2];
+      const headingClass =
+        level === 1
+          ? 'ms:text-2xl ms:font-semibold'
+          : level === 2
+          ? 'ms:text-xl ms:font-semibold'
+          : level === 3
+          ? 'ms:text-lg ms:font-semibold'
+          : 'ms:text-base ms:font-semibold';
+      blocks.push(
+        <div key={`h-${i}`} className={`ms:my-1 ${headingClass}`}>
+          {renderMarkdownInline(text)}
+        </div>
+      );
+      i += 1;
+      continue;
+    }
+
+    blocks.push(
+      <p key={`p-${i}`} className="ms:my-1 ms:leading-relaxed">
+        {renderMarkdownInline(line)}
+      </p>
+    );
+    i += 1;
+  }
+
+  return <>{blocks}</>;
+}

--- a/packages/fields/src/lib/notes-composer.ts
+++ b/packages/fields/src/lib/notes-composer.ts
@@ -1,0 +1,38 @@
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Pluggable notes composer — hosts may replace NotesField's default textarea
+// (Write/Preview tabs) with a rich markdown editor, e.g. Kerebron via
+// @esheet/field-kerebron's KerebronNotesComposer. Markdown stays the storage
+// format either way.
+// ---------------------------------------------------------------------------
+
+export interface NotesComposerProps {
+  /** Current markdown value. Loaded once on mount; the composer owns edits. */
+  value: string;
+  /** Fired (may be debounced by the composer) with the markdown text. */
+  onChange: (markdown: string) => void;
+  /** Accessible label for the editing surface. */
+  ariaLabel: string;
+  /** Placeholder shown when empty (composers may ignore it). */
+  placeholder?: string;
+}
+
+export type NotesComposerComponent = React.ComponentType<NotesComposerProps>;
+
+let composer: NotesComposerComponent | undefined;
+
+/** Replace the default textarea composer in NotesField (app-wide). */
+export function registerNotesComposer(component: NotesComposerComponent): void {
+  composer = component;
+}
+
+/** The registered composer, or undefined for the built-in textarea. */
+export function getNotesComposer(): NotesComposerComponent | undefined {
+  return composer;
+}
+
+/** Reset to the built-in textarea (internal/test-only). */
+export function resetNotesComposer(): void {
+  composer = undefined;
+}

--- a/packages/fields/src/lib/touch-mode/touch-mode.css
+++ b/packages/fields/src/lib/touch-mode/touch-mode.css
@@ -146,8 +146,9 @@
     line-height: 1.4 !important;
   }
 
-  /* Note: buttons are NOT touched in builder to avoid affecting UI buttons */
-  .esheet-renderer-root:not(.touch-mode-disabled) button {
+  /* Note: buttons are NOT touched in builder to avoid affecting UI buttons.
+     [data-slot] buttons come from @mieweb/ui and size themselves. */
+  .esheet-renderer-root:not(.touch-mode-disabled) button:not([data-slot]) {
     min-height: 44px !important;
     font-size: 1rem !important;
   }
@@ -258,8 +259,9 @@
   line-height: 1.4 !important;
 }
 
-/* Note: buttons are NOT touched in builder to avoid affecting UI buttons */
-.esheet-renderer-root.esheet-touch-active button {
+/* Note: buttons are NOT touched in builder to avoid affecting UI buttons.
+   [data-slot] buttons come from @mieweb/ui and size themselves. */
+.esheet-renderer-root.esheet-touch-active button:not([data-slot]) {
   min-height: 44px !important;
   font-size: 1rem !important;
 }

--- a/packages/renderer-blaze/src/index.tsx
+++ b/packages/renderer-blaze/src/index.tsx
@@ -6,6 +6,11 @@ import {
   type EsheetRendererProps,
 } from '@esheet/renderer';
 
+export interface BlazeRendererOptions {
+  /** Optional wrappers supplied by field add-ons. */
+  fieldProviders?: EsheetRendererProps['fieldProviders'];
+}
+
 type UnknownRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is UnknownRecord {
@@ -54,7 +59,8 @@ function toRendererProps(data: unknown): EsheetRendererProps {
 }
 
 export function registerBlazeTemplate(
-  templateName = 'esheetRenderer'
+  templateName = 'esheetRenderer',
+  options: BlazeRendererOptions = {}
 ): boolean {
   const globals = globalThis as UnknownRecord;
   const templateApi = globals.Template;
@@ -108,7 +114,11 @@ export function registerBlazeTemplate(
       const data = isFunction(currentData) ? currentData() : undefined;
       const props = toRendererProps(data);
       root.render(
-        React.createElement(EsheetRenderer, { ...props, ref: rendererRef })
+        React.createElement(EsheetRenderer, {
+          ...props,
+          fieldProviders: options.fieldProviders,
+          ref: rendererRef,
+        })
       );
     };
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -7,6 +7,7 @@ export {
   type GetResponseResult,
   type ResponseFormat,
 } from './lib/EsheetRenderer.js';
+export type { FieldProvider } from '@esheet/fields';
 
 // Render tree builder (for computing setValue values in builder)
 export {

--- a/packages/renderer/src/lib/EsheetRenderer.spec.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.spec.tsx
@@ -17,6 +17,61 @@ function getRendererHandle(ref: React.RefObject<EsheetRendererHandle | null>) {
 }
 
 describe('EsheetRenderer', () => {
+  it('stamps notes authorship from the identity prop', () => {
+    const ref = React.createRef<EsheetRendererHandle>();
+    const notesForm = {
+      id: 'identity-form',
+      pages: [
+        {
+          id: 'page-1',
+          fields: [{ id: 'journal', fieldType: 'notes' }],
+        },
+      ],
+    };
+    const { getByRole } = render(
+      <EsheetRenderer
+        formDataInput={notesForm}
+        identity={{ name: 'Dr. Demo' }}
+        ref={ref}
+      />
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Add note' }));
+    fireEvent.change(getByRole('textbox', { name: 'Note text' }), {
+      target: { value: 'Stamped note' },
+    });
+    fireEvent.click(getByRole('button', { name: 'Save' }));
+
+    const notes = getRendererHandle(ref).getRawResponse()['journal']?.notes;
+    expect(notes).toHaveLength(1);
+    expect(notes?.[0].author).toBe('Dr. Demo');
+  });
+
+  it('saves notes unstamped when no identity is provided', () => {
+    const ref = React.createRef<EsheetRendererHandle>();
+    const { getByRole } = render(
+      <EsheetRenderer
+        formDataInput={{
+          id: 'no-identity-form',
+          pages: [
+            { id: 'page-1', fields: [{ id: 'journal', fieldType: 'notes' }] },
+          ],
+        }}
+        ref={ref}
+      />
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Add note' }));
+    fireEvent.change(getByRole('textbox', { name: 'Note text' }), {
+      target: { value: 'Anonymous note' },
+    });
+    fireEvent.click(getByRole('button', { name: 'Save' }));
+
+    const notes = getRendererHandle(ref).getRawResponse()['journal']?.notes;
+    expect(notes?.[0].author).toBeUndefined();
+    expect(notes?.[0].markdown).toBe('Anonymous note');
+  });
+
   it('uses builder row widths to lay fields out on a six-column grid', async () => {
     const { container } = render(
       <EsheetRenderer

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -20,10 +20,12 @@ import {
 import { createRendererTools, type RendererTools } from './renderer-tools.js';
 import {
   FormStoreContext,
+  FieldProviderStack,
   UIContext,
   ZodIssuesPanel,
   FeedbackModal,
   useTouchMode,
+  type FieldProvider,
 } from '@esheet/fields';
 import { ensureDefaultFieldComponentsRegistered } from './register-defaults.js';
 import { useRendererInit } from './hooks/useRendererInit.js';
@@ -93,6 +95,8 @@ export interface EsheetRendererProps {
   bottomNavigation?: boolean;
   /** Block forward page navigation while required fields on the current page are unanswered. */
   validateNavigation?: boolean;
+  /** Optional wrappers supplied by field add-ons. */
+  fieldProviders?: readonly FieldProvider[];
 }
 
 // ---------------------------------------------------------------------------
@@ -203,12 +207,14 @@ export const EsheetRenderer = React.forwardRef<
   return (
     <FormStoreContext.Provider value={formStore}>
       <UIContext.Provider value={uiStore}>
-        <EsheetRendererInner
-          {...props}
-          formStore={formStore}
-          uiStore={uiStore}
-          ref={ref}
-        />
+        <FieldProviderStack providers={props.fieldProviders}>
+          <EsheetRendererInner
+            {...props}
+            formStore={formStore}
+            uiStore={uiStore}
+            ref={ref}
+          />
+        </FieldProviderStack>
       </UIContext.Provider>
     </FormStoreContext.Provider>
   );

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -97,6 +97,12 @@ export interface EsheetRendererProps {
   validateNavigation?: boolean;
   /** Optional wrappers supplied by field add-ons. */
   fieldProviders?: readonly FieldProvider[];
+  /**
+   * Identity of the current user. When provided, fields that record
+   * authorship (e.g. `notes`) stamp new entries with `identity.name`.
+   * Absent → entries save unstamped.
+   */
+  identity?: { name: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -248,6 +254,7 @@ const EsheetRendererInner = React.forwardRef<
     topNavigation = false,
     bottomNavigation = true,
     validateNavigation = true,
+    identity,
   },
   ref
 ) {
@@ -255,6 +262,11 @@ const EsheetRendererInner = React.forwardRef<
   const [softBypassOpen, setSoftBypassOpen] = React.useState(false);
   const [pendingResponse, setPendingResponse] =
     React.useState<FormResponse | null>(null);
+
+  // Keep the host-supplied identity in the form store (stamps notes authorship).
+  React.useEffect(() => {
+    formStore.getState().setIdentity(identity);
+  }, [formStore, identity]);
 
   const handleSubmitClick = () => {
     const state = formStore.getState();

--- a/packages/renderer/src/lib/EsheetRenderer.tsx
+++ b/packages/renderer/src/lib/EsheetRenderer.tsx
@@ -169,6 +169,8 @@ export interface EsheetRendererHandle {
   setTouchMode: (enabled: boolean) => void;
   /** Reset to auto-detection mode (clears manual override). Only works when touchMode='auto'. */
   resetTouchMode: () => void;
+  /** Show the page with this id. Returns `false` when the form has no such page. */
+  goToPage: (pageId: string) => boolean;
 }
 
 /**
@@ -307,6 +309,14 @@ const EsheetRendererInner = React.forwardRef<
   );
 
   // Expose ref API
+  const goToPageRef = React.useRef<((pageId: string) => boolean) | null>(null);
+  const registerGoToPage = React.useCallback(
+    (goToPage: (pageId: string) => boolean) => {
+      goToPageRef.current = goToPage;
+    },
+    []
+  );
+
   React.useImperativeHandle(
     ref,
     () => ({
@@ -366,6 +376,7 @@ const EsheetRendererInner = React.forwardRef<
       isTouchModeEnabled: () => isTouchEnabled,
       setTouchMode: setTouchModeInternal,
       resetTouchMode: resetTouchModeInternal,
+      goToPage: (pageId: string) => goToPageRef.current?.(pageId) ?? false,
     }),
     [
       formStore,
@@ -407,6 +418,7 @@ const EsheetRendererInner = React.forwardRef<
         topNavigation={topNavigation}
         bottomNavigation={bottomNavigation}
         validateNavigation={validateNavigation}
+        registerGoToPage={registerGoToPage}
       />
       {onSubmit && (
         <div className="renderer-submit ms:mt-6 ms:flex ms:justify-end">

--- a/packages/renderer/src/lib/components/FieldNode.tsx
+++ b/packages/renderer/src/lib/components/FieldNode.tsx
@@ -216,9 +216,10 @@ export const FieldNode = React.memo(function FieldNode({
     : null;
   const isChildOfSection = parentNode?.definition.fieldType === 'section';
 
-  const wrapperClass = `field-wrapper${isChildOfSection ? ' ms:py-1' : ''}${
-    !isEnabled ? ' ms:opacity-50 ms:pointer-events-none' : ''
-  }`;
+  // Positioned so the absolutely placed presence dots land on the field.
+  const wrapperClass = `field-wrapper ms:relative${
+    isChildOfSection ? ' ms:py-1' : ''
+  }${!isEnabled ? ' ms:opacity-50 ms:pointer-events-none' : ''}`;
 
   const fieldLabel = field.definition.question || field.definition.id;
 
@@ -241,12 +242,18 @@ export const FieldNode = React.memo(function FieldNode({
             role="img"
             aria-label={presence.map((peer) => peer.name).join(', ')}
           >
-            {presence.map((peer) => (
+            {presence.map((peer, index) => (
+              // Two windows of one person share a name, so the name is no key.
               <span
-                key={peer.name}
+                key={`${peer.name}-${index}`}
                 title={peer.name}
-                className="ms:inline-block ms:w-2.5 ms:h-2.5 ms:rounded-full ms:border ms:border-mssurface"
-                style={{ backgroundColor: peer.color }}
+                className="ms:inline-block ms:rounded-full ms:border ms:border-mssurface"
+                // Sized inline: a host may load only the fields stylesheet.
+                style={{
+                  backgroundColor: peer.color,
+                  width: '0.625rem',
+                  height: '0.625rem',
+                }}
               />
             ))}
           </div>

--- a/packages/renderer/src/lib/components/RendererBody.tsx
+++ b/packages/renderer/src/lib/components/RendererBody.tsx
@@ -14,6 +14,8 @@ export interface RendererBodyProps {
   bottomNavigation?: boolean;
   /** Block forward navigation when required fields on the current page are unanswered. */
   validateNavigation?: boolean;
+  /** Hands the host a way to jump to a page by id; `false` when there is no such page. */
+  registerGoToPage?: (goToPage: (pageId: string) => boolean) => void;
 }
 
 /**
@@ -29,6 +31,7 @@ export function RendererBody({
   topNavigation = false,
   bottomNavigation = true,
   validateNavigation = true,
+  registerGoToPage,
 }: RendererBodyProps) {
   const normalized = React.useSyncExternalStore(
     (cb) => form.subscribe(cb),
@@ -50,6 +53,15 @@ export function RendererBody({
       setCurrentPagesIdx(pages.length - 1);
     }
   }, [pages.length, currentPagesIdx]);
+
+  React.useEffect(() => {
+    registerGoToPage?.((pageId) => {
+      const index = pages.findIndex((page) => page.id === pageId);
+      if (index < 0) return false;
+      setCurrentPagesIdx(index);
+      return true;
+    });
+  }, [pages, registerGoToPage]);
 
   const isMultiPage = pages.length > 1;
   const hasPageNavigation = topNavigation || bottomNavigation;

--- a/packages/renderer/src/lib/register-defaults.ts
+++ b/packages/renderer/src/lib/register-defaults.ts
@@ -29,6 +29,7 @@ import {
   DisplayField,
   FileField,
   NotesField,
+  ActivityField,
 } from '@esheet/fields';
 
 let defaultsRegistered = false;
@@ -59,6 +60,7 @@ export function ensureDefaultFieldComponentsRegistered(): void {
     image: ImageField,
     file: FileField,
     notes: NotesField,
+    activity: ActivityField,
     html: HtmlField,
     display: DisplayField,
   });

--- a/packages/renderer/src/lib/register-defaults.ts
+++ b/packages/renderer/src/lib/register-defaults.ts
@@ -28,6 +28,7 @@ import {
   HtmlField,
   DisplayField,
   FileField,
+  NotesField,
 } from '@esheet/fields';
 
 let defaultsRegistered = false;
@@ -57,6 +58,7 @@ export function ensureDefaultFieldComponentsRegistered(): void {
     diagram: DiagramField,
     image: ImageField,
     file: FileField,
+    notes: NotesField,
     html: HtmlField,
     display: DisplayField,
   });

--- a/patches/@kerebron__extension-menu@0.8.10.patch
+++ b/patches/@kerebron__extension-menu@0.8.10.patch
@@ -1,0 +1,62 @@
+diff --git a/esm/CustomMenuPlugin.js b/esm/CustomMenuPlugin.js
+index d630c6893dd77f148ca72cf2b137364bbce3830c..eb0767f52e9654c915d606fdd330b7c942daa8d3 100644
+--- a/esm/CustomMenuPlugin.js
++++ b/esm/CustomMenuPlugin.js
+@@ -622,7 +622,7 @@ export class CustomMenuView {
+                         const mousedownEvent = new MouseEvent('mousedown', {
+                             bubbles: true,
+                             cancelable: true,
+-                            view: dntShim.dntGlobalThis,
++                            view: this.editorView.dom.ownerDocument.defaultView,
+                         });
+                         dom.dispatchEvent(mousedownEvent);
+                     }
+@@ -759,7 +759,7 @@ export class CustomMenuView {
+                             const mousedownEvent = new MouseEvent('mousedown', {
+                                 bubbles: true,
+                                 cancelable: true,
+-                                view: dntShim.dntGlobalThis,
++                                view: this.editorView.dom.ownerDocument.defaultView,
+                             });
+                             dom.dispatchEvent(mousedownEvent);
+                         }
+@@ -771,7 +771,7 @@ export class CustomMenuView {
+                             const mousedownEvent = new MouseEvent('mousedown', {
+                                 bubbles: true,
+                                 cancelable: true,
+-                                view: dntShim.dntGlobalThis,
++                                view: this.editorView.dom.ownerDocument.defaultView,
+                             });
+                             dom.dispatchEvent(mousedownEvent);
+                         }
+diff --git a/src/CustomMenuPlugin.ts b/src/CustomMenuPlugin.ts
+index bddaf1c8de850ef407ca40d5fadcc1ac71a8dca7..3ae2e52d0b27d98fb0f3d87decf24f1de3f28a86 100644
+--- a/src/CustomMenuPlugin.ts
++++ b/src/CustomMenuPlugin.ts
+@@ -742,7 +742,7 @@ export class CustomMenuView {
+             const mousedownEvent = new MouseEvent('mousedown', {
+               bubbles: true,
+               cancelable: true,
+-              view: dntShim.dntGlobalThis,
++              view: this.editorView.dom.ownerDocument.defaultView,
+             });
+             dom.dispatchEvent(mousedownEvent);
+           }
+@@ -905,7 +905,7 @@ export class CustomMenuView {
+               const mousedownEvent = new MouseEvent('mousedown', {
+                 bubbles: true,
+                 cancelable: true,
+-                view: dntShim.dntGlobalThis,
++                view: this.editorView.dom.ownerDocument.defaultView,
+               });
+               dom.dispatchEvent(mousedownEvent);
+             }
+@@ -918,7 +918,7 @@ export class CustomMenuView {
+               const mousedownEvent = new MouseEvent('mousedown', {
+                 bubbles: true,
+                 cancelable: true,
+-                view: dntShim.dntGlobalThis,
++                view: this.editorView.dom.ownerDocument.defaultView,
+               });
+               dom.dispatchEvent(mousedownEvent);
+             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     dependencies:
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -161,6 +161,9 @@ importers:
       '@esheet/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@esheet/document-list-field':
+        specifier: workspace:*
+        version: link:../../packages/document-list-field
       '@esheet/field-health':
         specifier: workspace:*
         version: link:../../packages/field-health
@@ -178,7 +181,7 @@ importers:
         version: 0.8.9
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3
@@ -262,7 +265,7 @@ importers:
         version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -280,7 +283,7 @@ importers:
         version: 2.8.1
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.18)(react@19.2.8)
+        version: 5.0.14(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       '@tailwindcss/cli':
         specifier: ^4.3.3
@@ -317,11 +320,47 @@ importers:
         version: 4.4.3
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.18)(react@19.2.8)
+        version: 5.0.14(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+
+  packages/document-list-field:
+    dependencies:
+      '@esheet/core':
+        specifier: workspace:*
+        version: link:../core
+      '@esheet/fields':
+        specifier: workspace:*
+        version: link:../fields
+      '@mieweb/datavis':
+        specifier: 1.6.0
+        version: 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+      '@mieweb/ui':
+        specifier: 0.7.1
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+      ag-grid-community:
+        specifier: ^35.1.0
+        version: 35.3.1
+      ag-grid-react:
+        specifier: ^35.1.0
+        version: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      datavis-ace:
+        specifier: 4.1.0
+        version: 4.1.0
+      lucide-react:
+        specifier: ^1.31.0
+        version: 1.31.0(react@19.2.8)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.8(react@19.2.8)
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
 
   packages/field-health:
     dependencies:
@@ -333,7 +372,7 @@ importers:
         version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -382,7 +421,7 @@ importers:
         version: 6.0.5(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vite-plugin-dts:
         specifier: ^5.0.3
-        version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
 
   packages/fields:
     dependencies:
@@ -391,7 +430,7 @@ importers:
         version: link:../core
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -1530,6 +1569,28 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@docsearch/core@4.7.0':
     resolution: {integrity: sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==}
     peerDependencies:
@@ -2040,6 +2101,75 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@mieweb/datavis@1.6.0':
+    resolution: {integrity: sha512-KCO8h/BkOUa7cMjS8rdD3CmXIJjKK770BOdbp99/2cpy8+Ij9e+lE6De0hnvWoHAq7pGAkYXelHI+kKrwOVcdA==}
+    peerDependencies:
+      datavis-ace: '>=4.1.0'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  '@mieweb/ui@0.6.1-dev.169':
+    resolution: {integrity: sha512-YE6vtT/6+hMB7YQROZxPUKm4FVxLTYyLAru+IY8enn9x6GsctCeOA0yjHD6RjQ8oqQDknWS2c3NEfCJ665pGQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@kerebron/editor': '>=0.7.9'
+      '@kerebron/editor-kits': '>=0.7.9'
+      '@kerebron/wasm': '>=0.7.9'
+      '@mieweb/datavis': '=1.5.0'
+      ag-grid-community: '>=32.0.0'
+      ag-grid-react: '>=32.0.0'
+      datavis-ace: '=4.1.0'
+      js-yaml: '>=4.0.0'
+      katex: '>=0.16.0'
+      mermaid: '>=11.0.0'
+      papaparse: '>=5.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      react-markdown: '>=9.0.0'
+      rehype-highlight: '>=7.0.0'
+      rehype-katex: '>=7.0.0'
+      rehype-sanitize: '>=6.0.0'
+      remark-gfm: '>=4.0.0'
+      remark-math: '>=6.0.0'
+      wavesurfer.js: '>=7.0.0'
+    peerDependenciesMeta:
+      '@kerebron/editor':
+        optional: true
+      '@kerebron/editor-kits':
+        optional: true
+      '@kerebron/wasm':
+        optional: true
+      '@mieweb/datavis':
+        optional: true
+      ag-grid-community:
+        optional: true
+      ag-grid-react:
+        optional: true
+      datavis-ace:
+        optional: true
+      js-yaml:
+        optional: true
+      katex:
+        optional: true
+      mermaid:
+        optional: true
+      papaparse:
+        optional: true
+      react-markdown:
+        optional: true
+      rehype-highlight:
+        optional: true
+      rehype-katex:
+        optional: true
+      rehype-sanitize:
+        optional: true
+      remark-gfm:
+        optional: true
+      remark-math:
+        optional: true
+      wavesurfer.js:
+        optional: true
 
   '@mieweb/ui@0.7.1':
     resolution: {integrity: sha512-39FDW2YjTfjH28atU81BUljhH+9YWV49X9ymMuElusNlwV9DakLpr26VsH01X5M1qX6VVheOPnTyv8SzzKAo3g==}
@@ -2563,6 +2693,17 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.2.3':
     resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2808,6 +2949,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@sveltejs/acorn-typescript@1.0.12':
     resolution: {integrity: sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==}
@@ -3579,6 +3723,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -3830,6 +3977,18 @@ packages:
   address@2.0.3:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
+
+  ag-charts-types@13.3.1:
+    resolution: {integrity: sha512-m37eUe4g//swvGh8PWMlYQH3gknjSsPeW4sQwBhM3/auGAHmN0wvxEWlrdAn98pBPg4HoKbtOy+yf7gPCYsnvQ==}
+
+  ag-grid-community@35.3.1:
+    resolution: {integrity: sha512-Wmkd/xYTCbAApcZZO74nBggZCnd/oX753NY3MJ4zYARVpfBHRWWhIBJ2sFTFKbDWwHZOWsx3YT9+kkyeuyLKlw==}
+
+  ag-grid-react@35.3.1:
+    resolution: {integrity: sha512-M3ljCQyGL+qzoyPN0BYrn4eAlgZr6Ailcjd8+a7OcneSiVsMNSJb/gTkIMUwmYivkPLIA8EEJ4hTxxKSaya6mQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -4095,6 +4254,9 @@ packages:
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4429,6 +4591,9 @@ packages:
     resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
     engines: {node: '>=6.4.0'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-js@3.50.0:
     resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
 
@@ -4733,6 +4898,10 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
+
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
@@ -4754,6 +4923,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  datavis-ace@4.1.0:
+    resolution: {integrity: sha512-heaXzdklp3jiqGRoK7YjcklyPT/2aigEEGMSV8Is2Z58oqHf8/rFPmztXjKb5ZQSqn6ygyPtV+u/iwJjTkhoFg==}
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
@@ -4785,6 +4957,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -5051,6 +5226,17 @@ packages:
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -5153,6 +5339,10 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5224,8 +5414,14 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
 
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -5264,6 +5460,9 @@ packages:
   ext-name@5.0.0:
     resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
     engines: {node: '>=4'}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -5650,6 +5849,9 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  html-parse-stringify@4.0.1:
+    resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
+
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
@@ -5729,6 +5931,14 @@ packages:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
 
+  i18next@26.3.6:
+    resolution: {integrity: sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==}
+    peerDependencies:
+      typescript: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -5758,6 +5968,9 @@ packages:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  immer@11.1.17:
+    resolution: {integrity: sha512-8Vu44Y0MuMBlTQz/jQ8HEMYNq/bBqk87MnBwYR5mC8AthfhEXidZ5aT/oA/CUqboa8THKltnD9L3xyqhU/Sy1Q==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -6151,6 +6364,10 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-formatter-js@https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac:
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac}
+    version: 2.3.4
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -6845,6 +7062,9 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   monaco-editor@0.56.0:
     resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
@@ -6884,6 +7104,9 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -6934,6 +7157,9 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
+
+  numeral@2.0.6:
+    resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7743,11 +7969,30 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
+  react-i18next@17.0.11:
+    resolution: {integrity: sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==}
+    peerDependencies:
+      i18next: '>= 26.2.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-json-view-lite@2.5.0:
     resolution: {integrity: sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==}
@@ -7761,6 +8006,18 @@ packages:
     peerDependencies:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
+
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react-router-config@5.1.1:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
@@ -7810,6 +8067,14 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts@3.10.1:
+    resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -7823,6 +8088,14 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -7908,6 +8181,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -8221,6 +8497,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   srcset@4.0.0:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
@@ -8603,6 +8882,9 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -8655,6 +8937,9 @@ packages:
 
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -8777,6 +9062,11 @@ packages:
       file-loader:
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -8810,6 +9100,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-dts@5.0.3:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
@@ -10431,6 +10724,31 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+
   '@docsearch/core@4.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       '@types/react': 19.2.18
@@ -11958,7 +12276,80 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+      datavis-ace: 4.1.0
+      i18next: 26.3.6(typescript@5.9.3)
+      lucide-react: 1.31.0(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-i18next: 17.0.11(i18next@26.3.6(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-is: 18.3.1
+      recharts: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1)
+    transitivePeerDependencies:
+      - '@kerebron/editor'
+      - '@kerebron/editor-kits'
+      - '@kerebron/wasm'
+      - '@types/react'
+      - ag-grid-community
+      - ag-grid-react
+      - js-yaml
+      - katex
+      - mermaid
+      - papaparse
+      - react-markdown
+      - react-native
+      - redux
+      - rehype-highlight
+      - rehype-katex
+      - rehype-sanitize
+      - remark-gfm
+      - remark-math
+      - typescript
+      - wavesurfer.js
+    optional: true
+
+  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+      datavis-ace: 4.1.0
+      i18next: 26.3.6(typescript@6.0.3)
+      lucide-react: 1.31.0(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-i18next: 17.0.11(i18next@26.3.6(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      react-is: 18.3.1
+      recharts: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1)
+    transitivePeerDependencies:
+      - '@kerebron/editor'
+      - '@kerebron/editor-kits'
+      - '@kerebron/wasm'
+      - '@types/react'
+      - ag-grid-community
+      - ag-grid-react
+      - js-yaml
+      - katex
+      - mermaid
+      - papaparse
+      - react-markdown
+      - react-native
+      - redux
+      - rehype-highlight
+      - rehype-katex
+      - rehype-sanitize
+      - remark-gfm
+      - remark-math
+      - typescript
+      - wavesurfer.js
+
+  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
     dependencies:
       '@swc/helpers': 0.5.23
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -11978,6 +12369,101 @@ snapshots:
       '@kerebron/editor': 0.8.9
       '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
       '@kerebron/wasm': 0.8.9
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
+      ag-grid-community: 35.3.1
+      ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      datavis-ace: 4.1.0
+      js-yaml: 5.2.3
+      katex: 0.16.47
+      mermaid: 11.16.1
+      papaparse: 5.5.4
+      remark-gfm: 4.0.1
+    optional: true
+
+  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      dompurify: 3.4.13
+      google-libphonenumber: 3.2.46
+      highlight.js: 11.11.2
+      lucide-react: 0.562.0(react@19.2.8)
+      luxon: 3.7.2
+      marked: 17.0.6
+      onnxruntime-web: 1.19.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tailwind-merge: 2.6.1
+    optionalDependencies:
+      '@kerebron/editor': 0.8.9
+      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.9
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+      ag-grid-community: 35.3.1
+      ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      datavis-ace: 4.1.0
+      js-yaml: 5.2.3
+      katex: 0.16.47
+      mermaid: 11.16.1
+      papaparse: 5.5.4
+      remark-gfm: 4.0.1
+
+  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      dompurify: 3.4.13
+      google-libphonenumber: 3.2.46
+      highlight.js: 11.11.2
+      lucide-react: 0.562.0(react@19.2.8)
+      luxon: 3.7.2
+      marked: 17.0.6
+      onnxruntime-web: 1.19.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tailwind-merge: 2.6.1
+    optionalDependencies:
+      '@kerebron/editor': 0.8.9
+      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.9
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
+      ag-grid-community: 35.3.1
+      ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      datavis-ace: 4.1.0
+      js-yaml: 5.2.3
+      katex: 0.16.47
+      mermaid: 11.16.1
+      papaparse: 5.5.4
+      remark-gfm: 4.0.1
+
+  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      dompurify: 3.4.13
+      google-libphonenumber: 3.2.46
+      highlight.js: 11.11.2
+      lucide-react: 0.562.0(react@19.2.8)
+      luxon: 3.7.2
+      marked: 17.0.6
+      onnxruntime-web: 1.19.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tailwind-merge: 2.6.1
+    optionalDependencies:
+      '@kerebron/editor': 0.8.9
+      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.9
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+      ag-grid-community: 35.3.1
+      ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      datavis-ace: 4.1.0
       js-yaml: 5.2.3
       katex: 0.16.47
       mermaid: 11.16.1
@@ -12380,6 +12866,18 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.17
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.8
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.2.3':
     optional: true
 
@@ -12572,6 +13070,8 @@ snapshots:
       micromark-util-symbol: 1.1.0
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@sveltejs/acorn-typescript@1.0.12(acorn@8.18.0)':
     dependencies:
@@ -13312,6 +13812,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/use-sync-external-store@0.0.6': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.9
@@ -13442,7 +13944,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13496,7 +13998,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -13705,6 +14207,19 @@ snapshots:
   acorn@8.18.0: {}
 
   address@2.0.3: {}
+
+  ag-charts-types@13.3.1: {}
+
+  ag-grid-community@35.3.1:
+    dependencies:
+      ag-charts-types: 13.3.1
+
+  ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      ag-grid-community: 35.3.1
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   aggregate-error@3.1.0:
     dependencies:
@@ -13988,6 +14503,8 @@ snapshots:
       require-from-string: 2.0.2
 
   big.js@5.2.2: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -14347,6 +14864,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.8
 
+  core-js@3.49.0: {}
+
   core-js@3.50.0: {}
 
   core-util-is@1.0.3: {}
@@ -14701,6 +15220,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
@@ -14733,6 +15257,18 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  datavis-ace@4.1.0:
+    dependencies:
+      bignumber.js: 9.3.1
+      core-js: 3.49.0
+      es6-symbol: 3.1.4
+      json-formatter-js: https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac
+      moment: 2.30.1
+      numeral: 2.0.6
+      papaparse: 5.5.4
+      sprintf-js: 1.1.3
+      underscore: 1.13.8
+
   dayjs@1.11.21: {}
 
   debounce@1.2.1: {}
@@ -14748,6 +15284,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -15059,6 +15597,24 @@ snapshots:
 
   es-toolkit@1.50.0: {}
 
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -15235,6 +15791,13 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+
   espree@9.6.1:
     dependencies:
       acorn: 8.18.0
@@ -15309,7 +15872,14 @@ snapshots:
       '@types/node': 20.19.9
       require-like: 0.1.2
 
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+
   eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -15406,6 +15976,10 @@ snapshots:
     dependencies:
       ext-list: 2.2.2
       sort-keys-length: 1.0.1
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   extend-shallow@2.0.1:
     dependencies:
@@ -15894,6 +16468,8 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.50.0
 
+  html-parse-stringify@4.0.1: {}
+
   html-tags@3.3.1: {}
 
   html-void-elements@3.0.0: {}
@@ -15982,6 +16558,15 @@ snapshots:
 
   hyperdyperid@1.2.0: {}
 
+  i18next@26.3.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  i18next@26.3.6(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -16001,6 +16586,8 @@ snapshots:
   ignore@7.0.6: {}
 
   image-size@2.0.2: {}
+
+  immer@11.1.17: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -16363,6 +16950,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-formatter-js@https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac: {}
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -17303,6 +17892,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  moment@2.30.1: {}
+
   monaco-editor@0.56.0:
     dependencies:
       dompurify: 3.4.13
@@ -17330,6 +17921,8 @@ snapshots:
   negotiator@0.6.4: {}
 
   neo-async@2.6.2: {}
+
+  next-tick@1.1.0: {}
 
   no-case@3.0.4:
     dependencies:
@@ -17382,6 +17975,8 @@ snapshots:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(postcss@8.5.26)
+
+  numeral@2.0.6: {}
 
   object-assign@4.1.1: {}
 
@@ -18289,9 +18884,34 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
+  react-i18next@17.0.11(i18next@26.3.6(typescript@5.9.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      html-parse-stringify: 4.0.1
+      i18next: 26.3.6(typescript@5.9.3)
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+      typescript: 5.9.3
+    optional: true
+
+  react-i18next@17.0.11(i18next@26.3.6(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      html-parse-stringify: 4.0.1
+      i18next: 26.3.6(typescript@6.0.3)
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+      typescript: 6.0.3
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-json-view-lite@2.5.0(react@19.2.8):
     dependencies:
@@ -18302,6 +18922,15 @@ snapshots:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.8)'
       webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(postcss@8.5.26)
+
+  react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      redux: 5.0.1
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -18369,6 +18998,26 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  recharts@3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@18.3.1)(react@19.2.8)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.50.0
+      eventemitter3: 5.0.4
+      immer: 11.1.17
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 18.3.1
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -18397,6 +19046,12 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect-metadata@0.2.2: {}
 
@@ -18545,6 +19200,8 @@ snapshots:
   require-like@0.1.2: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -18923,6 +19580,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3: {}
+
   srcset@4.0.0: {}
 
   stackback@0.0.2: {}
@@ -19292,6 +19951,8 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type@2.7.3: {}
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -19344,8 +20005,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.3:
-    optional: true
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 
@@ -19362,6 +20022,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
+
+  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 
@@ -19447,7 +20109,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
       '@rollup/pluginutils': 5.4.0
       '@volar/typescript': 2.4.28
@@ -19456,7 +20118,7 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.2.1
       magic-string: 0.30.21
-      typescript: 5.9.3
+      typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.19.9)
@@ -19510,6 +20172,10 @@ snapshots:
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(postcss@8.5.26))
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   util-deprecate@1.0.2: {}
 
   utila@0.4.0: {}
@@ -19539,6 +20205,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.18))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
       unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.18))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -19554,9 +20237,9 @@ snapshots:
       - typescript
       - webpack
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.19.9)
       vite: 8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -20045,9 +20728,11 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.14(@types/react@19.2.18)(react@19.2.8):
+  zustand@5.0.14(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
     optionalDependencies:
       '@types/react': 19.2.18
+      immer: 11.1.17
       react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,7 +420,7 @@ importers:
         version: 0.8.10
       '@kerebron/extension-menu':
         specifier: ^0.8.9
-        version: 0.8.10
+        version: 0.8.10(patch_hash=4bfcffd5f324775f98e04cec05c3fde04584c4a91dbfe7a7de65bc78baa37967)
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -436,7 +436,7 @@ importers:
         version: 6.0.5(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vite-plugin-dts:
         specifier: ^5.0.3
-        version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
 
   packages/fields:
     dependencies:
@@ -2317,49 +2317,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -2457,49 +2450,41 @@ packages:
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
@@ -2556,56 +2541,48 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.6.0':
     resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-glibc@2.6.0':
     resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -2754,42 +2731,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.3':
     resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.3':
     resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.3':
     resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.3':
     resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.3':
     resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
@@ -2835,25 +2806,21 @@ packages:
     resolution: {integrity: sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.7.12':
     resolution: {integrity: sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.7.12':
     resolution: {integrity: sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.7.12':
     resolution: {integrity: sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.7.12':
     resolution: {integrity: sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==}
@@ -3119,70 +3086,60 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-gnu@1.15.8':
     resolution: {integrity: sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.47':
     resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.47':
     resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.47':
     resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.47':
     resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.47':
     resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.47':
     resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
@@ -3270,42 +3227,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-arm64-musl@1.15.47':
     resolution: {integrity: sha512-NyXRQiVBkeutgCwCxUUaFqZdDmpZONs7Zz3AZGoY35s9GwXF412Nt22fK/e7lO/sM6G/+S3rOom/0xTmUQSK6A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/html-linux-ppc64-gnu@1.15.47':
     resolution: {integrity: sha512-rQ+XLJHFzu0e4M5p1+8kF2FKzI7WO9KPPji87OuicHZVrDCEqg7/jSGu3hys9CjIQIYVfR+tAFuZz3Q1/jOoNA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-s390x-gnu@1.15.47':
     resolution: {integrity: sha512-w6bitHrllrE3lqmf14cT3spmWhZHGts1O08O4adzxztSPto7O5GM3IerqZm/NtsqlxNsfbVHnhaNXxXWe/8Q+Q==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-x64-gnu@1.15.47':
     resolution: {integrity: sha512-FTA7E29gcyadd71prg8sJUVacYrIhAXS8L7p48yCfgcNOKquofN1TDOrHVOyYMoxplL3FUwwbN+AZxWO7QfWPQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-x64-musl@1.15.47':
     resolution: {integrity: sha512-g+K1GKUrj+S9o8Qsgii2g7ooMzZ750R4IAqH5CVElIA5FTMAx7KGnu9ga6aEnRwwLYxY3s1k/nN+ls0NEk240g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/html-win32-arm64-msvc@1.15.47':
     resolution: {integrity: sha512-5Iw3i00JdTySi+ccc2CM5bxY+8TZivQmcTqUC6mUdAY0/KYBgSe1/L294UJQ4OTLQqNDOYXY9jdb070zZUX7jg==}
@@ -3378,28 +3329,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -6381,7 +6328,7 @@ packages:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-formatter-js@https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac}
+    resolution: {tarball: https://codeload.github.com/mieweb/json-formatter-js/tar.gz/503be5a8368ecdea777f8a7e98bda827391aa6ac}
     version: 2.3.4
 
   json-parse-even-better-errors@2.3.1:
@@ -6533,56 +6480,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -20020,7 +19959,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.3: {}
+  typescript@6.0.3:
+    optional: true
 
   ufo@1.6.4: {}
 
@@ -20124,7 +20064,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
       '@rollup/pluginutils': 5.4.0
       '@volar/typescript': 2.4.28
@@ -20133,7 +20073,7 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.2.1
       magic-string: 0.30.21
-      typescript: 6.0.3
+      typescript: 5.9.3
       unplugin: 2.3.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.19.9)
@@ -20252,9 +20192,9 @@ snapshots:
       - typescript
       - webpack
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.12(@types/node@20.19.9))(@rspack/core@1.7.12(@swc/helpers@0.5.23))(rolldown@1.2.3)(typescript@5.9.3)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.19.9)
       vite: 8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   dompurify@<=3.4.10: '>=3.4.11'
   dompurify@<3.4.9: '>=3.4.9'
   dompurify@<=3.4.12: '>=3.4.13'
+  prosemirror-model: 1.25.9
 
 importers:
 
@@ -7888,9 +7889,6 @@ packages:
 
   prosemirror-dev-toolkit@1.1.8:
     resolution: {integrity: sha512-Qi549XA+DqU5cCkn/xv+M53gy1sQbyOTjiOfiG7Gjq5gm6ZxLilGN04UITWTAYx9kzLBi7Y9RJmvmWB4xiRauA==}
-
-  prosemirror-model@1.25.11:
-    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
 
   prosemirror-model@1.25.9:
     resolution: {integrity: sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==}
@@ -18787,14 +18785,10 @@ snapshots:
   prosemirror-dev-toolkit@1.1.8(svelte@5.56.8(@typescript-eslint/types@8.67.0)):
     dependencies:
       html: 1.0.0
-      prosemirror-model: 1.25.11
+      prosemirror-model: 1.25.9
       svelte-tree-view: 1.4.2(svelte@5.56.8(@typescript-eslint/types@8.67.0))
     transitivePeerDependencies:
       - svelte
-
-  prosemirror-model@1.25.11:
-    dependencies:
-      orderedmap: 2.1.1
 
   prosemirror-model@1.25.9:
     dependencies:
@@ -18802,17 +18796,17 @@ snapshots:
 
   prosemirror-state@1.4.3:
     dependencies:
-      prosemirror-model: 1.25.11
+      prosemirror-model: 1.25.9
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.0
 
   prosemirror-transform@1.10.4:
     dependencies:
-      prosemirror-model: 1.25.11
+      prosemirror-model: 1.25.9
 
   prosemirror-view@1.40.0:
     dependencies:
-      prosemirror-model: 1.25.11
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     dependencies:
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -176,12 +176,9 @@ importers:
       '@esheet/renderer':
         specifier: workspace:*
         version: link:../../packages/renderer
-      '@kerebron/wasm':
-        specifier: ^0.8.9
-        version: 0.8.9
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3
@@ -265,7 +262,7 @@ importers:
         version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -334,12 +331,18 @@ importers:
       '@esheet/fields':
         specifier: workspace:*
         version: link:../fields
+      '@kerebron/editor':
+        specifier: ^0.8.10
+        version: 0.8.10
+      '@kerebron/editor-kits':
+        specifier: ^0.8.10
+        version: 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
       '@mieweb/datavis':
         specifier: 1.6.0
-        version: 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+        version: 1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       ag-grid-community:
         specifier: ^35.1.0
         version: 35.3.1
@@ -372,7 +375,7 @@ importers:
         version: link:../fields
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -392,20 +395,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@kerebron/editor':
-        specifier: ^0.8.9
-        version: 0.8.9
+        specifier: ^0.8.10
+        version: 0.8.10
       '@kerebron/editor-kits':
-        specifier: ^0.8.9
-        version: 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/editor-react':
-        specifier: ^0.8.9
-        version: 0.8.9
-      '@kerebron/extension-basic-editor':
-        specifier: ^0.8.9
-        version: 0.8.9
-      '@kerebron/extension-menu':
-        specifier: ^0.8.9
-        version: 0.8.9
+        specifier: ^0.8.10
+        version: 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -430,7 +424,7 @@ importers:
         version: link:../core
       '@mieweb/ui':
         specifier: 0.7.1
-        version: 0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+        version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -2023,53 +2017,50 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@kerebron/editor-kits@0.8.9':
-    resolution: {integrity: sha512-xCTRYeQkBjfkPSPvQc1fxV6rPwc0JwE/3x8/Q1Eb/wrHWtdcRollt0u0BMi7m0YvMZhP7b01FvZPMQAkZQ0Tcw==}
+  '@kerebron/editor-kits@0.8.10':
+    resolution: {integrity: sha512-PqiATAYwvOcN9EW72T/tqDcmDU2O+K+W93aJvi43kHUVhNpUwAQydrpS4iQlaJcuhZLSxBLH6Xq6qy/EXu4W6w==}
 
-  '@kerebron/editor-react@0.8.9':
-    resolution: {integrity: sha512-+C3poS3xuhvtk7IMKQ75S5hnYW/xCgxgq6dYvSTJYffCYUyy5LuVZAt9OcW3C0KYrdD6oD+P2GLurvK+LSK5sg==}
+  '@kerebron/editor@0.8.10':
+    resolution: {integrity: sha512-bppbQgj4U/2/chWWtEIYdnA4Gsx6KpIUaPbQKsInm4tRF5TZMH/+A88kaD9iIjkJP6Rm+g01AmqLE/Cyd9e/Bg==}
 
-  '@kerebron/editor@0.8.9':
-    resolution: {integrity: sha512-hQyrKAjyFW8RF7Khfe12LApSvLTfISyg4m0jI11SPSHXJgPe/nNQGD4KoBDkS7d2M+ng72X+FxHLNmVWZtAjEA==}
+  '@kerebron/extension-basic-editor@0.8.10':
+    resolution: {integrity: sha512-TMvlaJPmRMzmY1eEuPFU029Diz8s89SQSNqNzkJ8pK4rhARsaf+h1M7J15KbZGBkC6EYXPH0Kcm/cJ4wTmM54Q==}
 
-  '@kerebron/extension-basic-editor@0.8.9':
-    resolution: {integrity: sha512-pGBEJkdSWCSibtFARNRd9wKH6sSDanJvcSPDwlgj53yBmzKjCLurnK9YhVhVMD/MzJxC8id0RI8oP3U22Mc2wQ==}
+  '@kerebron/extension-codecrock@0.8.10':
+    resolution: {integrity: sha512-/cGkS8sqYq//2B02ZsB2Z7lWTAMOyc71BWewBt0brZtqjVAzQ22ataoQoDXip4IHHSJ+13lJ9Uyfi2cCudYD4w==}
 
-  '@kerebron/extension-codecrock@0.8.9':
-    resolution: {integrity: sha512-l4AW621JzCCUcBd7S98gOiTSyaIbxEoH4Scv2yEyq2HBxaxO9kspZfnm65isnm1Q1mJEhEtYZ3xer48SHj02qw==}
+  '@kerebron/extension-dev-toolkit@0.8.10':
+    resolution: {integrity: sha512-xVJ1uFat2zFz3c0f4ObGHhYBqYa1UxGsitFY0A/nW3RdshTGSGo9QlUelohYX0gZXmSmWnd4r/cwWfEke1HPYg==}
 
-  '@kerebron/extension-dev-toolkit@0.8.9':
-    resolution: {integrity: sha512-XRpnS7t/3NyYKFXl2jy9OYiWhbGAje7V1xPsnKYm03sLZNw9dvkvcyE1Pv3ZHUsB/zxhiNY3SstPOo4+cr3VOg==}
+  '@kerebron/extension-markdown@0.8.10':
+    resolution: {integrity: sha512-Pix7dh2rQnEfjU08oc/xPeljMrjAA+m6NdhuRKP+bWX2Q1A0lSILrQC7HxE335n3QirCF+Crhh/Eivc87MCVMQ==}
 
-  '@kerebron/extension-markdown@0.8.9':
-    resolution: {integrity: sha512-1/Wx9rXKA4nXTsLW51UaOLywFzUEQa+coNsRJjcqaogF6o0toZwKSl/eE7/2enSz2arojGWJqDcrmjAimxVAvg==}
+  '@kerebron/extension-menu-legacy@0.8.10':
+    resolution: {integrity: sha512-WhERfIr1X/MNdkoT8tMfDwuSXhLA46vD5mvo4A7RdLvyx6LDzklpaXWy0muognl2S8MiO1xr8/n1GiEkWzSb3A==}
 
-  '@kerebron/extension-menu-legacy@0.8.9':
-    resolution: {integrity: sha512-xEt3fjtXmh6zrRJvoukh1XWa8n7aoh1JrKXH2Js3ebWEsZoWo/vHCzNs6EfaIC/K2F6DOcrZVOcx5R7Z0zuCPg==}
+  '@kerebron/extension-menu@0.8.10':
+    resolution: {integrity: sha512-s8uAtce6WqdMgssGlMFlDtk84xtN+oVvfoblv3NdHj+Y6pEtjMEpm+fF90vV0suJSHaFWauVUel+ty5ULokO9g==}
 
-  '@kerebron/extension-menu@0.8.9':
-    resolution: {integrity: sha512-FJNMRbv8dCQPYjJUrkSoPokshNvzO8QwFbZYQnT+ul3fXeupbQYFugBmK1Em8rWjlUNC22aDh3gHcRsApqEm7w==}
+  '@kerebron/extension-odt@0.8.10':
+    resolution: {integrity: sha512-+OVAG194HgCz/OfO3WQbrVAXGj9+Gj5Ffi1S9MpHOLpcgFWUDfoQNkxkJitZCTictkDtZdbBvfyvgA3ok4vB4g==}
 
-  '@kerebron/extension-odt@0.8.9':
-    resolution: {integrity: sha512-sjmHlMzrBwgSQufHUSbe/1NmDIAr6Z0xjQnTBV552ezPidI5sp78rneKKjY70DUzlBjPkYxB31cdSEKl1CsIOw==}
+  '@kerebron/extension-tables@0.8.10':
+    resolution: {integrity: sha512-GjTt8XB6flGvxIJwSN83NAe4i9v3QVckAeC5ETsf8Mr2jt2muTMAncqfjiYOIg0tVrCWQseGVC5La12vwlHAOg==}
 
-  '@kerebron/extension-tables@0.8.9':
-    resolution: {integrity: sha512-gU57VFLxADskuDUrZI/TVptvhUzVbBMku6NIBe8dFDn5+IZMHqNXDYZkxuVx1G7ff1Fzi6PqMeL3cJa2Vp0ayA==}
+  '@kerebron/extension-ui@0.8.10':
+    resolution: {integrity: sha512-OpRPQTw6mxu2LKoRc2R5+gGR/NJ5JdMOU+z+we4IyRJFsCB4qMR8W5Y/maPM7HbA9EpSYSEKOJDcSwcI50EGkQ==}
 
-  '@kerebron/extension-ui@0.8.9':
-    resolution: {integrity: sha512-6hBIaQUb3OKBT1Ikywf6VjGriiVt5QlcdbCPf0a7SkAqWrPkXGS//v5Xq9XbbCnVAt40RIHVONyQLCjF9DWmIQ==}
+  '@kerebron/odt-wasm@0.8.10':
+    resolution: {integrity: sha512-FHXe31DViU1Oyiu5zxXWxgA4T9ufjUzicDEcU4aj2wtF86laFeTXfR3GMbkDsa45sd4KPhYL0XcW5GIedE/9JA==}
 
-  '@kerebron/odt-wasm@0.8.9':
-    resolution: {integrity: sha512-S5Krh+W4cmENneQ78MlkfRtYRi4RElJzjEuFKBu4ki0r6mWH4JU0KLO7hiPPdauHGTJb4HaEDKNG3NcBwqtZGw==}
+  '@kerebron/tree-sitter@0.8.10':
+    resolution: {integrity: sha512-NEU9VwAMbSrhP1b3j4/JZRLG/scP11io/qDErG9Jrywged3ulmZQFLBHJgVEjsv4DNdRq+rCdLOjoNylLocYAQ==}
 
-  '@kerebron/tree-sitter@0.8.9':
-    resolution: {integrity: sha512-ECeKvf+mIn1wq5JYrPovKqRUfppRXlM7uveKF/PXZbyR/lZRhIQP42yallcFIV5z+jIBmydcsZo/sqddaJOsVw==}
+  '@kerebron/wasm@0.8.10':
+    resolution: {integrity: sha512-/f5JBs0fsw0GUMO+cTSfMxM0eaHqTnOm8wX2zA0OdkJh4DW2WvqK5oRH2tT8jSGD65lL7YC8xX/ykw9vHdMKKg==}
 
-  '@kerebron/wasm@0.8.9':
-    resolution: {integrity: sha512-XzcDL9mHeD8oKla6G2+SDbZHv3qK76oF3jNgUe3czFG6J24MqWB5zfv1ty19ZA1MirxTxpfUdjnmTiMH6ToPew==}
-
-  '@kerebron/workspace@0.8.9':
-    resolution: {integrity: sha512-BPa9pmxZcSg0bqPY1oeG2SBxN8OV97rrHqJPhV7+1gMjvlDtdlDFui7ZwocLwVaVQw7KU5YgdQDkRSa2AFeSuQ==}
+  '@kerebron/workspace@0.8.10':
+    resolution: {integrity: sha512-Cw6TG8aWDiE4kPJYSD6joE5wxKyDK3wwhl8VsGOT3bm+Ve1hsVkJVM3uC1XvA66n+06QA7caRSuAHLIcSGAarg==}
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
@@ -8697,6 +8688,10 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
+  temml@0.13.4:
+    resolution: {integrity: sha512-k1yolMBswx34Jw9hZn5Xh2/GBlwqlW+wiN7QaUYUMhSa1ypfti6rlCfSmCxWyooxH1G32C/Z+qVvgAsBOELZBQ==}
+    engines: {node: '>=18.13.0'}
+
   terser-webpack-plugin@5.6.1:
     resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
     engines: {node: '>= 10.13.0'}
@@ -9219,8 +9214,8 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  web-tree-sitter@0.26.11:
-    resolution: {integrity: sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==}
+  web-tree-sitter@0.26.12:
+    resolution: {integrity: sha512-fvqTNZQBGUgUgfP0mHw+iHf9Yf6bRQrp0A3pSf2v/hSKxkT1beCoIWoLVmlPL7O6dmySfSb/t1aJoJvrgTRStw==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -12083,119 +12078,115 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))':
+  '@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))':
     dependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/extension-basic-editor': 0.8.9
-      '@kerebron/extension-codecrock': 0.8.9
-      '@kerebron/extension-dev-toolkit': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/extension-markdown': 0.8.9
-      '@kerebron/extension-menu': 0.8.9
-      '@kerebron/extension-menu-legacy': 0.8.9
-      '@kerebron/extension-odt': 0.8.9
-      '@kerebron/extension-tables': 0.8.9
-      '@kerebron/extension-ui': 0.8.9
+      '@kerebron/editor': 0.8.10
+      '@kerebron/extension-basic-editor': 0.8.10
+      '@kerebron/extension-codecrock': 0.8.10
+      '@kerebron/extension-dev-toolkit': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/extension-markdown': 0.8.10
+      '@kerebron/extension-menu': 0.8.10
+      '@kerebron/extension-menu-legacy': 0.8.10
+      '@kerebron/extension-odt': 0.8.10
+      '@kerebron/extension-tables': 0.8.10
+      '@kerebron/extension-ui': 0.8.10
     transitivePeerDependencies:
       - svelte
 
-  '@kerebron/editor-react@0.8.9':
+  '@kerebron/editor@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
-      react: 19.2.8
-
-  '@kerebron/editor@0.8.9':
-    dependencies:
-      '@kerebron/workspace': 0.8.9
+      '@kerebron/workspace': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-basic-editor@0.8.9':
+  '@kerebron/extension-basic-editor@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.0
+      temml: 0.13.4
 
-  '@kerebron/extension-codecrock@0.8.9':
+  '@kerebron/extension-codecrock@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/extension-basic-editor': 0.8.9
-      '@kerebron/tree-sitter': 0.8.9
-      '@kerebron/wasm': 0.8.9
-      '@kerebron/workspace': 0.8.9
+      '@kerebron/editor': 0.8.10
+      '@kerebron/extension-basic-editor': 0.8.10
+      '@kerebron/tree-sitter': 0.8.10
+      '@kerebron/wasm': 0.8.10
+      '@kerebron/workspace': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-dev-toolkit@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))':
+  '@kerebron/extension-dev-toolkit@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-dev-toolkit: 1.1.8(svelte@5.56.8(@typescript-eslint/types@8.67.0))
       prosemirror-view: 1.40.0
     transitivePeerDependencies:
       - svelte
 
-  '@kerebron/extension-markdown@0.8.9':
+  '@kerebron/extension-markdown@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/extension-basic-editor': 0.8.9
-      '@kerebron/tree-sitter': 0.8.9
-      '@kerebron/wasm': 0.8.9
-      '@kerebron/workspace': 0.8.9
+      '@kerebron/editor': 0.8.10
+      '@kerebron/extension-basic-editor': 0.8.10
+      '@kerebron/tree-sitter': 0.8.10
+      '@kerebron/wasm': 0.8.10
+      '@kerebron/workspace': 0.8.10
       mathml2latex: 1.1.3
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
 
-  '@kerebron/extension-menu-legacy@0.8.9':
+  '@kerebron/extension-menu-legacy@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-menu@0.8.9':
+  '@kerebron/extension-menu@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-odt@0.8.9':
+  '@kerebron/extension-odt@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/odt-wasm': 0.8.9
+      '@kerebron/editor': 0.8.10
+      '@kerebron/odt-wasm': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
 
-  '@kerebron/extension-tables@0.8.9':
+  '@kerebron/extension-tables@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-ui@0.8.9':
+  '@kerebron/extension-ui@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.3
       prosemirror-view: 1.40.0
 
-  '@kerebron/odt-wasm@0.8.9': {}
+  '@kerebron/odt-wasm@0.8.10': {}
 
-  '@kerebron/tree-sitter@0.8.9':
+  '@kerebron/tree-sitter@0.8.10':
     dependencies:
-      web-tree-sitter: 0.26.11
+      web-tree-sitter: 0.26.12
 
-  '@kerebron/wasm@0.8.9':
+  '@kerebron/wasm@0.8.10':
     dependencies:
-      '@kerebron/editor': 0.8.9
+      '@kerebron/editor': 0.8.10
 
-  '@kerebron/workspace@0.8.9': {}
+  '@kerebron/workspace@0.8.10': {}
 
   '@keyv/serialize@1.1.1': {}
 
@@ -12276,12 +12267,12 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)':
+  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@dnd-kit/utilities': 3.2.2(react@19.2.8)
-      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       datavis-ace: 4.1.0
       i18next: 26.3.6(typescript@5.9.3)
       lucide-react: 1.31.0(react@19.2.8)
@@ -12313,12 +12304,12 @@ snapshots:
       - wavesurfer.js
     optional: true
 
-  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)':
+  '@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@dnd-kit/utilities': 3.2.2(react@19.2.8)
-      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
+      '@mieweb/ui': 0.6.1-dev.169(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
       datavis-ace: 4.1.0
       i18next: 26.3.6(typescript@6.0.3)
       lucide-react: 1.31.0(react@19.2.8)
@@ -12349,7 +12340,7 @@ snapshots:
       - typescript
       - wavesurfer.js
 
-  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
     dependencies:
       '@swc/helpers': 0.5.23
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12366,10 +12357,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       tailwind-merge: 2.6.1
     optionalDependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/wasm': 0.8.9
-      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
+      '@kerebron/editor': 0.8.10
+      '@kerebron/editor-kits': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.10
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
       ag-grid-community: 35.3.1
       ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       datavis-ace: 4.1.0
@@ -12380,7 +12371,7 @@ snapshots:
       remark-gfm: 4.0.1
     optional: true
 
-  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+  '@mieweb/ui@0.6.1-dev.169(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
     dependencies:
       '@swc/helpers': 0.5.23
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12397,10 +12388,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       tailwind-merge: 2.6.1
     optionalDependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/wasm': 0.8.9
-      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+      '@kerebron/editor': 0.8.10
+      '@kerebron/editor-kits': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.10
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
       ag-grid-community: 35.3.1
       ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       datavis-ace: 4.1.0
@@ -12410,7 +12401,7 @@ snapshots:
       papaparse: 5.5.4
       remark-gfm: 4.0.1
 
-  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
     dependencies:
       '@swc/helpers': 0.5.23
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12427,10 +12418,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       tailwind-merge: 2.6.1
     optionalDependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/wasm': 0.8.9
-      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
+      '@kerebron/editor': 0.8.10
+      '@kerebron/editor-kits': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.10
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@5.9.3)
       ag-grid-community: 35.3.1
       ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       datavis-ace: 4.1.0
@@ -12440,7 +12431,7 @@ snapshots:
       papaparse: 5.5.4
       remark-gfm: 4.0.1
 
-  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
+  '@mieweb/ui@0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)':
     dependencies:
       '@swc/helpers': 0.5.23
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12457,10 +12448,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       tailwind-merge: 2.6.1
     optionalDependencies:
-      '@kerebron/editor': 0.8.9
-      '@kerebron/editor-kits': 0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0))
-      '@kerebron/wasm': 0.8.9
-      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.9(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.9)(@kerebron/wasm@0.8.9)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
+      '@kerebron/editor': 0.8.10
+      '@kerebron/editor-kits': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
+      '@kerebron/wasm': 0.8.10
+      '@mieweb/datavis': 1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3)
       ag-grid-community: 35.3.1
       ag-grid-react: 35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       datavis-ace: 4.1.0
@@ -13944,7 +13935,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13998,7 +13989,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.4.2)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@20.19.9)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@20.19.9)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -19819,6 +19810,8 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  temml@0.13.4: {}
+
   terser-webpack-plugin@5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -20356,7 +20349,7 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  web-tree-sitter@0.26.11: {}
+  web-tree-sitter@0.26.12: {}
 
   web-worker@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,11 @@ overrides:
   dompurify@<3.4.9: '>=3.4.9'
   dompurify@<=3.4.12: '>=3.4.13'
 
+patchedDependencies:
+  '@kerebron/extension-menu@0.8.10':
+    hash: 4bfcffd5f324775f98e04cec05c3fde04584c4a91dbfe7a7de65bc78baa37967
+    path: patches/@kerebron__extension-menu@0.8.10.patch
+
 importers:
 
   .:
@@ -176,6 +181,9 @@ importers:
       '@esheet/renderer':
         specifier: workspace:*
         version: link:../../packages/renderer
+      '@kerebron/wasm':
+        specifier: ^0.8.10
+        version: 0.8.10
       '@mieweb/ui':
         specifier: 0.7.1
         version: 0.7.1(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@mieweb/datavis@1.6.0(@kerebron/editor-kits@0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@kerebron/editor@0.8.10)(@kerebron/wasm@0.8.10)(@types/react@19.2.18)(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(redux@5.0.1)(remark-gfm@4.0.1)(typescript@6.0.3))(ag-grid-community@35.3.1)(ag-grid-react@35.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(datavis-ace@4.1.0)(js-yaml@5.2.3)(katex@0.16.47)(mermaid@11.16.1)(papaparse@5.5.4)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(remark-gfm@4.0.1)
@@ -12085,7 +12093,7 @@ snapshots:
       '@kerebron/extension-codecrock': 0.8.10
       '@kerebron/extension-dev-toolkit': 0.8.10(svelte@5.56.8(@typescript-eslint/types@8.67.0))
       '@kerebron/extension-markdown': 0.8.10
-      '@kerebron/extension-menu': 0.8.10
+      '@kerebron/extension-menu': 0.8.10(patch_hash=4bfcffd5f324775f98e04cec05c3fde04584c4a91dbfe7a7de65bc78baa37967)
       '@kerebron/extension-menu-legacy': 0.8.10
       '@kerebron/extension-odt': 0.8.10
       '@kerebron/extension-tables': 0.8.10
@@ -12147,7 +12155,7 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-view: 1.40.0
 
-  '@kerebron/extension-menu@0.8.10':
+  '@kerebron/extension-menu@0.8.10(patch_hash=4bfcffd5f324775f98e04cec05c3fde04584c4a91dbfe7a7de65bc78baa37967)':
     dependencies:
       '@kerebron/editor': 0.8.10
       prosemirror-model: 1.25.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       '@esheet/core':
         specifier: workspace:*
         version: link:../core
+      '@esheet/fields':
+        specifier: workspace:*
+        version: link:../fields
       '@kerebron/editor':
         specifier: ^0.8.9
         version: 0.8.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
+linkWorkspacePackages: true
+
 auditConfig:
   ignoreCves:
     - CVE-2025-71330 # image-size is build-only and has no patched release

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "./packages/field-health"
+    },
+    {
+      "path": "./packages/document-list-field"
     }
   ]
 }


### PR DESCRIPTION
## PR Summary

### Overview
Adds a notes/annotation feature set across the stack, a new `@esheet/document-list-field` package, an append-only activity page type, and a pluggable rich-text composer backed by Kerebron.

### Highlights

**Core** (`types.ts`, `registry.ts`, stores/form-store.ts)
- `notes` field definition + `NoteEntry` response shape, registered in the field registry.
- `mergeNotes` and attachment-traversal helpers in the form store, with new specs.

**Fields** (`NotesField.tsx`)
- `NotesField`: entry list, composer, attachments, author stamping.
- `ActivityField` for the append-only response change log.
- `AttachmentManager` seam so hosts can own attachment bytes (`AttachmentManagerProvider.tsx`).
- Shared `markdown`, `file-utils`, and `notes-composer` helpers; `DisplayField`/`FileField` refactored onto them.

**Kerebron** (`KerebronNotesComposer.tsx`)
- Markdown composer implementing the pluggable composer contract.
- Reliability fixes: always initialize a document, serialize loads, pin `prosemirror-model` to a single copy, and a patch for `@kerebron/extension-menu` theming.

**Document List Field** (new package `document-list-field`)
- Grid, workflows (compose/upload), DataVis field, host provider seams, runtime, and styling — with specs for grid, workflows, provider, data, and runtime.

**Renderer / Builder / Adapters**
- `identity` prop for author stamping; presence dots now land on the field, one per peer.
- Notes support in the logic editor, conditions, and FHIR export.

### Scope
94 files, ~8.9k insertions / ~509 deletions (includes lockfile churn).

### Verification
Recommend running `pnpm lint && pnpm test && pnpm typecheck && pnpm build` plus `pnpm format:check` before merge.