### PR TITLE
feat(fields): add autocomplete field type backed by remote data sources

### DIFF
--- a/apps/demo/src/main.tsx
+++ b/apps/demo/src/main.tsx
@@ -1,6 +1,9 @@
 import './styles.css';
 import './ozwell-setup.js';
-import { registerFieldComponents } from '@esheet/fields';
+import {
+  registerFieldComponents,
+  registerAutocompleteFieldType,
+} from '@esheet/fields';
 import {
   RichTextEditorField,
   configureRichTextField,
@@ -19,6 +22,7 @@ import { BrandInitializer } from './components/BrandInitializer';
 
 // Register plugin fields (imports also self-register metadata + Zod schema)
 registerFieldComponents({ richtext: RichTextEditorField });
+registerAutocompleteFieldType();
 registerHealthFieldTypes({
   indexUrl: `${import.meta.env.BASE_URL}codify`.replace(/\/$/, ''),
 });

--- a/apps/demo/src/schemas/wiki-lookup.yaml
+++ b/apps/demo/src/schemas/wiki-lookup.yaml
@@ -1,0 +1,39 @@
+id: wiki-lookup
+title: Autocomplete Field Demo — Live Wikipedia
+description: Demonstrates the `autocomplete` custom field type searching a real remote API (Wikipedia) as you type, including enveloped responses and attribute capture.
+pages:
+  - id: page-1
+    fields:
+      - id: wiki-intro
+        fieldType: html
+        htmlContent: <h2 style='margin:0 0 8px'>Live remote autocomplete</h2><p>The fields below search <strong>Wikipedia</strong> as you type — debounced, with stale responses discarded. The data source URL is configurable per field in the builder.</p>
+        iframeHeight: 90
+      - id: section-wiki
+        fieldType: section
+        title: Reference Lookups
+        fields:
+          - id: favorite-topic
+            fieldType: autocomplete
+            question: Find a Wikipedia article about your condition
+            required: true
+            width: half
+            dataSourceUrl: https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*
+            answerPlaceholder: Start typing, e.g. "hypertension"…
+          - id: hometown
+            fieldType: autocomplete
+            question: What city are you from?
+            width: half
+            dataSourceUrl: https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*
+            answerPlaceholder: Start typing a city name…
+          - id: reference-article
+            fieldType: autocomplete
+            question: Reference article (enveloped response + captured attributes)
+            width: full
+            dataSourceUrl: https://en.wikipedia.org/w/rest.php/v1/search/title?q={query}&limit=8
+            resultsPath: pages
+            labelKey: title
+            valueKey: key
+            captureKeys:
+              - id
+              - description
+            answerPlaceholder: Start typing an article title…

--- a/packages/core/src/lib/functions/hydrate-response.spec.ts
+++ b/packages/core/src/lib/functions/hydrate-response.spec.ts
@@ -107,6 +107,24 @@ describe('hydrateResponse', () => {
     expect(result.items[0].answer).toEqual(selected);
   });
 
+  it('includes captured attributes alongside the answer', () => {
+    const fields = [mkField({ id: 'f1', fieldType: 'radio' })];
+    const selected = { id: 'opt_1', value: 'Toledo' };
+    const attributes = { city: 'Toledo', zip: '43604' };
+    const result = hydrate(fields, { f1: { selected, attributes } });
+    expect(result.items[0].attributes).toEqual(attributes);
+  });
+
+  it('omits attributes when empty or unanswered', () => {
+    const fields = [mkField({ id: 'f1', fieldType: 'radio' })];
+    const withEmpty = hydrate(fields, {
+      f1: { selected: { id: 'a', value: 'A' }, attributes: {} },
+    });
+    expect(withEmpty.items[0].attributes).toBeUndefined();
+    const unanswered = hydrate(fields, { f1: { attributes: { x: 'y' } } });
+    expect(unanswered.items[0].attributes).toBeUndefined();
+  });
+
   it('extracts selected array for multiselection fields', () => {
     const fields = [mkField({ id: 'f1', fieldType: 'check' })];
     const selected = [

--- a/packages/core/src/lib/functions/hydrate-response.ts
+++ b/packages/core/src/lib/functions/hydrate-response.ts
@@ -97,8 +97,12 @@ export function hydrateResponse(
           (definition as { title?: string }).title ??
           '',
       };
-      if (!isEmptyAnswer(answer))
+      if (!isEmptyAnswer(answer)) {
         item.answer = answer as ResponseItem['answer'];
+        const attributes = responses[id]?.attributes;
+        if (attributes && Object.keys(attributes).length > 0)
+          item.attributes = attributes;
+      }
       items.push(item);
     }
   }

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1280,6 +1280,12 @@ export interface FieldResponse {
   markupImage?: string;
   /** File/attachment(s) uploaded by user (file field). Supports single or multiple files. */
   fileData?: AttachmentAnswer | AttachmentAnswer[];
+  /**
+   * Extra attributes captured from the selected item (autocomplete field).
+   * Keyed by the source object's property name, e.g. an address pick may
+   * capture `{ city, state, zip }` alongside `selected`.
+   */
+  attributes?: Record<string, string>;
   /** Set to true when the response was filled programmatically by an AI agent. */
   _ai?: boolean;
 }
@@ -1489,6 +1495,8 @@ export interface ResponseItem {
   id: string;
   text?: string;
   answer?: AnswerValue;
+  /** Extra attributes captured from the selected item (see FieldResponse.attributes). */
+  attributes?: Record<string, string>;
 }
 
 export const RESPONSE_STATUSES = [

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -9,7 +9,12 @@ export {
   BooleanField,
   DropdownField,
   MultiSelectDropdownField,
+  AutocompleteField,
+  registerAutocompleteFieldType,
+  parseAutocompleteItems,
+  WIKIPEDIA_OPENSEARCH_URL,
 } from './selection/index.js';
+export type { AutocompleteFieldDefinition } from './selection/index.js';
 
 // Rating & Ranking
 export { RatingField, RankingField, SliderField } from './rating/index.js';

--- a/packages/fields/src/fields/selection/AutocompleteField.spec.tsx
+++ b/packages/fields/src/fields/selection/AutocompleteField.spec.tsx
@@ -1,0 +1,110 @@
+import {
+  captureAttributes,
+  parseAutocompleteItems,
+  resolveResultsPath,
+} from './AutocompleteField.js';
+
+describe('parseAutocompleteItems', () => {
+  it('parses Wikipedia opensearch arrays using urls as ids', () => {
+    const data = [
+      'cat',
+      ['Cat', 'Catfish'],
+      ['', ''],
+      [
+        'https://en.wikipedia.org/wiki/Cat',
+        'https://en.wikipedia.org/wiki/Catfish',
+      ],
+    ];
+    expect(parseAutocompleteItems(data)).toEqual([
+      { id: 'https://en.wikipedia.org/wiki/Cat', value: 'Cat' },
+      { id: 'https://en.wikipedia.org/wiki/Catfish', value: 'Catfish' },
+    ]);
+  });
+
+  it('falls back to the title as id when opensearch urls are missing', () => {
+    expect(parseAutocompleteItems(['cat', ['Cat']])).toEqual([
+      { id: 'Cat', value: 'Cat' },
+    ]);
+  });
+
+  it('parses string arrays', () => {
+    expect(parseAutocompleteItems(['Red', 'Blue'])).toEqual([
+      { id: 'Red', value: 'Red' },
+      { id: 'Blue', value: 'Blue' },
+    ]);
+  });
+
+  it('parses object arrays with labelKey and valueKey', () => {
+    const data = [
+      { name: 'Ada', code: 1 },
+      { name: 'Grace', code: 2 },
+      { code: 3 }, // missing label — dropped
+    ];
+    expect(parseAutocompleteItems(data, 'name', 'code')).toEqual([
+      { id: '1', value: 'Ada', raw: data[0] },
+      { id: '2', value: 'Grace', raw: data[1] },
+    ]);
+  });
+
+  it('defaults valueKey to labelKey', () => {
+    const data = [{ title: 'Ada' }];
+    expect(parseAutocompleteItems(data, 'title')).toEqual([
+      { id: 'Ada', value: 'Ada', raw: data[0] },
+    ]);
+  });
+
+  it('unwraps enveloped responses via resultsPath', () => {
+    const data = { data: { items: [{ label: 'Ada' }] } };
+    expect(
+      parseAutocompleteItems(data, undefined, undefined, 'data.items')
+    ).toEqual([{ id: 'Ada', value: 'Ada', raw: { label: 'Ada' } }]);
+  });
+
+  it('returns an empty array for a bad resultsPath', () => {
+    expect(
+      parseAutocompleteItems({ results: [] }, undefined, undefined, 'nope.deep')
+    ).toEqual([]);
+  });
+
+  it('returns an empty array for non-array data', () => {
+    expect(parseAutocompleteItems(null)).toEqual([]);
+    expect(parseAutocompleteItems({ items: [] })).toEqual([]);
+    expect(parseAutocompleteItems('nope')).toEqual([]);
+  });
+});
+
+describe('resolveResultsPath', () => {
+  it('returns data unchanged without a path', () => {
+    const data = [1, 2];
+    expect(resolveResultsPath(data)).toBe(data);
+    expect(resolveResultsPath(data, '')).toBe(data);
+  });
+
+  it('descends dot-paths and tolerates missing segments', () => {
+    expect(resolveResultsPath({ a: { b: [1] } }, 'a.b')).toEqual([1]);
+    expect(resolveResultsPath({ a: 1 }, 'a.b.c')).toBeUndefined();
+    expect(resolveResultsPath(null, 'a')).toBeUndefined();
+  });
+});
+
+describe('captureAttributes', () => {
+  const raw = { city: 'Toledo', state: 'OH', zip: 43604, tags: null };
+
+  it('copies requested keys as strings', () => {
+    expect(captureAttributes(raw, ['city', 'state', 'zip'])).toEqual({
+      city: 'Toledo',
+      state: 'OH',
+      zip: '43604',
+    });
+  });
+
+  it('skips missing and null keys', () => {
+    expect(captureAttributes(raw, ['tags', 'nope'])).toBeUndefined();
+  });
+
+  it('returns undefined without raw data or keys', () => {
+    expect(captureAttributes(undefined, ['city'])).toBeUndefined();
+    expect(captureAttributes(raw, [])).toBeUndefined();
+    expect(captureAttributes(raw)).toBeUndefined();
+  });
+});

--- a/packages/fields/src/fields/selection/AutocompleteField.tsx
+++ b/packages/fields/src/fields/selection/AutocompleteField.tsx
@@ -10,6 +10,8 @@ import { registerCustomFieldTypes } from '../../lib/component-registry.js';
  * chosen item as `{ selected: { id, value } }`, like a dropdown.
  */
 export interface AutocompleteFieldDefinition {
+  /** Field id, assigned by the builder like every field definition. */
+  id: string;
   question?: string;
   /**
    * Remote endpoint template. `{query}` is replaced with the URL-encoded
@@ -138,9 +140,7 @@ export const AutocompleteField = React.memo(function AutocompleteField({
   onUpdate,
   onResponse,
 }: FieldComponentProps) {
-  const def = field.definition as unknown as AutocompleteFieldDefinition & {
-    id: string;
-  };
+  const def = field.definition as unknown as AutocompleteFieldDefinition;
   const instanceId = form.getState().instanceId;
   const selected = response?.selected as SelectedOption | undefined;
 
@@ -172,7 +172,13 @@ export const AutocompleteField = React.memo(function AutocompleteField({
       if (selected) onResponse({ selected: undefined });
       return;
     }
-    if (!def.dataSourceUrl || q.length < minQueryLength) return;
+    if (!def.dataSourceUrl || q.length < minQueryLength) {
+      // Reset any earlier "Searching…" state so loading doesn't stick when
+      // the query shrinks below the minimum (the request above was aborted).
+      setItems([]);
+      setLoading(false);
+      return;
+    }
     const url = def.dataSourceUrl.replace('{query}', encodeURIComponent(q));
     setLoading(true);
     debounceTimer.current = setTimeout(async () => {

--- a/packages/fields/src/fields/selection/AutocompleteField.tsx
+++ b/packages/fields/src/fields/selection/AutocompleteField.tsx
@@ -1,0 +1,386 @@
+import React from 'react';
+import type { FieldComponentProps, SelectedOption } from '@esheet/core';
+import { Autocomplete } from '@mieweb/ui';
+import { registerCustomFieldTypes } from '../../lib/component-registry.js';
+
+/**
+ * Definition props for the `autocomplete` custom field type.
+ *
+ * The field searches a remote endpoint as the user types and stores the
+ * chosen item as `{ selected: { id, value } }`, like a dropdown.
+ */
+export interface AutocompleteFieldDefinition {
+  question?: string;
+  /**
+   * Remote endpoint template. `{query}` is replaced with the URL-encoded
+   * search text, e.g.
+   * `https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*`
+   */
+  dataSourceUrl?: string;
+  /** For JSON object-array responses: key holding the display label. Default `label`. */
+  labelKey?: string;
+  /** For JSON object-array responses: key holding the stored id. Defaults to `labelKey`. */
+  valueKey?: string;
+  /**
+   * Dot-path to the results array inside an enveloped response, e.g.
+   * `results` for `{ results: [...] }` or `data.items` for `{ data: { items: [...] } }`.
+   * Leave empty when the response is the array itself.
+   */
+  resultsPath?: string;
+  /**
+   * For JSON object-array responses: extra keys copied from the selected
+   * object into `response.attributes`, e.g. `['city', 'state', 'zip']` when
+   * picking an address. Values are stringified.
+   */
+  captureKeys?: string[];
+  /** Input placeholder text. */
+  answerPlaceholder?: string;
+  /** Minimum query length before searching. Default 2. */
+  minQueryLength?: number;
+}
+
+const DEBOUNCE_MS = 250;
+
+/** An option plus the raw source object it came from (for attribute capture). */
+export interface ParsedAutocompleteItem extends SelectedOption {
+  /** The raw response object this option was parsed from, when available. */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * Descends into an enveloped response along a dot-path, e.g. `data.items`.
+ * Returns the input unchanged when the path is empty.
+ */
+export function resolveResultsPath(data: unknown, path?: string): unknown {
+  if (!path) return data;
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (acc, key) =>
+        acc && typeof acc === 'object'
+          ? (acc as Record<string, unknown>)[key]
+          : undefined,
+      data
+    );
+}
+
+/**
+ * Normalizes a remote response into selectable options. Supports:
+ * 1. OpenSearch arrays (`[query, titles[], descriptions[], urls[]]`, e.g. Wikipedia)
+ * 2. Arrays of strings
+ * 3. Arrays of objects (using `labelKey` / `valueKey`; the raw object is
+ *    retained for attribute capture)
+ *
+ * Enveloped responses (`{ results: [...] }`) are unwrapped first via `resultsPath`.
+ */
+export function parseAutocompleteItems(
+  data: unknown,
+  labelKey = 'label',
+  valueKey = labelKey,
+  resultsPath?: string
+): ParsedAutocompleteItem[] {
+  data = resolveResultsPath(data, resultsPath);
+  if (!Array.isArray(data)) return [];
+
+  // OpenSearch: [query, titles, descriptions?, urls?]
+  if (typeof data[0] === 'string' && Array.isArray(data[1])) {
+    const titles = data[1] as unknown[];
+    const urls = Array.isArray(data[3]) ? (data[3] as unknown[]) : [];
+    return titles
+      .filter((t): t is string => typeof t === 'string')
+      .map((title, i) => ({
+        id: typeof urls[i] === 'string' ? (urls[i] as string) : title,
+        value: title,
+      }));
+  }
+
+  if (data.every((d) => typeof d === 'string')) {
+    return (data as string[]).map((s) => ({ id: s, value: s }));
+  }
+
+  return data
+    .filter((d): d is Record<string, unknown> => !!d && typeof d === 'object')
+    .map((o): ParsedAutocompleteItem | null => {
+      const label = o[labelKey];
+      const id = o[valueKey] ?? label;
+      return typeof label === 'string'
+        ? { id: String(id), value: label, raw: o }
+        : null;
+    })
+    .filter((item): item is ParsedAutocompleteItem => item !== null);
+}
+
+/**
+ * Copies `captureKeys` from a raw response object into a string map for
+ * `response.attributes`. Missing keys are skipped; values are stringified.
+ */
+export function captureAttributes(
+  raw: Record<string, unknown> | undefined,
+  captureKeys?: string[]
+): Record<string, string> | undefined {
+  if (!raw || !captureKeys?.length) return undefined;
+  const attributes: Record<string, string> = {};
+  for (const key of captureKeys) {
+    const v = raw[key];
+    if (v !== undefined && v !== null) attributes[key] = String(v);
+  }
+  return Object.keys(attributes).length ? attributes : undefined;
+}
+
+export const AutocompleteField = React.memo(function AutocompleteField({
+  field,
+  form,
+  isPreview,
+  isEnabled,
+  isRequired,
+  isSoftRequired,
+  response,
+  onUpdate,
+  onResponse,
+}: FieldComponentProps) {
+  const def = field.definition as unknown as AutocompleteFieldDefinition & {
+    id: string;
+  };
+  const instanceId = form.getState().instanceId;
+  const selected = response?.selected as SelectedOption | undefined;
+
+  const [query, setQuery] = React.useState(selected?.value ?? '');
+  const [items, setItems] = React.useState<ParsedAutocompleteItem[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const debounceTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const abortRef = React.useRef<AbortController | undefined>(undefined);
+
+  // Cleanup on unmount: cancel the pending debounce and in-flight request.
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(debounceTimer.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const minQueryLength = def.minQueryLength ?? 2;
+
+  const search = (q: string) => {
+    setQuery(q);
+    clearTimeout(debounceTimer.current);
+    abortRef.current?.abort();
+    if (!q) {
+      setItems([]);
+      setLoading(false);
+      if (selected) onResponse({ selected: undefined });
+      return;
+    }
+    if (!def.dataSourceUrl || q.length < minQueryLength) return;
+    const url = def.dataSourceUrl.replace('{query}', encodeURIComponent(q));
+    setLoading(true);
+    debounceTimer.current = setTimeout(async () => {
+      const ac = new AbortController();
+      abortRef.current = ac;
+      try {
+        const res = await fetch(url, { signal: ac.signal });
+        if (!res.ok) throw new Error(`Data source responded ${res.status}`);
+        const data: unknown = await res.json();
+        // Ignore stale responses: only the latest request may update state.
+        if (abortRef.current !== ac) return;
+        setItems(
+          parseAutocompleteItems(
+            data,
+            def.labelKey,
+            def.valueKey,
+            def.resultsPath
+          )
+        );
+        setLoading(false);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        if (abortRef.current !== ac) return;
+        setItems([]);
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+  };
+
+  if (isPreview) {
+    return (
+      <div className="autocomplete-field-preview ms:space-y-1.5">
+        <div className="ms:text-sm ms:font-medium ms:text-mstext ms:break-words ms:overflow-hidden">
+          {def.question || 'Question'}
+          {(isRequired || isSoftRequired) && (
+            <span
+              className={`ms:ml-0.5 ${
+                isSoftRequired ? 'ms:text-mswarning' : 'ms:text-msdanger'
+              }`}
+            >
+              *
+            </span>
+          )}
+        </div>
+        <Autocomplete<ParsedAutocompleteItem>
+          items={items}
+          getItemKey={(item) => item.id}
+          renderItem={(item) => <span>{item.value}</span>}
+          onSelect={(item) => {
+            setQuery(item.value);
+            onResponse({
+              selected: { id: item.id, value: item.value },
+              attributes: captureAttributes(item.raw, def.captureKeys),
+            });
+          }}
+          value={query}
+          onValueChange={search}
+          clearOnSelect={false}
+          minQueryLength={minQueryLength}
+          placeholder={def.answerPlaceholder || 'Start typing to search…'}
+          emptyMessage={loading ? 'Searching…' : 'No results found.'}
+          disabled={!isEnabled}
+          aria-label={def.question || 'Question'}
+          inputProps={{ id: `${instanceId}-autocomplete-answer-${def.id}` }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="autocomplete-field-edit ms:space-y-3">
+      <EditInput
+        id={`${instanceId}-canvas-question-${def.id}`}
+        label="Question"
+        value={def.question || ''}
+        onChange={(question) => onUpdate({ question })}
+        placeholder="Enter question"
+      />
+
+      <EditInput
+        id={`${instanceId}-canvas-datasource-${def.id}`}
+        label="Data source URL"
+        type="url"
+        value={def.dataSourceUrl || ''}
+        onChange={(dataSourceUrl) => onUpdate({ dataSourceUrl })}
+        placeholder="https://example.com/search?q={query}"
+        hint="`{query}` is replaced with the searched text. Supports OpenSearch-style responses (e.g. Wikipedia), string arrays, and object arrays."
+      />
+
+      <div className="ms:grid ms:grid-cols-2 ms:gap-3">
+        <EditInput
+          id={`${instanceId}-canvas-resultspath-${def.id}`}
+          label="Results path"
+          value={def.resultsPath || ''}
+          onChange={(resultsPath) =>
+            onUpdate({ resultsPath: resultsPath || undefined })
+          }
+          placeholder="e.g. results or data.items"
+          hint="Dot-path to the array inside an enveloped response. Leave empty when the response is the array itself."
+        />
+        <EditInput
+          id={`${instanceId}-canvas-capturekeys-${def.id}`}
+          label="Capture attributes"
+          value={(def.captureKeys ?? []).join(', ')}
+          onChange={(csv) => {
+            const captureKeys = csv
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean);
+            onUpdate({
+              captureKeys: captureKeys.length ? captureKeys : undefined,
+            });
+          }}
+          placeholder="e.g. city, state, zip"
+          hint="Comma-separated keys copied from the selected object into the response."
+        />
+      </div>
+
+      <div className="ms:grid ms:grid-cols-2 ms:gap-3">
+        <EditInput
+          id={`${instanceId}-canvas-labelkey-${def.id}`}
+          label="Label key"
+          value={def.labelKey || ''}
+          onChange={(labelKey) => onUpdate({ labelKey: labelKey || undefined })}
+          placeholder="label"
+          hint="For object responses: key shown to the user."
+        />
+        <EditInput
+          id={`${instanceId}-canvas-valuekey-${def.id}`}
+          label="Value key"
+          value={def.valueKey || ''}
+          onChange={(valueKey) => onUpdate({ valueKey: valueKey || undefined })}
+          placeholder="defaults to label key"
+          hint="For object responses: key stored as the answer id."
+        />
+      </div>
+    </div>
+  );
+});
+
+/** Labeled text input row used by the builder-canvas edit view. */
+function EditInput({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  hint,
+  type = 'text',
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  hint?: string;
+  type?: string;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="ms:block ms:text-sm ms:font-medium ms:text-mstextmuted ms:mb-1"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        aria-label={label}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="ms:px-3 ms:py-2 ms:h-10 ms:w-full ms:border ms:border-msborder ms:bg-mssurface ms:text-mstext ms:rounded-lg ms:focus:border-msprimary ms:focus:ring-1 ms:focus:ring-msprimary/30 ms:outline-none ms:transition-colors"
+      />
+      {hint && <p className="ms:mt-1 ms:text-xs ms:text-mstextmuted">{hint}</p>}
+    </div>
+  );
+}
+
+/** The Wikipedia opensearch endpoint used as the friendly default data source. */
+export const WIKIPEDIA_OPENSEARCH_URL =
+  'https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=8&format=json&origin=*';
+
+/**
+ * Registers the `autocomplete` custom field type: a type-ahead question that
+ * searches a remote endpoint and stores the chosen item like a dropdown.
+ *
+ * @example
+ * ```tsx
+ * import { registerAutocompleteFieldType } from '@esheet/fields';
+ * registerAutocompleteFieldType();
+ * ```
+ */
+export function registerAutocompleteFieldType(): void {
+  registerCustomFieldTypes({
+    autocomplete: {
+      label: 'Autocomplete',
+      category: 'selection',
+      answerType: 'selection',
+      hasOptions: false,
+      hasMatrix: false,
+      defaultProps: {
+        width: 'third',
+        dataSourceUrl: WIKIPEDIA_OPENSEARCH_URL,
+      },
+      placeholder: { question: 'Enter your question...' },
+      component: AutocompleteField,
+    },
+  });
+}

--- a/packages/fields/src/fields/selection/index.ts
+++ b/packages/fields/src/fields/selection/index.ts
@@ -4,3 +4,10 @@ export { BooleanField } from './BooleanField.js';
 export { DropdownField } from './DropdownField.js';
 export { MultiSelectDropdownField } from './MultiSelectDropdownField.js';
 export { OpenChoiceField } from './OpenChoiceField.js';
+export {
+  AutocompleteField,
+  registerAutocompleteFieldType,
+  parseAutocompleteItems,
+  WIKIPEDIA_OPENSEARCH_URL,
+} from './AutocompleteField.js';
+export type { AutocompleteFieldDefinition } from './AutocompleteField.js';

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -29,6 +29,10 @@ export {
   BooleanField,
   DropdownField,
   MultiSelectDropdownField,
+  AutocompleteField,
+  registerAutocompleteFieldType,
+  parseAutocompleteItems,
+  WIKIPEDIA_OPENSEARCH_URL,
   RatingField,
   RankingField,
   SliderField,
@@ -45,6 +49,7 @@ export {
   FileField,
 } from './fields/index.js';
 export type {
+  AutocompleteFieldDefinition,
   DrawingData,
   DrawingPadConfig,
   DrawingPadPayload,


### PR DESCRIPTION

https://github.com/user-attachments/assets/64140de4-d645-4b95-bebb-1c1bc07b0c32

## Summary

Adds a new `autocomplete` custom field type that searches a remote data source as the user types, built on `@mieweb/ui`'s `Autocomplete` component.

## Features

- **Configurable data source**: `dataSourceUrl` with a `{query}` token, defaulting to Wikipedia's opensearch endpoint. 250ms debounce, `AbortController` cancellation, stale-response guard, and unmount cleanup.
- **Three response shapes supported**:
  - OpenSearch arrays (`[query, titles[], descs[], urls[]]`, e.g. Wikipedia)
  - plain string arrays
  - object arrays via `labelKey` (displayed) / `valueKey` (stored id)
- **Enveloped responses**: `resultsPath` dot-path unwraps `{ pages: [...] }` / `{ data: { items: [...] } }` style payloads.
- **Attribute capture**: `captureKeys` copies extra keys from the selected object into `response.attributes` (e.g. picking an address also captures `{ city, state, zip }`), which flows through `hydrateResponse` into the submission payload as `ResponseItem.attributes`.
- **Builder edit panel**: inputs for question, data source URL, results path, capture attributes, label key, and value key — all with hints.
- **Demo**: registered in the demo app palette + new `wiki-lookup.yaml` example schema for `/renderer` demonstrating both the opensearch and enveloped REST endpoints.

## Core changes (additive only)

- `FieldResponse.attributes?: Record<string, string>` and `ResponseItem.attributes?` — optional; nothing existing sets them, so existing payloads are unchanged. `hydrateResponse` emits them only when present and non-empty.

## Tests

- 13 new specs for the field (parsing, resultsPath, captureAttributes, key mapping, malformed responses)
- 2 new specs for `hydrateResponse` attributes passthrough
- Full suites green: core 425/425, fields 30/30; tsc + eslint + prettier clean

## Verification

Verified end-to-end in the demo app builder and renderer against live Wikipedia endpoints — including the enveloped REST title-search (`resultsPath: pages`, `valueKey: key`, `captureKeys: [id, description]`), with captured attributes confirmed in the dry-run submission payload.